### PR TITLE
Fix broken winston types in logger

### DIFF
--- a/core/cli/package.json
+++ b/core/cli/package.json
@@ -26,7 +26,7 @@
     "chai": "^4.3.4",
     "globby": "^10.0.2",
     "ts-node": "^8.10.2",
-    "winston": "^3.4.0"
+    "winston": "^3.5.1"
   },
   "dependencies": {
     "@dotcom-tool-kit/error": "file:../../lib/error",

--- a/lib/logger/package.json
+++ b/lib/logger/package.json
@@ -27,7 +27,7 @@
     "ansi-colors": "^4.1.1",
     "ansi-regex": "^5.0.1",
     "triple-beam": "^1.3.0",
-    "winston": "^3.5.0",
+    "winston": "^3.4.0",
     "winston-transport": "^4.4.2"
   },
   "devDependencies": {

--- a/lib/logger/package.json
+++ b/lib/logger/package.json
@@ -27,7 +27,7 @@
     "ansi-colors": "^4.1.1",
     "ansi-regex": "^5.0.1",
     "triple-beam": "^1.3.0",
-    "winston": "^3.4.0",
+    "winston": "^3.5.1",
     "winston-transport": "^4.4.2"
   },
   "devDependencies": {

--- a/lib/logger/src/helpers.ts
+++ b/lib/logger/src/helpers.ts
@@ -1,6 +1,6 @@
 import { ChildProcess } from 'child_process'
 import { Readable, Transform } from 'stream'
-import { Logger, level as LogLevel } from 'winston'
+import { Logger } from 'winston'
 import { ToolKitError } from '@dotcom-tool-kit/error'
 import { rootLogger } from './logger'
 import { HookTransport, consoleTransport } from './transports'
@@ -36,7 +36,7 @@ function ansiTrim(message: string): string {
 // calling functions from external libraries that you expect will do their own
 // logging.
 export function hookConsole(logger: Logger, processName: string): () => void {
-  function writeShim(stream: NodeJS.WriteStream, level: LogLevel): NodeJS.WriteStream['write'] {
+  function writeShim(stream: NodeJS.WriteStream, level: string): NodeJS.WriteStream['write'] {
     return (message: string, encoding?, writeCallback?) => {
       // HACK allow winston logs from other threads to go straight through
       if (message.startsWith('[')) {

--- a/lib/logger/src/logger.ts
+++ b/lib/logger/src/logger.ts
@@ -3,7 +3,7 @@ import { format } from './format'
 import { consoleTransport } from './transports'
 
 export const rootLogger: winston.Logger = winston.createLogger({
-  level: (process.env.LOG_LEVEL as winston.level | undefined) ?? (process.env.CIRCLECI ? 'verbose' : 'info'),
+  level: process.env.LOG_LEVEL ?? (process.env.CIRCLECI ? 'verbose' : 'info'),
   format,
   transports: [consoleTransport]
 })

--- a/lib/package-json-hook/package.json
+++ b/lib/package-json-hook/package.json
@@ -21,7 +21,7 @@
   "homepage": "https://github.com/financial-times/dotcom-tool-kit/tree/main/lib/package-json-hook",
   "devDependencies": {
     "@jest/globals": "^27.4.6",
-    "winston": "^3.4.0"
+    "winston": "^3.5.1"
   },
   "files": [
     "/lib",

--- a/lib/types/package.json
+++ b/lib/types/package.json
@@ -32,6 +32,6 @@
     "@types/lodash.isplainobject": "^4.0.6",
     "@types/lodash.mapvalues": "^4.6.6",
     "@types/prompts": "^2.0.14",
-    "winston": "^3.4.0"
+    "winston": "^3.5.1"
   }
 }

--- a/lib/vault/package.json
+++ b/lib/vault/package.json
@@ -36,6 +36,6 @@
   "devDependencies": {
     "@types/jest": "^27.0.2",
     "node-fetch": "^1.7.3",
-    "winston": "^3.4.0"
+    "winston": "^3.5.1"
   }
 }

--- a/lib/wait-for-ok/package.json
+++ b/lib/wait-for-ok/package.json
@@ -22,7 +22,7 @@
   "devDependencies": {
     "@types/node": "^12.20.24",
     "@types/node-fetch": "^2.5.10",
-    "winston": "^3.4.0"
+    "winston": "^3.5.1"
   },
   "files": [
     "/lib",

--- a/plugins/babel/package.json
+++ b/plugins/babel/package.json
@@ -32,7 +32,7 @@
   "devDependencies": {
     "@babel/preset-env": "^7.16.11",
     "@jest/globals": "^27.4.6",
-    "winston": "^3.4.0"
+    "winston": "^3.5.1"
   },
   "peerDependencies": {
     "@babel/core": "7.x"

--- a/plugins/circleci/package.json
+++ b/plugins/circleci/package.json
@@ -29,7 +29,7 @@
     "@types/jest": "^27.4.0",
     "@types/js-yaml": "^4.0.3",
     "@types/lodash.isequal": "^4.5.5",
-    "winston": "^3.4.0"
+    "winston": "^3.5.1"
   },
   "files": [
     "/lib",

--- a/plugins/eslint/package.json
+++ b/plugins/eslint/package.json
@@ -25,7 +25,7 @@
   "devDependencies": {
     "@jest/globals": "^27.4.6",
     "@types/eslint": "^7.2.13",
-    "winston": "^3.4.0"
+    "winston": "^3.5.1"
   },
   "files": [
     "/lib",

--- a/plugins/heroku/package.json
+++ b/plugins/heroku/package.json
@@ -35,7 +35,7 @@
   "devDependencies": {
     "@types/financial-times__package-json": "file:../../types/financial-times__package-json",
     "@types/p-retry": "^3.0.1",
-    "winston": "^3.4.0"
+    "winston": "^3.5.1"
   },
   "files": [
     "/lib",

--- a/plugins/jest/package.json
+++ b/plugins/jest/package.json
@@ -29,6 +29,6 @@
   ],
   "devDependencies": {
     "@jest/globals": "^27.4.6",
-    "winston": "^3.4.0"
+    "winston": "^3.5.1"
   }
 }

--- a/plugins/lint-staged/tsconfig.json
+++ b/plugins/lint-staged/tsconfig.json
@@ -4,6 +4,6 @@
     "outDir": "lib",
     "rootDir": "src"
   },
-  "references": [{ "path": "../../lib/hook" }, { "path": "../../lib/logger" }],
+  "references": [{ "path": "../../lib/hook" }],
   "include": ["src/**/*"]
 }

--- a/plugins/lint-staged/tsconfig.json
+++ b/plugins/lint-staged/tsconfig.json
@@ -4,6 +4,6 @@
     "outDir": "lib",
     "rootDir": "src"
   },
-  "references": [{ "path": "../../lib/hook" }],
+  "references": [{ "path": "../../lib/hook" }, { "path": "../../lib/logger" }],
   "include": ["src/**/*"]
 }

--- a/plugins/mocha/package.json
+++ b/plugins/mocha/package.json
@@ -28,7 +28,7 @@
     "@jest/globals": "^27.4.6",
     "@types/glob": "^7.1.3",
     "@types/mocha": "^8.2.2",
-    "winston": "^3.4.0"
+    "winston": "^3.5.1"
   },
   "files": [
     "/lib",

--- a/plugins/n-test/package.json
+++ b/plugins/n-test/package.json
@@ -25,7 +25,7 @@
   "devDependencies": {
     "@jest/globals": "^27.4.6",
     "@types/jest": "^27.4.0",
-    "winston": "^3.4.0"
+    "winston": "^3.5.1"
   },
   "files": [
     "/lib",

--- a/plugins/npm/package.json
+++ b/plugins/npm/package.json
@@ -12,9 +12,9 @@
   "dependencies": {
     "@actions/exec": "^1.1.0",
     "@dotcom-tool-kit/error": "file:../../lib/error",
-    "@dotcom-tool-kit/husky-hook": "file:../husky-hook",
-    "@dotcom-tool-kit/package-json-hook": "file:../package-json-hook",
-    "@dotcom-tool-kit/types": "file:../types"
+    "@dotcom-tool-kit/husky-hook": "file:../../lib/husky-hook",
+    "@dotcom-tool-kit/package-json-hook": "file:../../lib/package-json-hook",
+    "@dotcom-tool-kit/types": "file:../../lib/types"
   },
   "repository": {
     "type": "git",

--- a/plugins/prettier/package.json
+++ b/plugins/prettier/package.json
@@ -33,7 +33,7 @@
     "@jest/globals": "^27.4.6",
     "jest": "^27.4.7",
     "ts-jest": "^27.1.3",
-    "winston": "^3.4.0"
+    "winston": "^3.5.1"
   },
   "volta": {
     "extends": "../../package.json"

--- a/plugins/upload-assets-to-s3/package.json
+++ b/plugins/upload-assets-to-s3/package.json
@@ -30,7 +30,7 @@
     "@types/glob": "^7.1.3",
     "@types/jest": "^27.4.0",
     "@types/mime": "^2.0.3",
-    "winston": "^3.4.0"
+    "winston": "^3.5.1"
   },
   "files": [
     "/lib",

--- a/plugins/webpack/package.json
+++ b/plugins/webpack/package.json
@@ -29,7 +29,7 @@
     "@jest/globals": "^27.4.6",
     "ts-node": "^10.0.0",
     "webpack": "^4.42.1",
-    "winston": "^3.4.0"
+    "winston": "^3.5.1"
   },
   "files": [
     "/lib",


### PR DESCRIPTION
winston have now [issued a patch](https://github.com/winstonjs/winston/releases/tag/v3.5.1) that fixes the breaking type change that was inadvertently made in [version 3.5.0](https://github.com/winstonjs/winston/releases/tag/v3.5.0) though this, naturally, breaks the [changes](https://github.com/Financial-Times/dotcom-tool-kit/commit/663c89849ec967081caf2e73d0190e8fb759dc39) we made to accommodate that release...