### PR TITLE
CPP-846 Allow Node version to be configured in CircleCI hook

### DIFF
--- a/lib/types/src/schema.ts
+++ b/lib/types/src/schema.ts
@@ -68,6 +68,7 @@ import type { NextRouterOptions } from './schema/next-router'
 import type { PrettierOptions } from './schema/prettier'
 import type { LintStagedNpmOptions } from './schema/lint-staged-npm'
 import type { BabelOptions } from './schema/babel'
+import type { CircleCIOptions } from './schema/circleci'
 
 export type Options = {
   '@dotcom-tool-kit/eslint'?: ESLintOptions
@@ -83,4 +84,5 @@ export type Options = {
   '@dotcom-tool-kit/prettier'?: PrettierOptions
   '@dotcom-tool-kit/lint-staged-npm'?: LintStagedNpmOptions
   '@dotcom-tool-kit/babel'?: BabelOptions
+  '@dotcom-tool-kit/circleci'?: CircleCIOptions
 }

--- a/lib/types/src/schema/circleci.ts
+++ b/lib/types/src/schema/circleci.ts
@@ -1,0 +1,8 @@
+import { SchemaOutput } from '../schema'
+
+export const CircleCISchema = {
+  nodeVersion: 'string?'
+} as const
+export type CircleCIOptions = SchemaOutput<typeof CircleCISchema>
+
+export const Schema = CircleCISchema

--- a/plugins/circleci/src/circleci-config.ts
+++ b/plugins/circleci/src/circleci-config.ts
@@ -4,6 +4,7 @@ import isEqual from 'lodash.isequal'
 import path from 'path'
 import { ToolKitError } from '@dotcom-tool-kit/error'
 import { styles } from '@dotcom-tool-kit/logger'
+import { getOptions } from '@dotcom-tool-kit/options'
 import { Hook } from '@dotcom-tool-kit/types'
 import { Workflow, JobConfig, CircleConfig, automatedComment } from '@dotcom-tool-kit/types/lib/circleci'
 const developmentVersion = '0.0.0-development'
@@ -143,14 +144,15 @@ export default abstract class CircleCiConfigHook extends Hook {
             }
           ],
           jobs: [
-            'checkout', 
+            'checkout',
             {
               'tool-kit/setup': {
                 requires: ['checkout']
               }
-        }],
+            }
+          ]
+        }
       }
-    }
     }
 
     const currentVersion = await this.getVersionTag()
@@ -175,7 +177,12 @@ export default abstract class CircleCiConfigHook extends Hook {
       throw error
     }
 
-    const job = this.jobOptions ? { [this.job]: this.jobOptions } : this.job
+    const job = {
+      [this.job]: {
+        'node-version': getOptions('@dotcom-tool-kit/circleci')?.nodeVersion ?? '16.14-browsers',
+        ...this.jobOptions
+      }
+    }
     // Avoid duplicating jobs (this can happen when check() fails when the version is wrong)
     if (!jobs.some((candidateJob) => isEqual(candidateJob, job))) {
       jobs.push(job)

--- a/plugins/circleci/test/circleci-config.test.ts
+++ b/plugins/circleci/test/circleci-config.test.ts
@@ -61,18 +61,18 @@ describe('CircleCI config hook', () => {
               'tool-kit': {
                 jobs: expect.arrayContaining([
                   expect.objectContaining({
-                    'test-job': {
+                    'test-job': expect.objectContaining({
                       requires: ['another-job']
-                    }
+                    })
                   })
                 ])
               },
               nightly: {
                 jobs: expect.arrayContaining([
                   expect.objectContaining({
-                    'test-job': {
+                    'test-job': expect.objectContaining({
                       requires: ['another-job']
-                    }
+                    })
                   })
                 ])
               }

--- a/plugins/circleci/tsconfig.json
+++ b/plugins/circleci/tsconfig.json
@@ -12,6 +12,9 @@
     },
     {
       "path": "../../lib/types"
+    },
+    {
+      "path": "../../lib/options"
     }
   ],
   "compilerOptions": {


### PR DESCRIPTION
Now that we've migrated to newer Node versions we need to update CircleCI configs to use the correct Node version too. But seeing as both Node 14 and Node 16 should be supported we can't just hardcode one version (though that might cause upgrade issues down the road anyway!) So you can now set the Node version you want in the Tool Kit config, with the default being Node 16.