### PR TITLE
Vault options fix

### DIFF
--- a/packages/vault/package.json
+++ b/packages/vault/package.json
@@ -11,6 +11,7 @@
     "@dotcom-tool-kit/options": "file:../options",
     "@dotcom-tool-kit/types": "file:../types",
     "@financial-times/n-fetch": "^1.0.0-beta.7",
+    "cosmiconfig": "^7.0.1",
     "fs": "0.0.1-security",
     "os": "^0.1.2",
     "path": "^0.12.7",

--- a/packages/vault/src/getVaultOptions.ts
+++ b/packages/vault/src/getVaultOptions.ts
@@ -1,0 +1,17 @@
+import { VaultOptions } from '@dotcom-tool-kit/types/lib/schema/vault'
+import { ToolKitError } from '@dotcom-tool-kit/error'
+import { cosmiconfig } from 'cosmiconfig'
+
+const explorer = cosmiconfig('toolkit', { ignoreEmptySearchPlaces: false })
+
+export async function getVaultOptions(): Promise<VaultOptions> {
+  try {
+    const result = await explorer.search(process.cwd())
+    const { team, app } = result?.config.options['@dotcom-tool-kit/vault']
+    return { team, app }
+  } catch {
+    const error = new ToolKitError('unable to locate .toolkitrc.yml')
+    error.details = `check that you've created a .toolkit.yml in the root of your project, see https://github.com/Financial-Times/dotcom-tool-kit#configuration`
+    throw error
+  }
+}


### PR DESCRIPTION
A bug that was introduced in when we moved the vault options into the [vault plugin](https://github.com/Financial-Times/dotcom-tool-kit/blob/51fb03f3035413d91556b08b9af1218ab4facd5c/packages/vault/src/index.ts#L42). Unfortunately, this is a non-standard plugin that doesn't contain a task to get its options from installation, when [`getOptions`](https://github.com/Financial-Times/dotcom-tool-kit/blob/51fb03f3035413d91556b08b9af1218ab4facd5c/packages/options/src/index.ts#L5) is called. Instead, it calls `getOptions` when the `getEnvVars` class is instantiated by another plugin, and at this point it returns an empty object, presumably because `options` is no longer in global memory.

This PR adds a function in `vault` that reads the .toolkitrc.yml of the consuming app, and returns the relevant options for `vault`. This is the simplest way I can think, but very happy to hear different approaches 🙂 
