### PR TITLE
export publish task from npm not circleci-npm

### DIFF
--- a/core/cli/test/__snapshots__/index.test.ts.snap
+++ b/core/cli/test/__snapshots__/index.test.ts.snap
@@ -969,6 +969,7 @@ Object {
         "root": "plugins/npm/lib/index.js",
         "tasks": Array [
           [Function],
+          [Function],
         ],
       },
     },
@@ -1868,6 +1869,7 @@ Object {
         "root": "plugins/npm/lib/index.js",
         "tasks": Array [
           [Function],
+          [Function],
         ],
       },
     },
@@ -2280,6 +2282,7 @@ Object {
         },
         "root": "plugins/npm/lib/index.js",
         "tasks": Array [
+          [Function],
           [Function],
         ],
       },
@@ -3181,6 +3184,7 @@ Object {
       "root": "plugins/npm/lib/index.js",
       "tasks": Array [
         [Function],
+        [Function],
       ],
     },
     "@dotcom-tool-kit/vault": Object {
@@ -3339,6 +3343,7 @@ Object {
     "Mocha": [Function],
     "NTest": [Function],
     "NpmPrune": [Function],
+    "NpmPublish": [Function],
   },
 }
 `;

--- a/plugins/circleci-npm/src/index.ts
+++ b/plugins/circleci-npm/src/index.ts
@@ -1,7 +1,5 @@
 import CircleCiConfigHook from '@dotcom-tool-kit/circleci/lib/circleci-config'
-import NpmPublish, { semVerRegex } from '@dotcom-tool-kit/npm/lib/tasks/npm-publish'
-
-export const tasks = [NpmPublish]
+import { semVerRegex } from '@dotcom-tool-kit/npm/lib/tasks/npm-publish'
 
 class PublishHook extends CircleCiConfigHook {
   job = 'tool-kit/publish'
@@ -18,5 +16,3 @@ class PublishHook extends CircleCiConfigHook {
 export const hooks = {
   'publish:tag': PublishHook
 }
-
-

--- a/plugins/npm/src/index.ts
+++ b/plugins/npm/src/index.ts
@@ -1,5 +1,6 @@
 import { PackageJsonHook } from '@dotcom-tool-kit/package-json-hook'
 import NpmPrune from './tasks/npm-prune'
+import NpmPublish from './tasks/npm-publish'
 
 class BuildLocal extends PackageJsonHook {
   static description = 'hook for `npm run build`, for building an app locally'
@@ -30,4 +31,7 @@ export const hooks = {
   'run:local': RunLocal
 }
 
-export const tasks = [NpmPrune]
+export const tasks =
+  NpmPrune,
+  NpmPublish
+]

--- a/plugins/npm/src/index.ts
+++ b/plugins/npm/src/index.ts
@@ -31,7 +31,7 @@ export const hooks = {
   'run:local': RunLocal
 }
 
-export const tasks =
+export const tasks = [
   NpmPrune,
   NpmPublish
 ]


### PR DESCRIPTION
tasks should only be exported from the plugin they're defined in