### PR TITLE
CPP-620 add basic node plugin for running node things

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,2 +1,3 @@
 **/lib/
 **/test/files
+packages/sandbox/server

--- a/packages/next-router/.toolkitrc.yml
+++ b/packages/next-router/.toolkitrc.yml
@@ -1,0 +1,6 @@
+plugins:
+  - '@dotcom-tool-kit/vault'
+
+hooks:
+  run:local:
+    - NextRouter

--- a/packages/next-router/package.json
+++ b/packages/next-router/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@dotcom-tool-kit/node",
+  "name": "@dotcom-tool-kit/next-router",
   "version": "0.0.0-development",
   "description": "",
   "main": "lib",
@@ -15,16 +15,15 @@
     "@dotcom-tool-kit/task": "file:../task",
     "@dotcom-tool-kit/types": "file:../types",
     "@dotcom-tool-kit/vault": "file:../vault",
-    "get-port": "^5.1.1",
-    "wait-port": "^0.2.9"
+    "ft-next-router": "^1.0.0"
   },
   "repository": {
     "type": "git",
     "url": "https://github.com/financial-times/dotcom-tool-kit.git",
-    "directory": "packages/node"
+    "directory": "packages/next-router"
   },
   "bugs": "https://github.com/financial-times/dotcom-tool-kit/issues",
-  "homepage": "https://github.com/financial-times/dotcom-tool-kit/tree/main/packages/node",
+  "homepage": "https://github.com/financial-times/dotcom-tool-kit/tree/main/packages/next-router",
   "files": [
     "/lib",
     ".toolkitrc.yml"

--- a/packages/next-router/src/index.ts
+++ b/packages/next-router/src/index.ts
@@ -1,0 +1,3 @@
+import NextRouter from './tasks/next-router'
+
+export const tasks = [NextRouter]

--- a/packages/next-router/src/tasks/next-router.ts
+++ b/packages/next-router/src/tasks/next-router.ts
@@ -1,0 +1,63 @@
+import { Task } from '@dotcom-tool-kit/task'
+import { VaultEnvVars } from '@dotcom-tool-kit/vault'
+import { register } from 'ft-next-router'
+import { readState } from '@dotcom-tool-kit/state'
+import { ToolKitError } from '@dotcom-tool-kit/error'
+import { fork } from 'child_process'
+import { NextRouterSchema } from '@dotcom-tool-kit/types/lib/schema/next-router'
+
+export default class NextRouter extends Task<typeof NextRouterSchema> {
+  static description = ''
+
+  async run(): Promise<void> {
+    if (!this.options.appName) {
+      const error = new ToolKitError('your app name must be configured to use next-router')
+      error.details = `this should be the same as its "name" field in next-service-registry. configure it in your .toolkitrc.yml, e.g.:
+
+options:
+  '@dotcom-tool-kit/next-router':
+    appName: article`
+
+      throw error
+    }
+
+    const vault = new VaultEnvVars({
+      environment: 'development',
+      vaultPath: {
+        app: 'next-router',
+        team: 'next'
+      }
+    })
+
+    const routerBin = require.resolve('ft-next-router/bin/next-router')
+    const vaultEnv = await vault.get()
+    const child = fork(routerBin, ['--daemon'], {
+      env: {
+        ...process.env,
+        ...vaultEnv
+      },
+      stdio: 'inherit'
+    })
+
+    await new Promise<void>((resolve, reject) => {
+      // command will exit immediately, hopefully having started the router in the background
+      child.on('exit', (code) => {
+        if (code === 0) {
+          resolve()
+        } else {
+          // TODO capture output from next-router and use ToolKitError?
+          reject(new Error(`couldn't start next-router. there's probably more information above.`))
+        }
+      })
+    })
+
+    const local = readState('local')
+    if (!local) {
+      const error = new ToolKitError('no locally running app found')
+      error.details = `make sure there's a task running your app, e.g. via the "node" plugin, configured to run before the next-router task.`
+      throw error
+    }
+
+    await register({ service: this.options.appName, port: local.port })
+  }
+}

--- a/packages/next-router/src/types/ft-next-router.d.ts
+++ b/packages/next-router/src/types/ft-next-router.d.ts
@@ -1,0 +1,8 @@
+declare module 'ft-next-router' {
+  type Service = {
+    service: string
+    port: number
+  }
+
+  export function register(args: Service): Promise<void>
+}

--- a/packages/next-router/tsconfig.json
+++ b/packages/next-router/tsconfig.json
@@ -1,0 +1,25 @@
+{
+  "extends": "../../tsconfig.settings.json",
+  "compilerOptions": {
+    "outDir": "lib",
+    "rootDir": "src"
+  },
+  "references": [
+    {
+      "path": "../task"
+    },
+    {
+      "path": "../vault"
+    },
+    {
+      "path": "../state"
+    },
+    {
+      "path": "../error"
+    },
+    {
+      "path": "../types"
+    }
+  ],
+  "include": ["src/**/*"]
+}

--- a/packages/node/.toolkitrc.yml
+++ b/packages/node/.toolkitrc.yml
@@ -1,0 +1,2 @@
+hooks:
+  'run:local': Node

--- a/packages/node/.toolkitrc.yml
+++ b/packages/node/.toolkitrc.yml
@@ -1,2 +1,5 @@
+plugins:
+  - '@dotcom-tool-kit/vault'
+
 hooks:
   'run:local': Node

--- a/packages/node/package.json
+++ b/packages/node/package.json
@@ -13,7 +13,9 @@
     "@dotcom-tool-kit/error": "file:../error",
     "@dotcom-tool-kit/task": "file:../task",
     "@dotcom-tool-kit/types": "file:../types",
-    "@dotcom-tool-kit/vault": "file:../vault"
+    "@dotcom-tool-kit/vault": "file:../vault",
+    "get-port": "^5.1.1",
+    "wait-port": "^0.2.9"
   },
   "repository": {
     "type": "git",

--- a/packages/node/package.json
+++ b/packages/node/package.json
@@ -12,7 +12,8 @@
   "dependencies": {
     "@dotcom-tool-kit/error": "file:../error",
     "@dotcom-tool-kit/task": "file:../task",
-    "@dotcom-tool-kit/types": "file:../types"
+    "@dotcom-tool-kit/types": "file:../types",
+    "@dotcom-tool-kit/vault": "file:../vault"
   },
   "repository": {
     "type": "git",

--- a/packages/node/package.json
+++ b/packages/node/package.json
@@ -1,0 +1,28 @@
+{
+  "name": "@dotcom-tool-kit/node",
+  "version": "0.0.0-development",
+  "description": "",
+  "main": "lib",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "keywords": [],
+  "author": "FT.com Platforms Team <platforms-team.customer-products@ft.com>",
+  "license": "ISC",
+  "dependencies": {
+    "@dotcom-tool-kit/error": "file:../error",
+    "@dotcom-tool-kit/task": "file:../task",
+    "@dotcom-tool-kit/types": "file:../types"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/financial-times/dotcom-tool-kit.git",
+    "directory": "packages/node"
+  },
+  "bugs": "https://github.com/financial-times/dotcom-tool-kit/issues",
+  "homepage": "https://github.com/financial-times/dotcom-tool-kit/tree/main/packages/node",
+  "files": [
+    "/lib",
+    ".toolkitrc.yml"
+  ]
+}

--- a/packages/node/src/index.ts
+++ b/packages/node/src/index.ts
@@ -1,0 +1,3 @@
+import Node from './tasks/node'
+
+export const tasks = [Node]

--- a/packages/node/src/tasks/node.ts
+++ b/packages/node/src/tasks/node.ts
@@ -1,0 +1,36 @@
+import { Task } from '@dotcom-tool-kit/task'
+import { NodeOptions, NodeSchema } from '@dotcom-tool-kit/types/lib/schema/node'
+import { ToolKitError } from '@dotcom-tool-kit/error'
+import { fork } from 'child_process'
+
+export default class Node extends Task<typeof NodeSchema> {
+  static description = ''
+
+  static defaultOptions: NodeOptions = {
+    entry: './server/app.js'
+  }
+
+  async run(): Promise<void> {
+    const { entry } = this.options
+
+    if (!entry) {
+      const error = new ToolKitError('the Node tasks requires an `entry` option')
+      error.details = 'this is the entrypoint for your app, e.g. `server/app.js`'
+      throw error
+    }
+
+    const child = fork(
+      entry,
+      // TODO arguments?
+      {
+        env: {
+          ...process.env
+          // TODO: vault, PORT
+        },
+        stdio: 'inherit'
+      }
+    )
+
+    // TODO wait for it to listen
+  }
+}

--- a/packages/node/src/tasks/node.ts
+++ b/packages/node/src/tasks/node.ts
@@ -3,6 +3,8 @@ import { NodeOptions, NodeSchema } from '@dotcom-tool-kit/types/lib/schema/node'
 import { ToolKitError } from '@dotcom-tool-kit/error'
 import { fork } from 'child_process'
 import { VaultEnvVars } from '@dotcom-tool-kit/vault'
+import getPort from 'get-port'
+import waitPort from 'wait-port'
 
 export default class Node extends Task<typeof NodeSchema> {
   static description = ''
@@ -18,6 +20,11 @@ export default class Node extends Task<typeof NodeSchema> {
     })
 
     const vaultEnv = await vault.get()
+    const port =
+      process.env.PORT ||
+      (await getPort({
+        port: [3001, 3002, 3003]
+      }))
 
     if (!entry) {
       const error = new ToolKitError('the Node tasks requires an `entry` option')
@@ -31,13 +38,16 @@ export default class Node extends Task<typeof NodeSchema> {
       {
         env: {
           ...vaultEnv,
+          PORT: port.toString(),
           ...process.env
-          // TODO: PORT
         },
         stdio: 'inherit'
       }
     )
 
-    // TODO wait for it to listen
+    await waitPort({
+      host: 'localhost',
+      port: Number(port)
+    })
   }
 }

--- a/packages/node/src/tasks/node.ts
+++ b/packages/node/src/tasks/node.ts
@@ -3,6 +3,7 @@ import { NodeOptions, NodeSchema } from '@dotcom-tool-kit/types/lib/schema/node'
 import { ToolKitError } from '@dotcom-tool-kit/error'
 import { fork } from 'child_process'
 import { VaultEnvVars } from '@dotcom-tool-kit/vault'
+import { writeState } from '@dotcom-tool-kit/state'
 import getPort from 'get-port'
 import waitPort from 'wait-port'
 
@@ -21,7 +22,7 @@ export default class Node extends Task<typeof NodeSchema> {
 
     const vaultEnv = await vault.get()
     const port =
-      process.env.PORT ||
+      Number(process.env.PORT) ||
       (await getPort({
         port: [3001, 3002, 3003]
       }))
@@ -43,7 +44,9 @@ export default class Node extends Task<typeof NodeSchema> {
 
     await waitPort({
       host: 'localhost',
-      port: Number(port)
+      port: port
     })
+
+    writeState('local', { port })
   }
 }

--- a/packages/node/src/tasks/node.ts
+++ b/packages/node/src/tasks/node.ts
@@ -32,18 +32,14 @@ export default class Node extends Task<typeof NodeSchema> {
       throw error
     }
 
-    const child = fork(
-      entry,
-      // TODO arguments?
-      {
-        env: {
-          ...vaultEnv,
-          PORT: port.toString(),
-          ...process.env
-        },
-        stdio: 'inherit'
-      }
-    )
+    const child = fork(entry, {
+      env: {
+        ...vaultEnv,
+        PORT: port.toString(),
+        ...process.env
+      },
+      stdio: 'inherit'
+    })
 
     await waitPort({
       host: 'localhost',

--- a/packages/node/src/tasks/node.ts
+++ b/packages/node/src/tasks/node.ts
@@ -2,6 +2,7 @@ import { Task } from '@dotcom-tool-kit/task'
 import { NodeOptions, NodeSchema } from '@dotcom-tool-kit/types/lib/schema/node'
 import { ToolKitError } from '@dotcom-tool-kit/error'
 import { fork } from 'child_process'
+import { VaultEnvVars } from '@dotcom-tool-kit/vault'
 
 export default class Node extends Task<typeof NodeSchema> {
   static description = ''
@@ -12,6 +13,11 @@ export default class Node extends Task<typeof NodeSchema> {
 
   async run(): Promise<void> {
     const { entry } = this.options
+    const vault = new VaultEnvVars({
+      environment: 'development'
+    })
+
+    const vaultEnv = await vault.get()
 
     if (!entry) {
       const error = new ToolKitError('the Node tasks requires an `entry` option')
@@ -24,8 +30,9 @@ export default class Node extends Task<typeof NodeSchema> {
       // TODO arguments?
       {
         env: {
+          ...vaultEnv,
           ...process.env
-          // TODO: vault, PORT
+          // TODO: PORT
         },
         stdio: 'inherit'
       }

--- a/packages/node/tsconfig.json
+++ b/packages/node/tsconfig.json
@@ -7,6 +7,12 @@
   "references": [
     {
       "path": "../task"
+    },
+    {
+      "path": "../error"
+    },
+    {
+      "path": "../options"
     }
   ],
   "include": ["src/**/*"]

--- a/packages/node/tsconfig.json
+++ b/packages/node/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "extends": "../../tsconfig.settings.json",
+  "compilerOptions": {
+    "outDir": "lib",
+    "rootDir": "src"
+  },
+  "references": [
+    {
+      "path": "../task"
+    }
+  ],
+  "include": ["src/**/*"]
+}

--- a/packages/sandbox/.toolkitrc.yml
+++ b/packages/sandbox/.toolkitrc.yml
@@ -1,4 +1,5 @@
 plugins:
   - '@dotcom-tool-kit/frontend-app'
+  - '@dotcom-tool-kit/node'
 hooks: {}
 options: {}

--- a/packages/sandbox/.toolkitrc.yml
+++ b/packages/sandbox/.toolkitrc.yml
@@ -2,4 +2,7 @@ plugins:
   - '@dotcom-tool-kit/frontend-app'
   - '@dotcom-tool-kit/node'
 hooks: {}
-options: {}
+options:
+  '@dotcom-tool-kit/vault':
+    team: next
+    app: next-static # for testing

--- a/packages/sandbox/.toolkitrc.yml
+++ b/packages/sandbox/.toolkitrc.yml
@@ -1,8 +1,16 @@
 plugins:
   - '@dotcom-tool-kit/frontend-app'
   - '@dotcom-tool-kit/node'
-hooks: {}
+  - '@dotcom-tool-kit/next-router'
+
+hooks:
+  run:local:
+    - Node
+    - NextRouter
+
 options:
   '@dotcom-tool-kit/vault':
     team: next
     app: next-static # for testing
+  '@dotcom-tool-kit/next-router':
+    appName: static # for testing

--- a/packages/sandbox/package.json
+++ b/packages/sandbox/package.json
@@ -5,7 +5,8 @@
   "scripts": {
     "test": "dotcom-tool-kit test:local",
     "build": "dotcom-tool-kit build:local",
-    "heroku-postbuild": "dotcom-tool-kit release:remote build:remote cleanup:remote"
+    "heroku-postbuild": "dotcom-tool-kit release:remote build:remote cleanup:remote",
+    "start": "dotcom-tool-kit run:local"
   },
   "keywords": [],
   "author": "",
@@ -23,5 +24,8 @@
   },
   "volta": {
     "extends": "../../package.json"
+  },
+  "dependencies": {
+    "@dotcom-tool-kit/node": "file:../node"
   }
 }

--- a/packages/sandbox/package.json
+++ b/packages/sandbox/package.json
@@ -26,6 +26,7 @@
     "extends": "../../package.json"
   },
   "dependencies": {
+    "@dotcom-tool-kit/next-router": "file:../next-router",
     "@dotcom-tool-kit/node": "file:../node"
   }
 }

--- a/packages/sandbox/server/app.js
+++ b/packages/sandbox/server/app.js
@@ -1,0 +1,11 @@
+const http = require('http')
+
+const server = http.createServer((req, res) => {
+  console.log(`${req.method} ${req.url}`)
+  res.statusCode = 418
+  res.end(`i'm a teapot`)
+})
+
+server.listen(process.env.PORT || 3137, () => {
+  console.log(`listening on ${server.address().port}`)
+})

--- a/packages/state/src/index.ts
+++ b/packages/state/src/index.ts
@@ -23,11 +23,16 @@ interface ProductionState {
   appIds: string[]
 }
 
+interface LocalState {
+  port: number
+}
+
 export interface State {
   ci: CIState
   review: ReviewState
   staging: StagingState
   production: ProductionState
+  local: LocalState
 }
 
 export function readState<T extends keyof State>(stage: T): State[T] | null {

--- a/packages/types/src/schema.ts
+++ b/packages/types/src/schema.ts
@@ -50,6 +50,8 @@ import type { SmokeTestOptions } from './schema/n-test'
 import type { UploadAssetsToS3Options } from './schema/upload-assets-to-s3'
 import type { VaultOptions } from './schema/vault'
 import type { WebpackOptions } from './schema/webpack'
+import type { NodeOptions } from './schema/node'
+import type { NextRouterOptions } from './schema/next-router'
 
 export type Options = {
   '@dotcom-tool-kit/eslint'?: ESLintOptions
@@ -59,4 +61,6 @@ export type Options = {
   '@dotcom-tool-kit/upload-assets-to-s3'?: UploadAssetsToS3Options
   '@dotcom-tool-kit/vault'?: VaultOptions
   '@dotcom-tool-kit/webpack'?: WebpackOptions
+  '@dotcom-tool-kit/node'?: NodeOptions
+  '@dotcom-tool-kit/next-router'?: NextRouterOptions
 }

--- a/packages/types/src/schema/next-router.ts
+++ b/packages/types/src/schema/next-router.ts
@@ -1,0 +1,8 @@
+import { SchemaOutput } from '../schema'
+
+export const NextRouterSchema = {
+  appName: 'string'
+} as const
+export type NextRouterOptions = SchemaOutput<typeof NextRouterSchema>
+
+export const Schema = NextRouterSchema

--- a/packages/types/src/schema/node.ts
+++ b/packages/types/src/schema/node.ts
@@ -1,0 +1,9 @@
+import { SchemaOutput } from '../schema'
+
+export const NodeSchema = {
+  entry: 'string?',
+  config: 'record.unknown?'
+} as const
+export type NodeOptions = SchemaOutput<typeof NodeSchema>
+
+export const Schema = NodeSchema

--- a/packages/types/src/schema/node.ts
+++ b/packages/types/src/schema/node.ts
@@ -1,8 +1,7 @@
 import { SchemaOutput } from '../schema'
 
 export const NodeSchema = {
-  entry: 'string?',
-  config: 'record.unknown?'
+  entry: 'string?'
 } as const
 export type NodeOptions = SchemaOutput<typeof NodeSchema>
 

--- a/packages/vault/src/index.ts
+++ b/packages/vault/src/index.ts
@@ -16,6 +16,7 @@ export type Environment = 'production' | 'continuous-integration' | 'development
 
 export type VaultSettings = {
   environment: Environment
+  vaultPath?: VaultOptions
 }
 
 type ReturnFetch = {
@@ -42,9 +43,9 @@ export class VaultEnvVars {
   vaultPath: VaultOptions
   environment: string
 
-  constructor({ environment }: VaultSettings) {
+  constructor({ environment, vaultPath }: VaultSettings) {
     this.environment = environment
-    const options = getOptions('@dotcom-tool-kit/vault')
+    const options = vaultPath || getOptions('@dotcom-tool-kit/vault')
     if (!options || !('team' in options && 'app' in options)) {
       const error = new ToolKitError('Vault options not found in your Tool Kit configuration')
       error.details = `"team" and "app" are needed to get your app's secrets from vault, e.g.

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -69,6 +69,9 @@
     },
     {
       "path": "packages/node"
+    },
+    {
+      "path": "packages/next-router"
     }
   ]
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -66,6 +66,9 @@
     },
     {
       "path": "packages/options"
+    },
+    {
+      "path": "packages/node"
     }
   ]
 }


### PR DESCRIPTION
adds a plugin to run a node app directly on the `run:local` hook. depends on #130. plugin is deliberately unconfigurable (apart from server entry point) for now. it's easy to add options but impossible to delete them.