### PR TITLE
Fix unreturned promises from mock function

### DIFF
--- a/plugins/heroku/test/tasks/review.test.ts
+++ b/plugins/heroku/test/tasks/review.test.ts
@@ -18,9 +18,9 @@ jest.mock('../../src/herokuClient', () => {
   return {
     get: jest.fn((path: string) => {
       if (path.includes('test-pipeline')) {
-        return { id: 'test-pipeline-id' }
+        return Promise.resolve({ id: 'test-pipeline-id' })
       } else {
-        Promise.reject()
+        return Promise.reject()
       }
     })
   }


### PR DESCRIPTION
Was getting `UnhandledPromiseRejection` warnings when running our test suite. Turns out this `Promise.resolve` was being created but not returned (and consequently not handled.) Return the other path as a promise as well to better mimic the behaviour of the `heroku-client` method we're mocking.