### PR TITLE
increase timeout in core/cli/test/index.test.ts

### DIFF
--- a/core/cli/test/index.test.ts
+++ b/core/cli/test/index.test.ts
@@ -9,7 +9,7 @@ import winston, { Logger } from 'winston'
 const logger = (winston as unknown) as Logger
 
 // Loading all the plugins can (unfortunately) take longer than the default 2s timeout
-jest.setTimeout(15000)
+jest.setTimeout(20000)
 
 function makeRootRelative(thing: { root: string }) {
   thing.root = path.relative(process.cwd(), thing.root)


### PR DESCRIPTION
to fix [this](https://app.circleci.com/pipelines/github/Financial-Times/dotcom-tool-kit/1189/workflows/bfd0e692-fbb0-4f51-b62f-4c877e4f24d6/jobs/4259) intermittent issue 