### PR TITLE
Integrate change API orb into tool kit orb

### DIFF
--- a/orb/src/@orb.yml
+++ b/orb/src/@orb.yml
@@ -12,3 +12,4 @@ display:
 # If your orb requires other orbs, you can import them like this. Otherwise remove the "orbs" stanza.
 orbs:
   node: circleci/node@4.7.0
+  change-api: financial-times/change-api@0.25.1

--- a/orb/src/jobs/heroku-promote.yml
+++ b/orb/src/jobs/heroku-promote.yml
@@ -2,6 +2,16 @@ parameters:
   node-version:
     default: "12.22"
     type: string
+  systemCode:
+    default: $CIRCLE_PROJECT_REPONAME
+    description: >-
+      The systemcode of the system being changed. Defaults to the repository
+      name.
+    type: string
+  environment:
+    default: unknown
+    description: The environment in which the system is being changed.
+    type: string
 
 executor:
   name: node/default
@@ -12,3 +22,5 @@ steps:
   - run:
       name: Deploy to production
       command: npx dotcom-tool-kit deploy:production
+  - change-api/generate:
+      systemCode: <<parameters.node-version>>

--- a/orb/src/jobs/heroku-promote.yml
+++ b/orb/src/jobs/heroku-promote.yml
@@ -9,7 +9,7 @@ parameters:
       name.
     type: string
   environment:
-    default: unknown
+    default: production
     description: The environment in which the system is being changed.
     type: string
 

--- a/orb/src/jobs/heroku-promote.yml
+++ b/orb/src/jobs/heroku-promote.yml
@@ -23,4 +23,4 @@ steps:
       name: Deploy to production
       command: npx dotcom-tool-kit deploy:production
   - change-api/generate:
-      systemCode: <<parameters.node-version>>
+      systemCode: <<parameters.systemCode>>

--- a/orb/src/jobs/setup.yml
+++ b/orb/src/jobs/setup.yml
@@ -14,5 +14,6 @@ steps:
   - checkout
   - node/install-npm:
       version: <<parameters.npm-version>>
+  - change-api/install-jq
   - node/install-packages
   - persist-workspace


### PR DESCRIPTION
This will post any heroku deployments in CircleCI to the [Change API](https://github.com/Financial-Times/change-api) so changes in services can be tracked.