### PR TITLE
Revert "cpp-778 update config vars on review apps at first possible moment"

### DIFF
--- a/plugins/heroku/src/promoteStagingToProduction.ts
+++ b/plugins/heroku/src/promoteStagingToProduction.ts
@@ -3,7 +3,7 @@ import { ToolKitError } from '@dotcom-tool-kit/error'
 import { readState } from '@dotcom-tool-kit/state'
 import { gtg } from './gtg'
 import type { Logger } from 'winston'
-import { setAppConfigVars } from './setConfigVars'
+import { setConfigVars } from './setConfigVars'
 
 async function promoteStagingToProduction(logger: Logger, slug: string, systemCode?: string): Promise<void[]> {
   const state = readState(`production`)
@@ -34,7 +34,7 @@ async function promoteStagingToProduction(logger: Logger, slug: string, systemCo
   )
   
   for(const id of appIds) {
-    await setAppConfigVars(logger, id, 'production', systemCode)
+    await setConfigVars(logger, id, 'production', systemCode)
   }
 
   return Promise.all(latestRelease)

--- a/plugins/heroku/src/setConfigVars.ts
+++ b/plugins/heroku/src/setConfigVars.ts
@@ -3,13 +3,11 @@ import heroku from './herokuClient'
 import { ToolKitError } from '@dotcom-tool-kit/error'
 import { VaultEnvVars, Environment } from '@dotcom-tool-kit/vault'
 
-type Stage = 'test' | 'development' | 'review' | 'staging' | 'production'
-
-async function setAppConfigVars(
+async function setConfigVars(
   logger: Logger,
   appIdName: string,
   environment: Environment,
-  systemCode?: string,
+  systemCode?: string
 ): Promise<void> {
   try {
     logger.info(`setting config vars for ${appIdName}`)
@@ -27,11 +25,10 @@ async function setAppConfigVars(
     await heroku.patch(`/apps/${appIdName}/config-vars`, { body: configVars })
 
     logger.verbose('the following values have been set:', Object.keys(configVars).join(', '))
-    
+
     logger.info(`${appIdName} config vars have been updated successfully.`)
-
   } catch (err) {
-    const error = new ToolKitError(`Error updating config vars for ${appIdName} app`)
+    const error = new ToolKitError(`Error updating config vars`)
     if (err instanceof Error) {
       error.details = err.message
     }
@@ -39,34 +36,4 @@ async function setAppConfigVars(
   }
 }
 
-async function setStageConfigVars(
-  logger: Logger,
-  stage: Stage,
-  environment: Environment,
-  pipelineId: string,
-): Promise<void> {
-  try {
-    logger.info(`setting config vars for ${stage} stage`)
-
-    const vaultEnvVars = new VaultEnvVars(logger, {
-      environment
-    })
-
-    const configVars = await vaultEnvVars.get()
-
-    await heroku.patch(`/pipelines/${pipelineId}/stage/${stage}/config-vars`, { body: configVars })
-
-    logger.verbose('the following values have been set:', Object.keys(configVars).join(', '))
-    
-    logger.info(`config vars for ${stage} stage have been updated successfully.`)
-
-  } catch (err) {
-    const error = new ToolKitError(`Error updating config vars for ${stage} stage`)
-    if (err instanceof Error) {
-      error.details = err.message
-    }
-    throw error
-  }
-}
-
-export { setAppConfigVars, setStageConfigVars }
+export { setConfigVars }

--- a/plugins/heroku/src/tasks/review.ts
+++ b/plugins/heroku/src/tasks/review.ts
@@ -2,7 +2,7 @@ import { styles } from '@dotcom-tool-kit/logger'
 import { Task } from '@dotcom-tool-kit/types'
 import { getHerokuReviewApp } from '../getHerokuReviewApp'
 import { gtg } from '../gtg'
-import { setStageConfigVars } from '../setConfigVars'
+import { setConfigVars } from '../setConfigVars'
 import { writeState } from '@dotcom-tool-kit/state'
 import { HerokuSchema } from '@dotcom-tool-kit/types/lib/schema/heroku'
 import { ToolKitError } from '@dotcom-tool-kit/error'
@@ -28,12 +28,12 @@ options:
       }
 
       const pipeline: HerokuApiResPipeline = await herokuClient.get(`/pipelines/${this.options.pipeline}`)
-      
-      await setStageConfigVars(this.logger, 'review', 'continuous-integration', pipeline.id)
 
       const reviewAppId = await getHerokuReviewApp(this.logger, pipeline.id)
 
       writeState('review', { appId: reviewAppId })
+
+      await setConfigVars(this.logger, reviewAppId, 'continuous-integration')
 
       await gtg(this.logger, reviewAppId, 'review')
     } catch (err) {

--- a/plugins/heroku/src/tasks/staging.ts
+++ b/plugins/heroku/src/tasks/staging.ts
@@ -2,7 +2,7 @@ import { Task } from '@dotcom-tool-kit/types'
 import { ToolKitError } from '@dotcom-tool-kit/error'
 import { styles } from '@dotcom-tool-kit/logger'
 import { getHerokuStagingApp } from '../getHerokuStagingApp'
-import { setAppConfigVars } from '../setConfigVars'
+import { setConfigVars } from '../setConfigVars'
 import { scaleDyno } from '../scaleDyno'
 import { gtg } from '../gtg'
 import { getPipelineCouplings } from '../getPipelineCouplings'
@@ -35,7 +35,7 @@ options:
 
       //apply vars from vault
 
-      await setAppConfigVars(this.logger, appName, 'production', this.options.systemCode)
+      await setConfigVars(this.logger, appName, 'production', this.options.systemCode)
 
       //scale up staging
       await scaleDyno(this.logger, appName, 1)

--- a/plugins/heroku/test/tasks/review.test.ts
+++ b/plugins/heroku/test/tasks/review.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect, jest } from '@jest/globals'
 import Review from '../../src/tasks/review'
 import { getHerokuReviewApp } from '../../src/getHerokuReviewApp'
-import { setStageConfigVars } from '../../src/setConfigVars'
+import { setConfigVars } from '../../src/setConfigVars'
 import { gtg } from '../../src/gtg'
 import heroku from '../../src/herokuClient'
 import winston, { Logger } from 'winston'
@@ -37,7 +37,7 @@ jest.mock('../../src/getHerokuReviewApp', () => {
 
 jest.mock('../../src/setConfigVars', () => {
   return {
-    setStageConfigVars: jest.fn()
+    setConfigVars: jest.fn()
   }
 })
 
@@ -102,21 +102,20 @@ describe('review', () => {
     }
   })
 
-
-  it('should call setStageConfigVars with vault team and vault app', async () => {
-    const task = new Review(logger, { pipeline })
-
-    await task.run()
-
-    expect(setStageConfigVars).toBeCalledWith(expect.anything(), 'review', 'continuous-integration', 'test-pipeline-id')
-  })
-
   it('should write app id to state', async () => {
     const task = new Review(logger, { pipeline })
 
     await task.run()
 
     expect(state.review).toEqual(appId)
+  })
+
+  it('should call setConfigVars with vault team and vault app', async () => {
+    const task = new Review(logger, { pipeline })
+
+    await task.run()
+
+    expect(setConfigVars).toBeCalledWith(expect.anything(), appId, 'continuous-integration')
   })
 
   it('should call gtg with appName', async () => {

--- a/plugins/heroku/test/tasks/staging.test.ts
+++ b/plugins/heroku/test/tasks/staging.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect, jest } from '@jest/globals'
 import Staging from '../../src/tasks/staging'
 import { getPipelineCouplings } from '../../src/getPipelineCouplings'
 import { getHerokuStagingApp } from '../../src/getHerokuStagingApp'
-import { setAppConfigVars } from '../../src/setConfigVars'
+import { setConfigVars } from '../../src/setConfigVars'
 import { scaleDyno } from '../../src/scaleDyno'
 import { gtg } from '../../src/gtg'
 import winston, { Logger } from 'winston'
@@ -27,7 +27,7 @@ jest.mock('../../src/getHerokuStagingApp', () => {
 
 jest.mock('../../src/setConfigVars', () => {
   return {
-    setAppConfigVars: jest.fn(() => false)
+    setConfigVars: jest.fn(() => false)
   }
 })
 
@@ -90,12 +90,12 @@ describe('staging', () => {
     }
   })
 
-  it('should call setAppConfigVars with vault team, vault app and system code', async () => {
+  it('should call setConfigVars with vault team, vault app and system code', async () => {
     const task = new Staging(logger, { pipeline, systemCode })
 
     await task.run()
 
-    expect(setAppConfigVars).toBeCalledWith(expect.anything(), appName, 'production', systemCode)
+    expect(setConfigVars).toBeCalledWith(expect.anything(), appName, 'production', systemCode)
   })
 
   it('should call scaleDyno', async () => {


### PR DESCRIPTION
Reverts Financial-Times/dotcom-tool-kit#171

I'm having trouble getting this to work, but, in any case, it still only runs in ci way after the review app is built. I think we need a different approach - possibly the review app running the equivalent of `make .env` in the heroku-postbuild. 

It needs to come out of main as it's blocking any releases. 