### PR TITLE
fix husky config format installed by hook

### DIFF
--- a/lib/husky-hook/src/index.ts
+++ b/lib/husky-hook/src/index.ts
@@ -1,7 +1,9 @@
 import { PackageJsonHelper } from '@dotcom-tool-kit/hook'
 
 type HuskyHooks = {
-  [hook: string]: string
+  hooks: {
+    [hook: string]: string
+  }
 }
 
 export abstract class HuskyHook extends PackageJsonHelper {
@@ -10,11 +12,11 @@ export abstract class HuskyHook extends PackageJsonHelper {
   async install(): Promise<void> {
     let command = `dotcom-tool-kit ${this.hook}`
     const huskyHooks = this.packageJson.getField<HuskyHooks>(this.field) || {}
-    const existingCommand = huskyHooks[this.key]
+    const existingCommand = huskyHooks.hooks[this.key]
     if (existingCommand?.startsWith('dotcom-tool-kit ')) {
       command = command.concat(existingCommand.replace('dotcom-tool-kit', ''))
     }
-    huskyHooks[this.key] = command
+    huskyHooks.hooks[this.key] = command
     this.packageJson.setField(this.field, huskyHooks)
 
     this.packageJson.writeChanges()

--- a/plugins/husky-npm/package.json
+++ b/plugins/husky-npm/package.json
@@ -12,6 +12,9 @@
   "dependencies": {
     "@dotcom-tool-kit/husky-hook": "file:../../lib/husky-hook"
   },
+  "peerDependencies": {
+    "husky": "^4.3.8"
+  },
   "repository": {
     "type": "git",
     "url": "https://github.com/financial-times/dotcom-tool-kit.git",


### PR DESCRIPTION
also add a `peerDependency` on the correct version of husky to make setting it up easier