### PR TITLE
Update to Node 16 and test Node 14 in the CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,21 +8,28 @@ references:
   #
   # Workspace
   #
-  container_config_node: &container_config_node
+  container_config_node:
+    &container_config_node
     working_directory: ~/project/build
     docker:
-      - image: cimg/node:12.22
+      - image: cimg/node:<< parameters.node-version >>
+    parameters:
+      node-version:
+        default: "16.14"
+        type: string
 
   workspace_root: &workspace_root ~/project
 
-  attach_workspace: &attach_workspace
+  attach_workspace:
+    &attach_workspace
     attach_workspace:
       at: *workspace_root
 
   #
   # Cache creation
   #
-  create_cache: &create_cache
+  create_cache:
+    &create_cache
     save_cache:
       key: cache-v1-{{ .Branch }}-{{ checksum "./package.json" }}
       paths:
@@ -31,7 +38,8 @@ references:
   #
   # Cache restoration
   #
-  restore_cache: &restore_cache
+  restore_cache:
+    &restore_cache
     restore_cache:
       keys:
         - cache-v1-{{ .Branch }}-{{ checksum "./package.json" }}
@@ -39,41 +47,48 @@ references:
   #
   # Filters
   #
-  filters_only_main: &filters_only_main
+  filters_only_main:
+    &filters_only_main
     branches:
       only:
         - main
 
-  filters_only_renovate_nori: &filters_only_renovate_nori
+  filters_only_renovate_nori:
+    &filters_only_renovate_nori
     branches:
       only: /(^renovate-.*|^nori\/.*)/
 
-  filters_ignore_tags_renovate_nori_build: &filters_ignore_tags_renovate_nori_build
+  filters_ignore_tags_renovate_nori_build:
+    &filters_ignore_tags_renovate_nori_build
     tags:
       ignore: /.*/
     branches:
       ignore: /(^renovate-.*|^nori\/.*|^gh-pages)/
 
-  filters_main_branch: &filters_main_branch
+  filters_main_branch:
+    &filters_main_branch
     branches:
       only:
         - main
 
-  filters_release_build: &filters_release_build
+  filters_release_build:
+    &filters_release_build
     tags:
       only:
         - /^v\d+\.\d+\.\d+$/
     branches:
       ignore: /.*/
-  
-  filters_prerelease_build: &filters_prerelease_build
+
+  filters_prerelease_build:
+    &filters_prerelease_build
     tags:
       only:
         - /^v\d+\.\d+\.\d+(?:-\w+\.\d+)$/
     branches:
       ignore: /.*/
 
-  filters_orbs_release_build: &filters_orbs_release_build
+  filters_orbs_release_build:
+    &filters_orbs_release_build
     tags:
       only:
         # CircleCI doesn't allow prerelease versions to be published
@@ -123,28 +138,29 @@ jobs:
       - *attach_workspace
       - run:
           name: Set npm auth token
-          command: echo "//registry.npmjs.org/:_authToken=${NPM_AUTH_TOKEN}" > ${HOME}/.npmrc
+          command: echo "//registry.npmjs.org/:_authToken=${NPM_AUTH_TOKEN}" >
+            ${HOME}/.npmrc
       - run:
           name: Bump version
           command: npx athloi version ${CIRCLE_TAG}
       - run:
           name: NPM publish
           command: npx athloi publish -- --access=public
-          
+
   prepublish:
     <<: *container_config_node
     steps:
       - *attach_workspace
       - run:
           name: Set npm auth token
-          command: echo "//registry.npmjs.org/:_authToken=${NPM_AUTH_TOKEN}" > ${HOME}/.npmrc
+          command: echo "//registry.npmjs.org/:_authToken=${NPM_AUTH_TOKEN}" >
+            ${HOME}/.npmrc
       - run:
           name: Bump version
           command: npx athloi version ${CIRCLE_TAG}
       - run:
           name: NPM publish
           command: npx athloi publish -- --access=public --tag=prerelease
-
 
 workflows:
   version: 2
@@ -154,12 +170,24 @@ workflows:
       - build:
           filters:
             <<: *filters_ignore_tags_renovate_nori_build
+          name: build-v<< matrix.node-version >>
+          matrix:
+            parameters:
+              node-version: [ "16.14", "14.19" ]
       - test:
           requires:
-            - build
+            - build-v<< matrix.node-version >>
+          name: test-v<< matrix.node-version >>
+          matrix:
+            parameters:
+              node-version: [ "16.14", "14.19" ]
       - lint:
           requires:
-            - build
+            - build-v<< matrix.node-version >>
+          name: lint-v<< matrix.node-version >>
+          matrix:
+            parameters:
+              node-version: [ "16.14", "14.19" ]
 
   renovate-nori-build-test:
     jobs:
@@ -170,56 +198,100 @@ workflows:
       - build:
           requires:
             - waiting-for-approval
+          name: build-v<< matrix.node-version >>
+          matrix:
+            parameters:
+              node-version: [ "16.14", "14.19" ]
       - test:
           requires:
-            - build
+            - build-v<< matrix.node-version >>
+          name: test-v<< matrix.node-version >>
+          matrix:
+            parameters:
+              node-version: [ "16.14", "14.19" ]
       - lint:
           requires:
-            - build
+            - build-v<< matrix.node-version >>
+          name: lint-v<< matrix.node-version >>
+          matrix:
+            parameters:
+              node-version: [ "16.14", "14.19" ]
 
   build-test-publish:
     jobs:
       - build:
           filters:
             <<: *filters_release_build
+          name: build-v<< matrix.node-version >>
+          matrix:
+            parameters:
+              node-version: [ "16.14", "14.19" ]
       - test:
           filters:
             <<: *filters_release_build
           requires:
-            - build
+            - build-v<< matrix.node-version >>
+          name: test-v<< matrix.node-version >>
+          matrix:
+            parameters:
+              node-version: [ "16.14", "14.19" ]
       - lint:
           filters:
             <<: *filters_release_build
           requires:
-            - build
+            - build-v<< matrix.node-version >>
+          name: lint-v<< matrix.node-version >>
+          matrix:
+            parameters:
+              node-version: [ "16.14", "14.19" ]
       - publish:
           filters:
             <<: *filters_release_build
           requires:
-            - lint
-            - test
-  
+            - lint-v<< matrix.node-version >>
+            - test-v<< matrix.node-version >>
+          name: publish-v<< matrix.node-version >>
+          matrix:
+            parameters:
+              node-version: [ "16.14", "14.19" ]
+
   build-test-prepublish:
     jobs:
       - build:
           filters:
             <<: *filters_prerelease_build
+          name: build-v<< matrix.node-version >>
+          matrix:
+            parameters:
+              node-version: [ "16.14", "14.19" ]
       - test:
           filters:
             <<: *filters_prerelease_build
           requires:
-            - build
+            - build-v<< matrix.node-version >>
+          name: test-v<< matrix.node-version >>
+          matrix:
+            parameters:
+              node-version: [ "16.14", "14.19" ]
       - lint:
           filters:
             <<: *filters_prerelease_build
           requires:
-            - build
+            - build-v<< matrix.node-version >>
+          name: lint-v<< matrix.node-version >>
+          matrix:
+            parameters:
+              node-version: [ "16.14", "14.19" ]
       - prepublish:
           filters:
             <<: *filters_prerelease_build
           requires:
-            - lint
-            - test
+            - lint-v<< matrix.node-version >>
+            - test-v<< matrix.node-version >>
+          name: prepublish-v<< matrix.node-version >>
+          matrix:
+            parameters:
+              node-version: [ "16.14", "14.19" ]
 
   nightly:
     triggers:
@@ -230,18 +302,28 @@ workflows:
     jobs:
       - build:
           context: next-nightly-build
+          name: build-v<< matrix.node-version >>
+          matrix:
+            parameters:
+              node-version: [ "16.14", "14.19" ]
       - test:
           requires:
-            - build
+            - build-v<< matrix.node-version >>
           context: next-nightly-build
+          name: test-v<< matrix.node-version >>
+          matrix:
+            parameters:
+              node-version: [ "16.14", "14.19" ]
 
   # Prior to producing a development orb (which requires credentials) basic validation, linting, and even unit testing can be performed.
   # This workflow will run on every commit
   orb-test-pack:
     jobs:
-      - orb-tools/lint: # Lint Yaml files
+      # Lint Yaml files
+      - orb-tools/lint:
           lint-dir: orb
-      - orb-tools/pack: # Pack orb source
+      # Pack orb source
+      - orb-tools/pack:
           source-dir: orb/src
       # Publish development version(s) of the orb.
       - orb-tools/publish-dev:
@@ -252,12 +334,13 @@ workflows:
 
   orb-integration-test_deploy:
     jobs:
-      # - integration-test-1
-      - orb-tools/lint: # Lint Yaml files
+      # Lint Yaml files
+      - orb-tools/lint:
           lint-dir: orb
           filters:
             <<: *filters_orbs_release_build
-      - orb-tools/pack: # Pack orb source
+      # Pack orb source
+      - orb-tools/pack:
           source-dir: orb/src
           filters:
             <<: *filters_orbs_release_build

--- a/package.json
+++ b/package.json
@@ -54,11 +54,11 @@
     "@types/superagent": "^4.1.10"
   },
   "volta": {
-    "node": "12.22.5",
+    "node": "16.14.0",
     "npm": "7.17.0"
   },
   "engines": {
-    "node": "12.x",
+    "node": "14.x || 16.x",
     "npm": "7.x || 8.x"
   }
 }


### PR DESCRIPTION
Upgrade the repository to a newer version of Node now that Node 12 is approaching end-of-life. Seeing as Tool Kit is included in other projects we want to support both Node 16 and Node 14, as they are being used in Heroku and AWS apps respectively.