### PR TITLE
Don't run setup orb job until workflow is approved

### DIFF
--- a/core/cli/test/__snapshots__/index.test.ts.snap
+++ b/core/cli/test/__snapshots__/index.test.ts.snap
@@ -670,7 +670,6 @@ Object {
       "jobOptions": Object {
         "requires": Array [
           "tool-kit/setup",
-          "waiting-for-approval",
         ],
       },
       "logger": DerivedLogger {},
@@ -1998,7 +1997,6 @@ Object {
             "jobOptions": Object {
               "requires": Array [
                 "tool-kit/setup",
-                "waiting-for-approval",
               ],
             },
             "logger": DerivedLogger {},
@@ -2748,7 +2746,6 @@ Object {
           "jobOptions": Object {
             "requires": Array [
               "tool-kit/setup",
-              "waiting-for-approval",
             ],
           },
           "logger": DerivedLogger {},

--- a/orb/src/jobs/setup.yml
+++ b/orb/src/jobs/setup.yml
@@ -11,7 +11,7 @@ executor:
   tag: <<parameters.node-version>>
 
 steps:
-  - checkout
+  - attach-workspace
   - node/install-npm:
       version: <<parameters.npm-version>>
   - change-api/install-jq

--- a/plugins/circleci/src/circleci-config.ts
+++ b/plugins/circleci/src/circleci-config.ts
@@ -126,10 +126,17 @@ export default abstract class CircleCiConfigHook extends Hook {
     const config = (await this.getCircleConfig()) ?? {
       version: 2.1,
       orbs: { 'tool-kit': 'financial-times/dotcom-tool-kit@dev:alpha' },
+      jobs: {
+        checkout: {
+          docker: [{ image: 'cimg/base:stable' }],
+          steps: ['checkout', 'tool-kit/persist-workspace']
+        }
+      },
       workflows: {
         version: 2,
         'tool-kit': {
           jobs: [
+            'checkout',
             {
               'waiting-for-approval': {
                 type: 'approval',
@@ -138,7 +145,7 @@ export default abstract class CircleCiConfigHook extends Hook {
             },
             {
               'tool-kit/setup': {
-                requires: ['waiting-for-approval']
+                requires: ['checkout', 'waiting-for-approval']
               }
             }
           ]

--- a/plugins/circleci/src/circleci-config.ts
+++ b/plugins/circleci/src/circleci-config.ts
@@ -130,11 +130,15 @@ export default abstract class CircleCiConfigHook extends Hook {
         version: 2,
         'tool-kit': {
           jobs: [
-            'tool-kit/setup',
             {
               'waiting-for-approval': {
                 type: 'approval',
                 filters: { branches: { only: '/(^renovate-.*|^nori/.*)/' } }
+              }
+            },
+            {
+              'tool-kit/setup': {
+                requires: ['waiting-for-approval']
               }
             }
           ]

--- a/plugins/circleci/src/index.ts
+++ b/plugins/circleci/src/index.ts
@@ -3,7 +3,7 @@ import CircleCiConfigHook from './circleci-config'
 
 export class BuildCI extends CircleCiConfigHook {
   job = 'tool-kit/build'
-  jobOptions = { requires: ['tool-kit/setup', 'waiting-for-approval'] }
+  jobOptions = { requires: ['tool-kit/setup'] }
   addToNightly = true
 }
 


### PR DESCRIPTION
During a nori run I noticed that currently `tool-kit/setup` does not require the `waiting-for-approval` job that optionally runs for nori branches, which instead only blocks the `tool-kit/build` job and onwards. This doesn't make much sense seeing as the `setup` job runs one of the most expensive operations in the CircleCI workflow – the `npm install` step – so really shouldn't be running until approved in order to reduce the load on the CI when we push a series of nori commits.