### PR TITLE
added back test with runInBand

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "clean-up-packages": "./scripts/clean-up-packages.sh",
     "build": "tsc --build --verbose tsconfig.json",
     "watch": "tsc --build --watch --verbose tsconfig.json",
-    "test": "jest --silent",
+    "test": "jest --silent --runInBand",
     "preinstall": "[ \"$INIT_CWD\" != \"$PWD\" ] || npm_config_yes=true npx check-engine"
   },
   "lint-staged": {

--- a/plugins/circleci-npm/package.json
+++ b/plugins/circleci-npm/package.json
@@ -4,7 +4,7 @@
   "description": "",
   "main": "lib",
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "cd ../../ ; npx jest --silent --projects plugins/circleci-npm"
   },
   "keywords": [],
   "author": "FT.com Platforms Team <platforms-team.customer-products@ft.com>",

--- a/plugins/circleci-npm/test/index.test.ts
+++ b/plugins/circleci-npm/test/index.test.ts
@@ -1,0 +1,12 @@
+import { describe, it, expect } from '@jest/globals'
+import { hooks } from '../'
+
+describe('npm plugin', () => {
+  it('should define package.json hooks', () => {
+    expect(hooks).toEqual(
+      expect.objectContaining({
+        'publish:tag': expect.any(Function)
+      })
+    )
+  })
+})

--- a/plugins/npm/test/npm-publish.test.ts
+++ b/plugins/npm/test/npm-publish.test.ts
@@ -1,0 +1,71 @@
+import NpmPublish, { semVerRegex } from '../src/tasks/npm-publish'
+import winston, { Logger } from 'winston'
+import { ToolKitError } from '../../../lib/error/lib'
+import * as state from '@dotcom-tool-kit/state'
+import pacote, { ManifestResult } from 'pacote'
+import { publish } from 'libnpmpublish'
+import pack from 'libnpmpack'
+
+const logger = (winston as unknown) as Logger
+
+const readStateMock = jest.spyOn(state, 'readState');
+jest.spyOn(pacote, 'manifest').mockImplementation(() => Promise.resolve({} as ManifestResult))
+jest.spyOn(process, 'cwd').mockImplementation(() => '')
+jest.mock('libnpmpack', () => {
+    return jest.fn(() => Promise.resolve())
+})
+jest.mock('libnpmpublish', () => {
+    return {
+        publish: jest.fn(() => Promise.resolve())
+    }
+})
+
+describe('NpmPublish', () => {
+    it('should throw an error if ci is not found in state', async () => {
+        readStateMock.mockReturnValue(null)
+        
+        const task = new NpmPublish(logger)
+        await expect(async () => { await task.run() }).rejects.toThrow(new ToolKitError(
+          `Could not find state for ci, check that you are running this task on circleci`
+        ))
+    })
+
+    it('should throw error if tag is not found', async () => {
+        readStateMock.mockReturnValue({tag: '', repo: '', branch: '', version: ''})
+        
+        const task = new NpmPublish(logger)
+        await expect(async () => { await task.run() }).rejects.toThrow(new ToolKitError('CIRCLE_TAG environment variable not found. Make sure you are running this on a release version!'))
+    })
+
+    it('should return prerelease if match prerelease regex in getNpmTag', () => {
+        const task = new NpmPublish(logger)
+        expect(task.getNpmTag('v1.6.0-beta.1')).toEqual('prerelease')
+    })
+
+    it('should return latest if match latest regex in getNpmTag', () => {
+        const task = new NpmPublish(logger)
+        expect(task.getNpmTag('v1.6.0')).toEqual('latest')
+    })
+
+    it('should throw error if tag does not match semver regex', async () => {
+        readStateMock.mockReturnValue({tag: 'random-branch', repo: '', branch: '', version: ''})
+        
+        const task = new NpmPublish(logger)
+        await expect(async () => { await task.run() }).rejects.toThrow(new ToolKitError(`CIRCLE_TAG does not match regex ${semVerRegex}. Configure your release version to match the regex eg. v1.2.3-beta.8`))
+    })
+
+    it('should call listPackedFiles, pack and publish if tag matches semver regex', async () => {
+        process.env.NPM_AUTH_TOKEN = process.env.NPM_AUTH_TOKEN || 'dummy_value'
+        readStateMock.mockReturnValue({tag: 'v1.2.3-beta.2', repo: '', branch: '', version: ''})
+        const listPackedFilesSpy = jest.spyOn(NpmPublish.prototype, 'listPackedFiles')
+        listPackedFilesSpy.mockImplementation(() => Promise.resolve())
+        
+        const task = new NpmPublish(logger)
+        await task.run()
+
+        expect(listPackedFilesSpy).toBeCalled()
+        expect(pack).toBeCalled()
+        expect(publish).toBeCalled()
+    })
+})
+


### PR DESCRIPTION
--runInBand makes tests run serially according to [docs](https://jestjs.io/docs/cli#--detectopenhandles), which allows the process to have more resources and therefore prevent the tests from being starved from resources and hang