### PR TITLE
CPP-771 Fix webpack failing if configPath option isn't set

### DIFF
--- a/plugins/webpack/src/run-webpack.ts
+++ b/plugins/webpack/src/run-webpack.ts
@@ -7,11 +7,11 @@ const webpackCLIPath = require.resolve('webpack-cli/bin/cli')
 
 export default function runWebpack(logger: Logger, options: WebpackOptions): Promise<void> {
   logger.info('starting Webpack...')
-  const child = fork(
-    webpackCLIPath,
-    ['build', `--mode=${options.mode}`, options.configPath ? `--config=${options.configPath}` : ''],
-    { silent: true }
-  )
+  const args = ['build', '--color', `--mode=${options.mode}`]
+  if (options.configPath) {
+    args.push(`--config=${options.configPath}`)
+  }
+  const child = fork(webpackCLIPath, args, { silent: true })
   hookFork(logger, 'webpack', child)
   return waitOnExit('webpack', child)
 }

--- a/plugins/webpack/test/tasks/webpack.test.ts
+++ b/plugins/webpack/test/tasks/webpack.test.ts
@@ -30,7 +30,7 @@ describe('webpack', () => {
 
       expect(fork).toBeCalledWith(
         webpackCLIPath,
-        ['build', '--mode=development', '--config=webpack.config.js'],
+        ['build', '--color', '--mode=development', '--config=webpack.config.js'],
         { silent: true }
       )
     })
@@ -44,7 +44,7 @@ describe('webpack', () => {
 
       expect(fork).toBeCalledWith(
         webpackCLIPath,
-        ['build', '--mode=production', '--config=webpack.config.js'],
+        ['build', '--color', '--mode=production', '--config=webpack.config.js'],
         { silent: true }
       )
     })


### PR DESCRIPTION
If configPath wasn't set we were instead falling back to inserting an empty string into the list of arguments to pass to webpack. Unfortunately, unlike on a terminal where empty space would typically be stripped, the empty string is still interpreted as an argument in this case (similar to how the empty string would be an argument if you ran `webpack ''` instead of `webpack  `) and by default is considered a path to the webpack config file, which then isn't found. The webpack error isn't particularly helpful so it went unnoticed.

As a bonus, also pass the `--color` option to webpack to force ANSI colours even though we're piping to winston.