### PR TITLE
Fix ignored lint-staged-npm glob options

### DIFF
--- a/plugins/lint-staged-npm/src/index.ts
+++ b/plugins/lint-staged-npm/src/index.ts
@@ -4,14 +4,20 @@ import { getOptions } from '@dotcom-tool-kit/options'
 class TestStaged extends LintStagedHook {
   static description = 'format prettier'
 
-  key = getOptions('@dotcom-tool-kit/lint-staged-npm')?.testGlob ?? '**/*.js'
+  _key?: string
+  get key(): string {
+    return (this._key ??= getOptions('@dotcom-tool-kit/lint-staged-npm')?.testGlob ?? '**/*.js')
+  }
   hook = 'test:staged'
 }
 
 class FormatStaged extends LintStagedHook {
   static description = 'format prettier'
 
-  key = getOptions('@dotcom-tool-kit/lint-staged-npm')?.formatGlob ?? '**/*.js'
+  _key?: string
+  get key(): string {
+    return (this._key ??= getOptions('@dotcom-tool-kit/lint-staged-npm')?.formatGlob ?? '**/*.js')
+  }
   hook = 'format:staged'
 }
 


### PR DESCRIPTION
`lint-staged-npm` allows you to set the globs used by lint-staged in your `.toolkitrc.yml` config. Previously, it would read the options when the class was constructed. However, now that we construct the classes when first loading the plugins (in order to verify they're instances of the `Hook` class) this code is now running before the options from the config file have been set. Instead, lazily read the options the first time the key property is accessed, which should be just after the place where they were previously being constructed.

This should fix all `lint-staged-npm` hooks being assigned to the default `**/*.js` glob regardless of their `formatGlob` and `testGlob` options.