### PR TITLE
Only lint staged files in pre-commit hook

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
   ],
   "husky": {
     "hooks": {
-      "pre-commit": "npm run lint && lint-staged",
+      "pre-commit": "lint-staged",
       "post-checkout": "npm run clean-up-packages -- $HUSKY_GIT_PARAMS"
     }
   },


### PR DESCRIPTION
Should significantly speed up the time it takes to run the hook, which would previously often run for upwards of 10 seconds every time a `git commit` was invoked. We don't need to run a whole lint each time; during a commit we only care about verifying the staged files. Other files may have issues but that's okay as we aren't committing them right now.