### PR TITLE
Remove line delimeters from release-please command

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -138,14 +138,14 @@ jobs:
       - *attach_workspace
       - run:
           name: Update release-please release PR
-          command: npx release-please release-pr \
-            --token=${RELEASE_PLEASE_GITHUB_TOKEN} \
+          command: npx release-please release-pr
+            --token=${RELEASE_PLEASE_GITHUB_TOKEN}
             --repo-url=${CIRCLE_PROJECT_USERNAME}/${CIRCLE_PROJECT_REPONAME}
       - run:
           name: Release any unreleased PR merges
-          command: npx release-please github-release \
-            --token=${RELEASE_PLEASE_GITHUB_TOKEN} \
-            --repo-url=${CIRCLE_PROJECT_USERNAME}/${CIRCLE_PROJECT_REPONAME} \
+          command: npx release-please github-release
+            --token=${RELEASE_PLEASE_GITHUB_TOKEN}
+            --repo-url=${CIRCLE_PROJECT_USERNAME}/${CIRCLE_PROJECT_REPONAME}
             --monorepo-tags
 
   publish:


### PR DESCRIPTION
They were breaking release-please's ability to parse the arguments as the slashes were inadvertently being included.

_yaml_ **shakes fist**