### PR TITLE
persist workspace after build job

### DIFF
--- a/orb/src/jobs/build.yml
+++ b/orb/src/jobs/build.yml
@@ -12,3 +12,4 @@ steps:
   - run:
       name: Run the project build-production task
       command: npx dotcom-tool-kit build:ci
+  - persist-workspace


### PR DESCRIPTION
`build` will probably have generated some files that we need to keep for future jobs