### PR TITLE
cpp-830 persist the state folder

### DIFF
--- a/orb/src/commands/persist-workspace.yml
+++ b/orb/src/commands/persist-workspace.yml
@@ -5,7 +5,7 @@ description: >
 parameters:
   path:
     type: string
-    default: .toolkitstate.json
+    default: .toolkitstate
     description: Path to persist to workspace
 
 steps:


### PR DESCRIPTION
Now that it's split out, we're going to need to persist the new state folder rather than the state file.