### PR TITLE
CPP-636 add nightly CircleCI build

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -157,6 +157,20 @@ workflows:
           requires:
             - test
 
+  nightly:
+    triggers:
+      - schedule:
+          cron: "0 0 * * *"
+          filters:
+            <<: *filters_only_main
+    jobs:
+      - build:
+          context: next-nightly-build
+      - test:
+          requires:
+            - build
+          context: next-nightly-build
+
   # Prior to producing a development orb (which requires credentials) basic validation, linting, and even unit testing can be performed.
   # This workflow will run on every commit
   orb-test-pack:


### PR DESCRIPTION
Based on [this Slack conversation](https://financialtimes.slack.com/archives/C3TJ6KXEU/p1610989688007600) this should be the only work needed to set up the nightly build.