### PR TITLE
CP-666 Add option to scale heroku dynos

### DIFF
--- a/core/create/src/index.ts
+++ b/core/create/src/index.ts
@@ -19,7 +19,8 @@ import { Logger } from './logger'
 
 const exec = promisify(_exec)
 
-const { version }: { version: string } = JSON.parse(
+const developmentVersion = '0.0.0-development'
+const { version: createVersion }: { version: string } = JSON.parse(
   readFileSync(path.resolve(__dirname, '../package.json'), 'utf-8')
 )
 
@@ -128,7 +129,19 @@ async function executeMigration(deleteConfig: boolean) {
   for (const pkg of packagesToInstall) {
     packageJson.requireDependency({
       pkg,
-      version,
+      version:
+        // Use relative file paths if running the create script locally
+        createVersion !== developmentVersion
+          ? createVersion
+          : 'file:' +
+            path.relative(
+              '',
+              path.join(
+                __dirname,
+                '../../../',
+                pkg === 'dotcom-tool-kit' ? 'core/cli' : `plugins/${pkg.slice(17)}`
+              )
+            ),
       field: 'devDependencies'
     })
   }

--- a/core/sandbox/package.json
+++ b/core/sandbox/package.json
@@ -14,24 +14,24 @@
   "license": "ISC",
   "description": "",
   "devDependencies": {
-    "@dotcom-tool-kit/circleci-heroku": "file:../circleci-heroku",
-    "@dotcom-tool-kit/eslint": "file:../eslint",
-    "@dotcom-tool-kit/frontend-app": "file:../frontend-app",
-    "@dotcom-tool-kit/lint-staged": "file:../lint-staged",
-    "@dotcom-tool-kit/lint-staged-npm": "file:../lint-staged-npm",
-    "@dotcom-tool-kit/mocha": "file:../mocha",
-    "@dotcom-tool-kit/n-test": "file:../n-test",
-    "@dotcom-tool-kit/npm": "file:../npm",
-    "@dotcom-tool-kit/prettier": "file:../prettier",
-    "@dotcom-tool-kit/upload-assets-to-s3": "file:../upload-assets-to-s3",
+    "@dotcom-tool-kit/circleci-heroku": "file:../../plugins/circleci-heroku",
+    "@dotcom-tool-kit/eslint": "file:../../plugins/eslint",
+    "@dotcom-tool-kit/frontend-app": "file:../../plugins/frontend-app",
+    "@dotcom-tool-kit/lint-staged": "file:../../plugins/lint-staged",
+    "@dotcom-tool-kit/lint-staged-npm": "file:../../plugins/lint-staged-npm",
+    "@dotcom-tool-kit/mocha": "file:../../plugins/mocha",
+    "@dotcom-tool-kit/n-test": "file:../../plugins/n-test",
+    "@dotcom-tool-kit/npm": "file:../../plugins/npm",
+    "@dotcom-tool-kit/prettier": "file:../../plugins/prettier",
+    "@dotcom-tool-kit/upload-assets-to-s3": "file:../../plugins/upload-assets-to-s3",
     "dotcom-tool-kit": "file:../cli"
   },
   "volta": {
     "extends": "../../package.json"
   },
   "dependencies": {
-    "@dotcom-tool-kit/next-router": "file:../next-router",
-    "@dotcom-tool-kit/node": "file:../node"
+    "@dotcom-tool-kit/next-router": "file:../../plugins/next-router",
+    "@dotcom-tool-kit/node": "file:../../plugins/node"
   },
   "husky": {
     "pre-commit": "dotcom-tool-kit git:precommit"

--- a/docs/migrating-to-tool-kit.md
+++ b/docs/migrating-to-tool-kit.md
@@ -186,7 +186,10 @@ continue, though naturally the optional ones may be skipped. These options will
 be added to your `.toolkitrc`. In the future, we will add support for default
 values in the migration tool (they are already available within Tool Kit
 itself,) so that for most cases you could accept default values, even for fields
-that are required.
+that are required. Some plugins will have specially-made prompts to allow
+setting options for more complex scenarios, such as the Heroku plugin which
+prompts you to fill in scaling information for each app you have in your
+project's Heroku pipeline.
 
 ### Migrating Your Makefile
 

--- a/lib/types/package.json
+++ b/lib/types/package.json
@@ -30,6 +30,7 @@
   "devDependencies": {
     "@jest/globals": "^26.6.2",
     "@types/lodash.isplainobject": "^4.0.6",
-    "@types/lodash.mapvalues": "^4.6.6"
+    "@types/lodash.mapvalues": "^4.6.6",
+    "@types/prompts": "^2.0.14"
   }
 }

--- a/lib/types/src/schema.ts
+++ b/lib/types/src/schema.ts
@@ -1,7 +1,9 @@
-// TODO: add support for more flexible union type and array/record generics
+import type prompts from 'prompts'
+
 export type ScalarSchemaType = 'string' | 'number' | 'boolean' | `|${string},${string}` | 'unknown'
 export type SchemaType = ScalarSchemaType | `array.${ScalarSchemaType}` | `record.${ScalarSchemaType}`
-export type ModifiedSchemaType = SchemaType | `${SchemaType}?`
+export type SchemaPromptGenerator<T> = (prompt: typeof prompts, onCancel: () => void) => Promise<T>
+export type ModifiedSchemaType = SchemaType | `${SchemaType}?` | SchemaPromptGenerator<unknown>
 
 export type Schema = {
   readonly [option: string]: ModifiedSchemaType
@@ -41,6 +43,11 @@ export type SchemaOutput<T extends Schema> = {
         ? SchemaTypeOutput<S>
         : never
       : never
+  } &
+  {
+    -readonly [option in keyof T as T[option] extends SchemaPromptGenerator<unknown>
+      ? option
+      : never]: T[option] extends SchemaPromptGenerator<infer R> ? R : never
   }
 
 import type { ESLintOptions } from './schema/eslint'

--- a/lib/types/src/schema/heroku.ts
+++ b/lib/types/src/schema/heroku.ts
@@ -2,9 +2,11 @@ import { SchemaOutput } from '../schema'
 
 export const HerokuSchema = {
   pipeline: 'string',
-  systemCode: 'string',
-  scale: 'number?'
+  systemCode: 'string'
 } as const
-export type HerokuOptions = SchemaOutput<typeof HerokuSchema>
+// HACK: improve SchemaOutput type to support nested objects
+export type HerokuOptions = SchemaOutput<typeof HerokuSchema> & {
+  scaling: { [app: string]: { [appType: string]: { size: string; quantity: number } } }
+}
 
 export const Schema = HerokuSchema

--- a/lib/types/src/schema/heroku.ts
+++ b/lib/types/src/schema/heroku.ts
@@ -1,7 +1,7 @@
 import { SchemaOutput, SchemaPromptGenerator } from '../schema'
 
 export interface HerokuScaling {
-  [app: string]: { [appType: string]: { size: string; quantity: number } }
+  [app: string]: { [processType: string]: { size: string; quantity: number } }
 }
 
 const scaling: SchemaPromptGenerator<HerokuScaling> = async (prompt, onCancel) => {
@@ -17,21 +17,21 @@ const scaling: SchemaPromptGenerator<HerokuScaling> = async (prompt, onCancel) =
       },
       { onCancel }
     )
-    const { appType, size, quantity, moreApps } = await prompt(
+    const { processType, size, quantity, moreApps } = await prompt(
       [
         {
-          name: 'appType',
+          name: 'processType',
           type: 'text',
           initial: 'web',
-          message: `What type of app is ${app}?`
+          message: `What is the process type of ${app}?`
         },
         { name: 'size', type: 'text', initial: 'standard-1X', message: `What should the size of ${app} be?` },
-        { name: 'quantity', type: 'number', message: `How many ${app} processes should be run?` },
+        { name: 'quantity', type: 'number', message: `What should the dyno size of ${app} be?` },
         { name: 'moreApps', type: 'confirm', message: 'Are there more Heroku apps in this pipeline?' }
       ],
       { onCancel }
     )
-    scaling[app] = { [appType]: { size, quantity } }
+    scaling[app] = { [processType]: { size, quantity } }
     allAppsConfigured = !moreApps
   }
   return scaling

--- a/lib/types/src/schema/heroku.ts
+++ b/lib/types/src/schema/heroku.ts
@@ -1,12 +1,47 @@
-import { SchemaOutput } from '../schema'
+import { SchemaOutput, SchemaPromptGenerator } from '../schema'
+
+export interface HerokuScaling {
+  [app: string]: { [appType: string]: { size: string; quantity: number } }
+}
+
+const scaling: SchemaPromptGenerator<HerokuScaling> = async (prompt, onCancel) => {
+  console.log('You must configure the scaling for each of the Heroku apps in your pipeline.')
+  const scaling: HerokuScaling = {}
+  let allAppsConfigured = false
+  while (!allAppsConfigured) {
+    const { app } = await prompt(
+      {
+        name: 'app',
+        type: 'text',
+        message: 'Enter the name of the Heroku app to configure'
+      },
+      { onCancel }
+    )
+    const { appType, size, quantity, moreApps } = await prompt(
+      [
+        {
+          name: 'appType',
+          type: 'text',
+          initial: 'web',
+          message: `What type of app is ${app}?`
+        },
+        { name: 'size', type: 'text', initial: 'standard-1X', message: `What should the size of ${app} be?` },
+        { name: 'quantity', type: 'number', message: `How many ${app} processes should be run?` },
+        { name: 'moreApps', type: 'confirm', message: 'Are there more Heroku apps in this pipeline?' }
+      ],
+      { onCancel }
+    )
+    scaling[app] = { [appType]: { size, quantity } }
+    allAppsConfigured = !moreApps
+  }
+  return scaling
+}
 
 export const HerokuSchema = {
   pipeline: 'string',
-  systemCode: 'string'
+  systemCode: 'string',
+  scaling
 } as const
-// HACK: improve SchemaOutput type to support nested objects
-export type HerokuOptions = SchemaOutput<typeof HerokuSchema> & {
-  scaling: { [app: string]: { [appType: string]: { size: string; quantity: number } } }
-}
+export type HerokuOptions = SchemaOutput<typeof HerokuSchema>
 
 export const Schema = HerokuSchema

--- a/lib/types/src/schema/heroku.ts
+++ b/lib/types/src/schema/heroku.ts
@@ -2,7 +2,8 @@ import { SchemaOutput } from '../schema'
 
 export const HerokuSchema = {
   pipeline: 'string',
-  systemCode: 'string'
+  systemCode: 'string',
+  scale: 'number?'
 } as const
 export type HerokuOptions = SchemaOutput<typeof HerokuSchema>
 

--- a/plugins/heroku/src/scaleDyno.ts
+++ b/plugins/heroku/src/scaleDyno.ts
@@ -2,17 +2,12 @@ import heroku from './herokuClient'
 import { ToolKitError } from '@dotcom-tool-kit/error'
 import type { HerokuApiResPatch } from 'heroku-client'
 
-async function scaleDyno(appName: string, quantity: number, type = 'web'): Promise<void> {
+async function scaleDyno(appName: string, quantity: number, type = 'web', size?: string): Promise<void> {
   console.log(`scaling dyno for ${appName}...`)
 
   const appFormation: HerokuApiResPatch[] = await heroku.patch(`/apps/${appName}/formation`, {
     body: {
-      updates: [
-        {
-          quantity: quantity,
-          type: type
-        }
-      ]
+      updates: [{ quantity, size, type }]
     }
   })
 

--- a/plugins/heroku/src/tasks/production.ts
+++ b/plugins/heroku/src/tasks/production.ts
@@ -1,7 +1,7 @@
 import { Task } from '@dotcom-tool-kit/types'
 import { ToolKitError } from '@dotcom-tool-kit/error'
 import { readState } from '@dotcom-tool-kit/state'
-import { HerokuSchema } from '@dotcom-tool-kit/types/lib/schema/heroku'
+import { HerokuSchema, HerokuOptions } from '@dotcom-tool-kit/types/lib/schema/heroku'
 import { scaleDyno } from '../scaleDyno'
 import { setSlug } from '../setSlug'
 
@@ -10,42 +10,47 @@ export default class HerokuProduction extends Task<typeof HerokuSchema> {
 
   async run(): Promise<void> {
     try {
-      console.log(`retrieving staging slug...`)
+      console.log('retrieving staging slug...')
       const state = readState('staging')
       if (!state) {
         throw new ToolKitError('could not find staging state information')
       }
       const { slugId } = state
 
-      console.log(`promoting staging to production....`)
+      console.log('promoting staging to production....')
       await setSlug(slugId)
 
-      console.log(`staging has been successfully promoted to production`)
+      console.log('staging has been successfully promoted to production')
 
-      if (this.options.scale) {
-        const { scale } = this.options
-        console.log(`scaling to ${scale} processes...`)
+      const { scaling } = this.options as HerokuOptions
 
-        console.log('retrieving production app ID...')
-        const state = readState('production')
-        if (!state) {
-          throw new ToolKitError('could not find production state information')
+      if (!scaling) {
+        const error = new ToolKitError('your heroku pipeline must have its scaling configured')
+        error.details = `configure it in your .toolkitrc.yml, with a quantity and size for each production app, e.g.:
+
+options:
+  '@dotcom-tool-kit/heroku':
+    app-name:
+      web:
+        size: standard-1x
+        quantity: 2`
+
+        throw error
+      }
+
+      for (const [appName, typeConfig] of Object.entries(scaling)) {
+        console.log(`scaling app ${appName}...`)
+        for (const [appType, { quantity, size }] of Object.entries(typeConfig)) {
+          await scaleDyno(appName, quantity, appType, size)
         }
-        const { appIds } = state
-
-        if (appIds.length > 1) {
-          console.warn('tool kit can currently only scale your first app')
-        }
-
-        await scaleDyno(appIds[0], scale)
-        console.log(`successfully scaled to ${scale} processes`)
+        console.log(`${appName} has been successfully scaled`)
       }
     } catch (err) {
       if (err instanceof ToolKitError) {
         throw err
       }
 
-      const error = new ToolKitError(`there was a problem promoting staging production`)
+      const error = new ToolKitError("there's an error with your production app")
       if (err instanceof Error) {
         error.details = err.message
       }

--- a/plugins/heroku/src/tasks/production.ts
+++ b/plugins/heroku/src/tasks/production.ts
@@ -1,7 +1,8 @@
 import { Task } from '@dotcom-tool-kit/types'
 import { ToolKitError } from '@dotcom-tool-kit/error'
 import { readState } from '@dotcom-tool-kit/state'
-import { HerokuOptions, HerokuSchema } from '@dotcom-tool-kit/types/lib/schema/heroku'
+import { HerokuSchema } from '@dotcom-tool-kit/types/lib/schema/heroku'
+import { scaleDyno } from '../scaleDyno'
 import { setSlug } from '../setSlug'
 
 export default class HerokuProduction extends Task<typeof HerokuSchema> {
@@ -20,6 +21,25 @@ export default class HerokuProduction extends Task<typeof HerokuSchema> {
       await setSlug(slugId)
 
       console.log(`staging has been successfully promoted to production`)
+
+      if (this.options.scale) {
+        const { scale } = this.options
+        console.log(`scaling to ${scale} processes...`)
+
+        console.log('retrieving production app ID...')
+        const state = readState('production')
+        if (!state) {
+          throw new ToolKitError('could not find production state information')
+        }
+        const { appIds } = state
+
+        if (appIds.length > 1) {
+          console.warn('tool kit can currently only scale your first app')
+        }
+
+        await scaleDyno(appIds[0], scale)
+        console.log(`successfully scaled to ${scale} processes`)
+      }
     } catch (err) {
       if (err instanceof ToolKitError) {
         throw err

--- a/plugins/heroku/src/tasks/production.ts
+++ b/plugins/heroku/src/tasks/production.ts
@@ -30,18 +30,19 @@ export default class HerokuProduction extends Task<typeof HerokuSchema> {
 
 options:
   '@dotcom-tool-kit/heroku':
-    app-name:
-      web:
-        size: standard-1x
-        quantity: 2`
+    scaling:
+      ft-next-static-eu:
+        web:
+          size: standard-1x
+          quantity: 2`
 
         throw error
       }
 
       for (const [appName, typeConfig] of Object.entries(scaling)) {
         console.log(`scaling app ${appName}...`)
-        for (const [appType, { quantity, size }] of Object.entries(typeConfig)) {
-          await scaleDyno(appName, quantity, appType, size)
+        for (const [processType, { quantity, size }] of Object.entries(typeConfig)) {
+          await scaleDyno(appName, quantity, processType, size)
         }
         console.log(`${appName} has been successfully scaled`)
       }

--- a/plugins/heroku/test/tasks/production.test.ts
+++ b/plugins/heroku/test/tasks/production.test.ts
@@ -16,20 +16,20 @@ const productionOptions = { scaling: { 'test-app': { web: { size: 'standard-1x',
 describe('staging', () => {
   it('should call set slug with slug id', async () => {
     mockSetSlug.mockImplementation(() => Promise.resolve([]))
-    const task = new Production(productionOptions as unknown)
+    const task = new Production(productionOptions)
     await task.run()
 
     expect(utils.setSlug).toBeCalledWith('slug-id')
   })
 
   it('should resolve when completed successfully', async () => {
-    const task = new Production(productionOptions as unknown)
+    const task = new Production(productionOptions)
     await expect(task.run()).resolves.not.toThrow()
   })
 
   it('should throw if it completes unsuccessfully', async () => {
     mockSetSlug.mockImplementation(() => Promise.reject())
-    const task = new Production(productionOptions as unknown)
+    const task = new Production(productionOptions)
     await expect(task.run()).rejects.toThrowError()
   })
 })

--- a/plugins/heroku/test/tasks/production.test.ts
+++ b/plugins/heroku/test/tasks/production.test.ts
@@ -8,25 +8,28 @@ jest.mock('@dotcom-tool-kit/state', () => {
   }
 })
 
+jest.mock('../../src/scaleDyno')
+
 const mockSetSlug = jest.spyOn(utils, 'setSlug')
+const productionOptions = { scaling: { 'test-app': { web: { size: 'standard-1x', quantity: 1 } } } }
 
 describe('staging', () => {
   it('should call set slug with slug id', async () => {
     mockSetSlug.mockImplementation(() => Promise.resolve([]))
-    const task = new Production({})
+    const task = new Production(productionOptions as unknown)
     await task.run()
 
     expect(utils.setSlug).toBeCalledWith('slug-id')
   })
 
   it('should resolve when completed successfully', async () => {
-    const task = new Production({})
+    const task = new Production(productionOptions as unknown)
     await expect(task.run()).resolves.not.toThrow()
   })
 
   it('should throw if it completes unsuccessfully', async () => {
     mockSetSlug.mockImplementation(() => Promise.reject())
-    const task = new Production({})
+    const task = new Production(productionOptions as unknown)
     await expect(task.run()).rejects.toThrowError()
   })
 })


### PR DESCRIPTION
Adds a new step to the `heroku:production` task that will scale the dyno to a value set in the `.toolkitrc.yml`. Will skip the step (leaving the dyno at its previous value) if no `scaling` option is set.

Would also have liked to added support for enabling autoscaling, but it seems that Heroku is using [undocumented API calls](https://github.com/heroku/cli/blob/4b89482ab15e28d1449af9cfe95821d64acd4b6e/packages/ps/src/commands/ps/autoscale/enable.ts#L64) to configure it. Other people have gone to the trouble of [documenting the behaviour](https://registry.terraform.io/providers/davidji99/herokux/latest/docs/resources/formation_autoscaling), but the documentation illustrates how flakey (and risky – if you set it up wrong you might be forced to delete and recreate your app config from scratch if the dyno is bricked!) the process is. Presumably it will also be subject to breaking changes whenever the developers see fit.

Also added a new way to prompt the user for more config options structures during the `npm init @financial-times/dotcom-tool-kit` process:

> It is difficult to create a generic way of prompting the user to give settings for more complex options structures like the ones added in the Heroku plugin, so instead we should allow plugins to create their own prompt flows for specific options if necessary. We pass the prompt function to them and they can construct a flow specific to their use case, returning the resultant options object.
In this instance, the Heroku plugin now prompts the user to enter the scaling configuration for each app in their Heroku pipeline.