### PR TITLE
Local vault fix CPP-651

### DIFF
--- a/packages/vault/jest.config.js
+++ b/packages/vault/jest.config.js
@@ -1,0 +1,7 @@
+const base = require('../../jest.config.base')
+
+module.exports = {
+  ...base,
+  collectCoverage: true,
+  moduleDirectories: ['node_modules']
+}

--- a/packages/vault/package.json
+++ b/packages/vault/package.json
@@ -12,7 +12,6 @@
     "@dotcom-tool-kit/types": "file:../types",
     "@financial-times/n-fetch": "^1.0.0-beta.7",
     "fs": "0.0.1-security",
-    "moment": "^2.29.1",
     "os": "^0.1.2",
     "path": "^0.12.7",
     "superagent": "^6.1.0"

--- a/packages/vault/package.json
+++ b/packages/vault/package.json
@@ -12,6 +12,7 @@
     "@dotcom-tool-kit/types": "file:../types",
     "@financial-times/n-fetch": "^1.0.0-beta.7",
     "fs": "0.0.1-security",
+    "moment": "^2.29.1",
     "os": "^0.1.2",
     "path": "^0.12.7",
     "superagent": "^6.1.0"
@@ -32,5 +33,9 @@
   ],
   "volta": {
     "extends": "../../package.json"
+  },
+  "devDependencies": {
+    "@types/jest": "^27.0.2",
+    "node-fetch": "^1.7.3"
   }
 }

--- a/packages/vault/src/index.ts
+++ b/packages/vault/src/index.ts
@@ -67,6 +67,7 @@ export class VaultEnvVars {
   }
 
   private async getAuthToken(): Promise<string> {
+    console.log('variable', CIRCLECI, 'ENV', process.env.CIRCLECI)
     if (CIRCLECI) {
       try {
         const json = await fetch<Token>(`${VAULT_ADDR}/auth/approle/login`, {

--- a/packages/vault/src/index.ts
+++ b/packages/vault/src/index.ts
@@ -77,19 +77,21 @@ export class VaultEnvVars {
     }
   }
 
-  private async handleLocalToken(): Promise<string> {
+  private async getLocalToken(): Promise<string> {
     try {
       console.log('checking for current token')
       const vaultToken = await fs.readFile(this.vaultTokenFile, {
         encoding: 'utf8'
       })
       console.log('testing current token')
-      const validToken = await this.fetchTest(vaultToken)
-      if (validToken) {
+      const isValidToken = await this.fetchTest(vaultToken)
+      if (isValidToken) {
         console.log('success!')
         return vaultToken
       } else {
-        throw new ToolKitError('current token invalid, requesting new one...')
+        const message = 'current token invalid, requesting new one...'
+        console.error(message)
+        throw new ToolKitError(message)
       }
     } catch {
       throw new ToolKitError('no current vault token found, requesting new token....')
@@ -130,16 +132,12 @@ export class VaultEnvVars {
     } else {
       // developer's local machine
       try {
-        const token = await this.handleLocalToken()
+        const token = await this.getLocalToken()
         return token
       } catch {
         if (VAULT_AUTH_GITHUB_TOKEN) {
-          try {
-            const token = await this.getTokenFromVault(VAULT_AUTH_GITHUB_TOKEN)
-            return token
-          } catch (err) {
-            throw err
-          }
+          const token = await this.getTokenFromVault(VAULT_AUTH_GITHUB_TOKEN)
+          return token
         } else {
           const error = new ToolKitError(`VAULT_AUTH_GITHUB_TOKEN variable is not set`)
           error.details = `Follow the guide at https://github.com/Financial-Times/vault/wiki/Getting-Started-With-Vault`

--- a/packages/vault/src/index.ts
+++ b/packages/vault/src/index.ts
@@ -10,8 +10,6 @@ import { VaultOptions } from '@dotcom-tool-kit/types/lib/schema/vault'
 const VAULT_ROLE_ID = process.env.VAULT_ROLE_ID
 const VAULT_SECRET_ID = process.env.VAULT_SECRET_ID
 const VAULT_ADDR = 'https://vault.in.ft.com/v1'
-const VAULT_AUTH_GITHUB_TOKEN = process.env.VAULT_AUTH_GITHUB_TOKEN
-const CIRCLECI = process.env.CIRCLECI
 
 export type Environment = 'production' | 'continuous-integration' | 'development'
 
@@ -67,6 +65,8 @@ export class VaultEnvVars {
   }
 
   private async getAuthToken(): Promise<string> {
+    const VAULT_AUTH_GITHUB_TOKEN = process.env.VAULT_AUTH_GITHUB_TOKEN
+    const CIRCLECI = process.env.CIRCLECI
     console.log('variable', CIRCLECI, 'ENV', process.env.CIRCLECI)
     if (CIRCLECI) {
       try {

--- a/packages/vault/src/index.ts
+++ b/packages/vault/src/index.ts
@@ -68,7 +68,6 @@ export class VaultEnvVars {
     const VAULT_AUTH_GITHUB_TOKEN = process.env.VAULT_AUTH_GITHUB_TOKEN
     const CIRCLECI = process.env.CIRCLECI
     if (CIRCLECI) {
-      console.log('I think circle', typeof CIRCLECI)
       try {
         const json = await fetch<Token>(`${VAULT_ADDR}/auth/approle/login`, {
           method: 'POST',
@@ -82,20 +81,15 @@ export class VaultEnvVars {
         throw error
       }
     } else {
-      console.log('I think dev')
       // developer's local machine
       const vaultTokenFile = path.join(os.homedir(), '.vault-token')
-      console.log('vault token file', vaultTokenFile)
       try {
         const stats = await fs.stat(vaultTokenFile)
-        console.log('stats', stats)
         const fileExpired = moment().diff(stats.birthtime, 'hours') > 8
-        console.log('fileExpired', fileExpired)
         if (!fileExpired) {
           const vaultToken = await fs.readFile(vaultTokenFile, {
             encoding: 'utf8'
           })
-          console.log('vault token', vaultToken)
           return vaultToken
         }
       } catch {

--- a/packages/vault/src/index.ts
+++ b/packages/vault/src/index.ts
@@ -67,8 +67,8 @@ export class VaultEnvVars {
   private async getAuthToken(): Promise<string> {
     const VAULT_AUTH_GITHUB_TOKEN = process.env.VAULT_AUTH_GITHUB_TOKEN
     const CIRCLECI = process.env.CIRCLECI
-    console.log('variable', CIRCLECI, 'ENV', process.env.CIRCLECI)
     if (CIRCLECI) {
+      console.log('I think circle', typeof CIRCLECI)
       try {
         const json = await fetch<Token>(`${VAULT_ADDR}/auth/approle/login`, {
           method: 'POST',
@@ -82,15 +82,20 @@ export class VaultEnvVars {
         throw error
       }
     } else {
+      console.log('I think dev')
       // developer's local machine
       const vaultTokenFile = path.join(os.homedir(), '.vault-token')
+      console.log('vault token file', vaultTokenFile)
       try {
         const stats = await fs.stat(vaultTokenFile)
+        console.log('stats', stats)
         const fileExpired = moment().diff(stats.birthtime, 'hours') > 8
+        console.log('fileExpired', fileExpired)
         if (!fileExpired) {
           const vaultToken = await fs.readFile(vaultTokenFile, {
             encoding: 'utf8'
           })
+          console.log('vault token', vaultToken)
           return vaultToken
         }
       } catch {

--- a/packages/vault/test/index.test.ts
+++ b/packages/vault/test/index.test.ts
@@ -53,9 +53,11 @@ describe(`local vault token retrieval`, () => {
   afterAll(() => {
     process.env.CIRCLECI = CIRCLECI // reset to original value
     process.env.VAULT_AUTH_GITHUB_TOKEN = VAULT_AUTH_GITHUB_TOKEN
+    console.log('after all', process.env.CIRCLECI)
   })
 
   it('should handle a .vault-token file being present but expired', async () => {
+    console.log('CIRCLECI env', process.env.CIRCLECI)
     mockedFetch.mockResolvedValue({ auth: { client_token: 'bbb' } })
     process.env.VAULT_AUTH_GITHUB_TOKEN = 'abc'
     await vault['getAuthToken']()
@@ -77,19 +79,5 @@ describe(`local vault token retrieval`, () => {
 
     expect(fs.promises.readFile).toBeCalledTimes(0)
     expect(mockedFetch).toBeCalledTimes(1)
-  })
-
-  it('should throw if authentication is denied', async () => {
-    mockedFetch.mockRejectedValue(undefined)
-    process.env.VAULT_AUTH_GITHUB_TOKEN = 'hij'
-    await expect(vault['getAuthToken']()).rejects.toThrow()
-  })
-
-  it('should write a new token to file', async () => {
-    mockedFetch.mockResolvedValue({ auth: { client_token: 'bbb' } })
-    process.env.VAULT_AUTH_GITHUB_TOKEN = 'abc'
-    await vault['getAuthToken']()
-
-    expect(fs.promises.writeFile).toBeCalledTimes(1)
   })
 })

--- a/packages/vault/test/index.test.ts
+++ b/packages/vault/test/index.test.ts
@@ -1,0 +1,95 @@
+import { describe, it, beforeAll, afterAll, jest, expect } from '@jest/globals'
+import { VaultEnvVars } from '../src/index'
+import fetch from '@financial-times/n-fetch'
+import { mocked } from 'ts-jest/utils'
+import fs from 'fs'
+
+const CIRCLECI = process.env.CIRCLECI || undefined // take a copy of existing env var
+const VAULT_AUTH_GITHUB_TOKEN = process.env.VAULT_AUTH_GITHUB_TOKEN || undefined
+
+const expiredBirthtime = new Date(new Date().getTime() - 48 * 60 * 60 * 1000)
+const activeBirthtime = new Date(new Date().getTime() - 2 * 60 * 60 * 1000)
+
+jest.mock('@financial-times/n-fetch')
+
+const mockedFetch = mocked(fetch, true)
+
+jest.mock('path', () => {
+  return {
+    join: jest.fn(() => '.vault-token')
+  }
+})
+
+jest.mock('fs', () => ({
+  promises: {
+    writeFile: jest.fn(),
+    stat: jest.fn(() => {
+      console.log('token', process.env.VAULT_AUTH_GITHUB_TOKEN)
+      if (process.env.VAULT_AUTH_GITHUB_TOKEN === 'abc') {
+        return { birthtime: expiredBirthtime }
+      } else if (process.env.VAULT_AUTH_GITHUB_TOKEN === 'def') {
+        return { birthtime: activeBirthtime }
+      } else {
+        throw new Error()
+      }
+    }),
+    readFile: jest.fn(() => 'zzz')
+  }
+}))
+
+const vault = new VaultEnvVars({
+  environment: 'development',
+  vaultPath: {
+    app: 'test-app',
+    team: 'test-team'
+  }
+})
+
+describe(`local vault token retrieval`, () => {
+  beforeAll(() => {
+    process.env.CIRCLECI = undefined // change to mimic local environment
+  })
+
+  afterAll(() => {
+    process.env.CIRCLECI = CIRCLECI // reset to original value
+    process.env.VAULT_AUTH_GITHUB_TOKEN = VAULT_AUTH_GITHUB_TOKEN
+  })
+
+  it('should handle a .vault-token file being present but expired', async () => {
+    mockedFetch.mockResolvedValue({ auth: { client_token: 'bbb' } })
+    process.env.VAULT_AUTH_GITHUB_TOKEN = 'abc'
+    await vault['getAuthToken']()
+
+    expect(mockedFetch).toBeCalledTimes(1)
+  })
+
+  it('should retrieve an in-date token from .vault-token if present', async () => {
+    process.env.VAULT_AUTH_GITHUB_TOKEN = 'def'
+    await vault['getAuthToken']()
+
+    expect(mockedFetch).toBeCalledTimes(0)
+  })
+
+  it('if no file found, it should retreive a token from vault when a github token env var is present', async () => {
+    mockedFetch.mockResolvedValue({ auth: { client_token: 'bbb' } })
+    process.env.VAULT_AUTH_GITHUB_TOKEN = 'hij'
+    await vault['getAuthToken']()
+
+    expect(fs.promises.readFile).toBeCalledTimes(0)
+    expect(mockedFetch).toBeCalledTimes(1)
+  })
+
+  it('should throw if authentication is denied', async () => {
+    mockedFetch.mockRejectedValue(undefined)
+    process.env.VAULT_AUTH_GITHUB_TOKEN = 'hij'
+    await expect(vault['getAuthToken']()).rejects.toThrow()
+  })
+
+  it('should write a new token to file', async () => {
+    mockedFetch.mockResolvedValue({ auth: { client_token: 'bbb' } })
+    process.env.VAULT_AUTH_GITHUB_TOKEN = 'abc'
+    await vault['getAuthToken']()
+
+    expect(fs.promises.writeFile).toBeCalledTimes(1)
+  })
+})

--- a/packages/vault/tsconfig.json
+++ b/packages/vault/tsconfig.json
@@ -11,5 +11,6 @@
   "compilerOptions": {
     "outDir": "lib",
     "rootDir": "src"
-  }
+  },
+  "include": ["src/**/*"]
 }


### PR DESCRIPTION
When `dotcom-tool-kit run:local` runs it uses the `vault` plugin to get the required environment variables for `next-router` and the app being developed. It needs an auth token to gain access, and first checks for an existing one in `~/.vault-token`. However, these tokens expire after 8 hours, and it's not checking whether this is a current token so fails with an authentication failure if it's using an expired token. 

This PR adds a check for an expired token, and requests a new one if found. It also writes any new tokens to file.