### PR TITLE
remove babel plugin from the backend-app preset

### DIFF
--- a/plugins/backend-app/.toolkitrc.yml
+++ b/plugins/backend-app/.toolkitrc.yml
@@ -1,15 +1,8 @@
 plugins:
   - '@dotcom-tool-kit/npm'
   - '@dotcom-tool-kit/circleci-heroku'
-  - '@dotcom-tool-kit/babel'
   - '@dotcom-tool-kit/node'
 
 hooks:
   'run:local':
     - Node
-  'build:local':
-    - BabelDevelopment
-  'build:ci':
-    - BabelProduction
-  'build:remote':
-    - BabelProduction

--- a/plugins/backend-app/package.json
+++ b/plugins/backend-app/package.json
@@ -7,7 +7,6 @@
   "author": "FT.com Platforms Team <platforms-team.customer-products@ft.com>",
   "license": "ISC",
   "dependencies": {
-    "@dotcom-tool-kit/babel": "file:../babel",
     "@dotcom-tool-kit/circleci-heroku": "file:../circleci-heroku",
     "@dotcom-tool-kit/npm": "file:../npm",
     "@dotcom-tool-kit/node": "file:../node"


### PR DESCRIPTION
it won't necessarily be needed, and we don't have a good workflow in place for e.g. running it before starting the server or in watch mode, so remove it and let people configure it themselves