### PR TITLE
CPP-782 Add nodemon plugin

### DIFF
--- a/core/sandbox/.toolkitrc.yml
+++ b/core/sandbox/.toolkitrc.yml
@@ -1,6 +1,6 @@
 plugins:
   - '@dotcom-tool-kit/frontend-app'
-  - '@dotcom-tool-kit/node'
+  - '@dotcom-tool-kit/nodemon'
   - '@dotcom-tool-kit/next-router'
   - '@dotcom-tool-kit/prettier'
   - '@dotcom-tool-kit/lint-staged-npm'
@@ -8,7 +8,7 @@ plugins:
 
 hooks:
   run:local:
-    - Node
+    - Nodemon
     - NextRouter
 
 options:

--- a/core/sandbox/package.json
+++ b/core/sandbox/package.json
@@ -17,22 +17,21 @@
     "@dotcom-tool-kit/circleci-heroku": "file:../../plugins/circleci-heroku",
     "@dotcom-tool-kit/eslint": "file:../../plugins/eslint",
     "@dotcom-tool-kit/frontend-app": "file:../../plugins/frontend-app",
+    "@dotcom-tool-kit/jest": "file:../../plugins/jest",
     "@dotcom-tool-kit/lint-staged": "file:../../plugins/lint-staged",
     "@dotcom-tool-kit/lint-staged-npm": "file:../../plugins/lint-staged-npm",
     "@dotcom-tool-kit/mocha": "file:../../plugins/mocha",
-    "@dotcom-tool-kit/jest": "file:../../plugins/jest",
     "@dotcom-tool-kit/n-test": "file:../../plugins/n-test",
+    "@dotcom-tool-kit/next-router": "file:../../plugins/next-router",
+    "@dotcom-tool-kit/nodemon": "file:../../plugins/nodemon",
     "@dotcom-tool-kit/npm": "file:../../plugins/npm",
     "@dotcom-tool-kit/prettier": "file:../../plugins/prettier",
     "@dotcom-tool-kit/upload-assets-to-s3": "file:../../plugins/upload-assets-to-s3",
-    "dotcom-tool-kit": "file:../cli"
+    "dotcom-tool-kit": "file:../cli",
+    "nodemon": "^2.0.15"
   },
   "volta": {
     "extends": "../../package.json"
-  },
-  "dependencies": {
-    "@dotcom-tool-kit/next-router": "file:../../plugins/next-router",
-    "@dotcom-tool-kit/node": "file:../../plugins/node"
   },
   "husky": {
     "hooks": {

--- a/lib/logger/src/helpers.ts
+++ b/lib/logger/src/helpers.ts
@@ -79,7 +79,12 @@ export function hookConsole(logger: Logger, processName: string): () => void {
 
 // This function hooks winston into the stdout and stderr of child processes
 // that we have spawned forked. Useful for when you need to invoke a CLI tool.
-export function hookFork(logger: Logger, process: string, child: ChildProcess, logStdErr = true): void {
+export function hookFork(
+  logger: Logger,
+  process: string,
+  child: Pick<ChildProcess, 'stdout' | 'stderr'>,
+  logStdErr = true
+): void {
   function hookStream(stream: Readable, level: string) {
     stream.setEncoding('utf8')
     stream

--- a/lib/types/src/schema.ts
+++ b/lib/types/src/schema.ts
@@ -63,6 +63,7 @@ import type { UploadAssetsToS3Options } from './schema/upload-assets-to-s3'
 import type { VaultOptions } from './schema/vault'
 import type { WebpackOptions } from './schema/webpack'
 import type { NodeOptions } from './schema/node'
+import type { NodemonOptions } from './schema/nodemon'
 import type { NextRouterOptions } from './schema/next-router'
 import type { PrettierOptions } from './schema/prettier'
 import type { LintStagedNpmOptions } from './schema/lint-staged-npm'
@@ -77,6 +78,7 @@ export type Options = {
   '@dotcom-tool-kit/vault'?: VaultOptions
   '@dotcom-tool-kit/webpack'?: WebpackOptions
   '@dotcom-tool-kit/node'?: NodeOptions
+  '@dotcom-tool-kit/nodemon'?: NodemonOptions
   '@dotcom-tool-kit/next-router'?: NextRouterOptions
   '@dotcom-tool-kit/prettier'?: PrettierOptions
   '@dotcom-tool-kit/lint-staged-npm'?: LintStagedNpmOptions

--- a/lib/types/src/schema/nodemon.ts
+++ b/lib/types/src/schema/nodemon.ts
@@ -1,7 +1,8 @@
 import { SchemaOutput } from '../schema'
 
 export const NodemonSchema = {
-  entry: 'string?'
+  entry: 'string?',
+  configPath: 'string?'
 } as const
 export type NodemonOptions = SchemaOutput<typeof NodemonSchema>
 

--- a/lib/types/src/schema/nodemon.ts
+++ b/lib/types/src/schema/nodemon.ts
@@ -1,0 +1,8 @@
+import { SchemaOutput } from '../schema'
+
+export const NodemonSchema = {
+  entry: 'string?'
+} as const
+export type NodemonOptions = SchemaOutput<typeof NodemonSchema>
+
+export const Schema = NodemonSchema

--- a/plugins/nodemon/.toolkitrc.yml
+++ b/plugins/nodemon/.toolkitrc.yml
@@ -1,0 +1,5 @@
+plugins:
+  - '@dotcom-tool-kit/vault'
+
+hooks:
+  'run:local': Nodemon

--- a/plugins/nodemon/package.json
+++ b/plugins/nodemon/package.json
@@ -1,0 +1,36 @@
+{
+  "name": "@dotcom-tool-kit/nodemon",
+  "version": "0.0.0-development",
+  "description": "",
+  "main": "lib",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "keywords": [],
+  "author": "FT.com Platforms Team <platforms-team.customer-products@ft.com>",
+  "license": "ISC",
+  "dependencies": {
+    "@dotcom-tool-kit/error": "file:../../lib/error",
+    "@dotcom-tool-kit/state": "file:../../lib/state",
+    "@dotcom-tool-kit/types": "file:../../lib/types",
+    "@dotcom-tool-kit/vault": "file:../../lib/vault",
+    "get-port": "^5.1.1"
+  },
+  "peerDependencies": {
+    "nodemon": "2.x"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/financial-times/dotcom-tool-kit.git",
+    "directory": "plugins/nodemon"
+  },
+  "bugs": "https://github.com/financial-times/dotcom-tool-kit/issues",
+  "homepage": "https://github.com/financial-times/dotcom-tool-kit/tree/main/plugins/nodemon",
+  "files": [
+    "/lib",
+    ".toolkitrc.yml"
+  ],
+  "devDependencies": {
+    "@types/nodemon": "^1.19.1"
+  }
+}

--- a/plugins/nodemon/src/index.ts
+++ b/plugins/nodemon/src/index.ts
@@ -1,0 +1,3 @@
+import Nodemon from './tasks/nodemon'
+
+export const tasks = [Nodemon]

--- a/plugins/nodemon/src/tasks/nodemon.ts
+++ b/plugins/nodemon/src/tasks/nodemon.ts
@@ -15,7 +15,7 @@ export default class Nodemon extends Task<typeof NodemonSchema> {
   }
 
   async run(): Promise<void> {
-    const { entry } = this.options
+    const { entry, configPath } = this.options
     const vault = new VaultEnvVars(this.logger, {
       environment: 'development'
     })
@@ -42,7 +42,7 @@ export default class Nodemon extends Task<typeof NodemonSchema> {
       PORT: port.toString(),
       ...process.env
     }
-    nodemon({ script: entry, env, stdout: false })
+    nodemon({ script: entry, env, stdout: false, configFile: configPath })
     nodemon.on('readable', () => {
       // These fields aren't specified in the type declaration for some reason
       const { stdout, stderr } = (nodemon as unknown) as { stdout: Readable; stderr: Readable }

--- a/plugins/nodemon/src/tasks/nodemon.ts
+++ b/plugins/nodemon/src/tasks/nodemon.ts
@@ -1,0 +1,72 @@
+import { ToolKitError } from '@dotcom-tool-kit/error'
+import { hookFork, styles } from '@dotcom-tool-kit/logger'
+import { Task } from '@dotcom-tool-kit/types'
+import { NodemonOptions, NodemonSchema } from '@dotcom-tool-kit/types/lib/schema/nodemon'
+import { VaultEnvVars } from '@dotcom-tool-kit/vault'
+import getPort from 'get-port'
+import nodemon from 'nodemon'
+import { Readable } from 'stream'
+
+export default class Nodemon extends Task<typeof NodemonSchema> {
+  static description = ''
+
+  static defaultOptions: NodemonOptions = {
+    entry: './server/app.js'
+  }
+
+  async run(): Promise<void> {
+    const { entry } = this.options
+    const vault = new VaultEnvVars(this.logger, {
+      environment: 'development'
+    })
+
+    const vaultEnv = await vault.get()
+    const port =
+      Number(process.env.PORT) ||
+      (await getPort({
+        port: [3001, 3002, 3003]
+      }))
+
+    if (!entry) {
+      const error = new ToolKitError(
+        `the ${styles.task('Nodemon')} task requires an ${styles.option('entry')} option`
+      )
+      error.details = `this is the entrypoint for your app, e.g. ${styles.filepath('server/app.js')}`
+      throw error
+    }
+
+    this.logger.verbose('starting the child nodemon process...')
+
+    const env = {
+      ...vaultEnv,
+      PORT: port.toString(),
+      ...process.env
+    }
+    nodemon({ script: entry, env, stdout: false })
+    nodemon.on('readable', () => {
+      // These fields aren't specified in the type declaration for some reason
+      const { stdout, stderr } = (nodemon as unknown) as { stdout: Readable; stderr: Readable }
+      hookFork(this.logger, entry, { stdout, stderr })
+    })
+    const nodemonLogger = this.logger.child({ process: 'nodemon' })
+    nodemon.on('log', (msg) => {
+      function nodemonToWinstonLogLevel(level: string): string {
+        switch (level) {
+          case 'log':
+            return 'debug'
+          case 'info':
+          case 'detail':
+            return 'verbose'
+          case 'fail':
+          case 'error':
+            return 'error'
+          case 'status':
+          default:
+            return 'info'
+        }
+      }
+      nodemonLogger.log(nodemonToWinstonLogLevel(msg.type), msg.message)
+    })
+    await new Promise((resolve) => nodemon.on('start', resolve))
+  }
+}

--- a/plugins/nodemon/tsconfig.json
+++ b/plugins/nodemon/tsconfig.json
@@ -1,0 +1,22 @@
+{
+  "extends": "../../tsconfig.settings.json",
+  "compilerOptions": {
+    "outDir": "lib",
+    "rootDir": "src"
+  },
+  "references": [
+    {
+      "path": "../../lib/types"
+    },
+    {
+      "path": "../../lib/error"
+    },
+    {
+      "path": "../../lib/logger"
+    },
+    {
+      "path": "../../lib/options"
+    }
+  ],
+  "include": ["src/**/*"]
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -93,6 +93,9 @@
     },
     {
       "path": "plugins/jest"
+    },
+    {
+      "path": "plugins/nodemon"
     }
   ]
 }


### PR DESCRIPTION
This plugin provides a task that can be used in place of the Node plugin and will restart the running process if there are file changes in the directory or if the process exits unexpectedly. Will respect the configuration specified in a `nodemon.json` in `$CWD`, `$HOME`, or the location specified by the `configPath` option.

I figured there was big enough difference in code to justify splitting this out into a new module rather than just being an option you could toggle in a `.toolkitrc.yml`. Splitting the plugins also means that we do not force consumers to install the `nodemon` package when they just want to install the Node plugin.