### PR TITLE
create build-test job to stop workspace persistence

### DIFF
--- a/orb/src/jobs/build-test.yml
+++ b/orb/src/jobs/build-test.yml
@@ -1,0 +1,26 @@
+# temp workaround for heroku-staging's .toolkitstate.json being overwritten by the build job
+parameters:
+  node-version:
+    default: '12.22'
+    type: string
+
+executor:
+  name: node/default
+  tag: <<parameters.node-version>>
+
+steps:
+  - attach-workspace
+  - run:
+      name: Run the project build-production task
+      command: npx dotcom-tool-kit build:ci
+  - run:
+      name: Run tests
+      command: "npx dotcom-tool-kit test:ci"
+      environment:
+        JEST_JUNIT_OUTPUT: test-results/jest/results.xml # TODO change depending on which test plugin is running? or actually, move this into the plugin? or do it as tool kit config. hmm
+        MOCHA_FILE: test-results/mocha/results.xml
+  - store_test_results:
+      path: test-results
+  - store_artifacts:
+      path: test-results
+      destination: test-results


### PR DESCRIPTION
This is a workaround to avoid the toolkit state file being overwritten. Apps can use this job in their .circleci/config.yml job rather than build and test, as used in next-static [here](https://github.com/Financial-Times/next-static/blob/4cdf82ce537f30eaa0d646d0e0fadd236acf4b5c/.circleci/config.yml#L51-L62)