### PR TITLE
CPP-638 add circleci nightly workflow to task

### DIFF
--- a/core/cli/test/__snapshots__/index.test.ts.snap
+++ b/core/cli/test/__snapshots__/index.test.ts.snap
@@ -630,6 +630,7 @@ Object {
   },
   "hooks": Object {
     "build:ci": BuildCI {
+      "addToNightly": true,
       "circleConfigPath": ".circleci/config.yml",
       "id": "build:ci",
       "job": "tool-kit/build",
@@ -645,6 +646,7 @@ Object {
         "hooks": Object {
           "build:ci": [Circular],
           "test:ci": TestCI {
+            "addToNightly": true,
             "circleConfigPath": ".circleci/config.yml",
             "id": "test:ci",
             "job": "tool-kit/test",
@@ -1858,6 +1860,7 @@ Object {
       },
     },
     "test:ci": TestCI {
+      "addToNightly": true,
       "circleConfigPath": ".circleci/config.yml",
       "id": "test:ci",
       "job": "tool-kit/test",
@@ -1871,6 +1874,7 @@ Object {
         "TestCI": [Function],
         "hooks": Object {
           "build:ci": BuildCI {
+            "addToNightly": true,
             "circleConfigPath": ".circleci/config.yml",
             "id": "build:ci",
             "job": "tool-kit/build",
@@ -2583,6 +2587,7 @@ Object {
       "TestCI": [Function],
       "hooks": Object {
         "build:ci": BuildCI {
+          "addToNightly": true,
           "circleConfigPath": ".circleci/config.yml",
           "id": "build:ci",
           "job": "tool-kit/build",
@@ -2595,6 +2600,7 @@ Object {
           "plugin": [Circular],
         },
         "test:ci": TestCI {
+          "addToNightly": true,
           "circleConfigPath": ".circleci/config.yml",
           "id": "test:ci",
           "job": "tool-kit/test",

--- a/plugins/circleci/src/circleci-config.ts
+++ b/plugins/circleci/src/circleci-config.ts
@@ -10,7 +10,7 @@ type JobConfig = {
 }
 
 type TriggerConfig = {
-  schedule?: { cron: string, filters?: { branches: { only?: string; ignore?: string } } }
+  schedule?: { cron: string; filters?: { branches: { only?: string; ignore?: string } } }
 }
 
 type Workflow = {
@@ -136,18 +136,16 @@ export default abstract class CircleCiConfigHook extends Hook {
             }
           ]
         },
-        'nightly': {
+        nightly: {
           triggers: [
-            { 
-              'schedule': {
+            {
+              schedule: {
                 cron: '0 0 * * *',
-                filters: { branches: { only: 'main'}}
+                filters: { branches: { only: 'main' } }
               }
             }
           ],
-          jobs: [
-            'tool-kit/setup'
-          ]
+          jobs: ['tool-kit/setup']
         }
       }
     }
@@ -157,7 +155,10 @@ export default abstract class CircleCiConfigHook extends Hook {
       config.orbs['tool-kit'] = `financial-times/dotcom-tool-kit@${currentVersion}`
     }
 
-    if (!(config.workflows?.['tool-kit'] as Workflow).jobs || !(config.workflows?.['nightly'] as Workflow).jobs) {
+    if (
+      !(config.workflows?.['tool-kit'] as Workflow).jobs ||
+      !(config.workflows?.['nightly'] as Workflow).jobs
+    ) {
       throw new Error(
         'Found malformed CircleCI config that was automatically generated. Please delete and install again'
       )
@@ -175,7 +176,9 @@ export default abstract class CircleCiConfigHook extends Hook {
       if (this.addToNightly) {
         // clone job and remove waiting for approvals
         const clonedJob = JSON.parse(JSON.stringify(job))
-        clonedJob[this.job].requires = clonedJob[this.job].requires.filter((x: string) => x !== 'waiting-for-approval')
+        clonedJob[this.job].requires = clonedJob[this.job].requires.filter(
+          (x: string) => x !== 'waiting-for-approval'
+        )
         nightlyJobs.push(clonedJob)
       }
     }

--- a/plugins/circleci/src/circleci-config.ts
+++ b/plugins/circleci/src/circleci-config.ts
@@ -78,17 +78,8 @@ export default abstract class CircleCiConfigHook extends Hook {
 
   async check(): Promise<boolean> {
     const config = await this.getCircleConfig()
-    const workflows = config?.workflows
-    // If the config has just one workflow defined check that one, else check
-    // the workflow named 'tool-kit'
-    const workflowName =
-      workflows && Object.keys(workflows).length === 2
-        ? // If the objects has two keys we know at least one isn't 'version'
-          // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-          Object.keys(workflows).find((workflow) => workflow !== 'version')!
-        : 'tool-kit'
-    const workflow = workflows?.[workflowName] as Workflow | undefined
-    const jobs = workflow?.jobs
+    const workflows = config?.workflows as Record<string, Workflow | undefined> | undefined
+    const jobs = workflows?.['tool-kit']?.jobs
     if (!jobs) {
       return false
     }

--- a/plugins/circleci/src/circleci-config.ts
+++ b/plugins/circleci/src/circleci-config.ts
@@ -154,11 +154,17 @@ export default abstract class CircleCiConfigHook extends Hook {
     const workflows = config.workflows as Record<string, Workflow>
     const jobs = workflows?.['tool-kit']?.jobs
     const nightlyJobs = workflows?.['nightly']?.jobs
-    if (!jobs || !nightlyJobs) {
+    if (!jobs) {
       throw new Error(
         'Found malformed CircleCI config that was automatically generated. Please delete and install again'
       )
     }
+    if (!nightlyJobs) {
+      throw new Error(
+        'Found an older version of the CircleCI config without a nightly workflow. Please delete and install again'
+      )
+    }
+
     const job = this.jobOptions ? { [this.job]: this.jobOptions } : this.job
     // Avoid duplicating jobs (this can happen when check() fails when the version is wrong)
     if (!jobs.some((candidateJob) => isEqual(candidateJob, job))) {

--- a/plugins/circleci/src/circleci-config.ts
+++ b/plugins/circleci/src/circleci-config.ts
@@ -151,20 +151,14 @@ export default abstract class CircleCiConfigHook extends Hook {
       config.orbs['tool-kit'] = `financial-times/dotcom-tool-kit@${currentVersion}`
     }
 
-    if (
-      !(config.workflows?.['tool-kit'] as Workflow).jobs ||
-      !(config.workflows?.['nightly'] as Workflow).jobs
-    ) {
+    const workflows = config.workflows as Record<string, Workflow>
+    const jobs = workflows?.['tool-kit']?.jobs
+    const nightlyJobs = workflows?.['nightly']?.jobs
+    if (!jobs || !nightlyJobs) {
       throw new Error(
         'Found malformed CircleCI config that was automatically generated. Please delete and install again'
       )
     }
-    // TypeScript can't seem to pick up that we've already checked the optional
-    // properties here
-    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-    const jobs = (config.workflows!['tool-kit'] as Workflow).jobs!
-    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-    const nightlyJobs = (config.workflows!['nightly'] as Workflow).jobs!
     const job = this.jobOptions ? { [this.job]: this.jobOptions } : this.job
     // Avoid duplicating jobs (this can happen when check() fails when the version is wrong)
     if (!jobs.some((candidateJob) => isEqual(candidateJob, job))) {

--- a/plugins/circleci/src/circleci-config.ts
+++ b/plugins/circleci/src/circleci-config.ts
@@ -169,14 +169,17 @@ export default abstract class CircleCiConfigHook extends Hook {
     // Avoid duplicating jobs (this can happen when check() fails when the version is wrong)
     if (!jobs.some((candidateJob) => isEqual(candidateJob, job))) {
       jobs.push(job)
-      if (this.addToNightly) {
-        // clone job and remove waiting for approvals
-        const clonedJob = JSON.parse(JSON.stringify(job))
-        clonedJob[this.job].requires = clonedJob[this.job].requires.filter(
-          (x: string) => x !== 'waiting-for-approval'
-        )
-        nightlyJobs.push(clonedJob)
-      }
+    }
+    if (this.addToNightly && !nightlyJobs.some((candidateJob) => isEqual(candidateJob, job))) {
+      const nightlyJob = this.jobOptions
+        ? {
+            [this.job]: {
+              ...this.jobOptions,
+              requires: this.jobOptions.requires?.filter((x: string) => x !== 'waiting-for-approval')
+            }
+          }
+        : this.job
+      nightlyJobs.push(nightlyJob)
     }
 
     const serialised = automatedComment + yaml.dump(config)

--- a/plugins/circleci/src/index.ts
+++ b/plugins/circleci/src/index.ts
@@ -4,11 +4,13 @@ import CircleCiConfigHook from './circleci-config'
 export class BuildCI extends CircleCiConfigHook {
   job = 'tool-kit/build'
   jobOptions = { requires: ['tool-kit/setup', 'waiting-for-approval'] }
+  addToNightly = true
 }
 
 export class TestCI extends CircleCiConfigHook {
   job = 'tool-kit/test'
   jobOptions = { requires: [new BuildCI().job] }
+  addToNightly = true
 }
 
 export const hooks = {

--- a/plugins/circleci/test/circleci-config.test.ts
+++ b/plugins/circleci/test/circleci-config.test.ts
@@ -10,6 +10,7 @@ describe('CircleCI config hook', () => {
     jobOptions = {
       requires: ['another-job']
     }
+    addToNightly = true
   }
 
   const originalDir = process.cwd()
@@ -57,6 +58,15 @@ describe('CircleCI config hook', () => {
           expect.objectContaining({
             workflows: {
               'tool-kit': {
+                jobs: expect.arrayContaining([
+                  expect.objectContaining({
+                    'test-job': {
+                      requires: ['another-job']
+                    }
+                  })
+                ])
+              },
+              'nightly': {
                 jobs: expect.arrayContaining([
                   expect.objectContaining({
                     'test-job': {

--- a/plugins/circleci/test/circleci-config.test.ts
+++ b/plugins/circleci/test/circleci-config.test.ts
@@ -66,7 +66,7 @@ describe('CircleCI config hook', () => {
                   })
                 ])
               },
-              'nightly': {
+              nightly: {
                 jobs: expect.arrayContaining([
                   expect.objectContaining({
                     'test-job': {

--- a/plugins/circleci/test/files/comment-without-hook/.circleci/config.yml
+++ b/plugins/circleci/test/files/comment-without-hook/.circleci/config.yml
@@ -2,3 +2,5 @@
 workflows:
   tool-kit:
     jobs: []
+  nightly:
+    jobs: []

--- a/plugins/circleci/test/files/with-hook/.circleci/config.yml
+++ b/plugins/circleci/test/files/with-hook/.circleci/config.yml
@@ -2,3 +2,6 @@ workflows:
   tool-kit:
     jobs:
       - test-job
+  nightly:
+    jobs:
+      - test-job


### PR DESCRIPTION
[Ticket CPP-638](https://financialtimes.atlassian.net/browse/CPP-638)

This PR modifies the circleci plugin so that it:

- errors and asks user to recreate if `nightly` workflow is not present
- adds optional `addToNightly` property to the `CircleConfig` interface
- if `addToNightly` is set to **true** it will clone the `tool-kit` job, remove the `waiting-for-approval` requirement and add it to the `nightly` workflow
- sets the `addToNightly` property to **true** for `BuildCI` and `TestCI`
- fixes tests