### PR TITLE
Bump Node versions in orb

### DIFF
--- a/orb/README.md
+++ b/orb/README.md
@@ -9,7 +9,7 @@ Each job is a very simple wrapper that calls its respective hook, where most of 
 ```yaml
 parameters:
   node-version:
-    default: '12.22'
+    default: '16.14'
     type: string
 
 executor:

--- a/orb/src/@orb.yml
+++ b/orb/src/@orb.yml
@@ -11,5 +11,5 @@ display:
 
 # If your orb requires other orbs, you can import them like this. Otherwise remove the "orbs" stanza.
 orbs:
-  node: circleci/node@4.7.0
+  node: circleci/node@5.0.2
   change-api: financial-times/change-api@0.25.1

--- a/orb/src/jobs/build-test.yml
+++ b/orb/src/jobs/build-test.yml
@@ -1,7 +1,7 @@
 # temp workaround for heroku-staging's .toolkitstate.json being overwritten by the build job
 parameters:
   node-version:
-    default: '12.22'
+    default: '16.14'
     type: string
 
 executor:

--- a/orb/src/jobs/build.yml
+++ b/orb/src/jobs/build.yml
@@ -1,6 +1,6 @@
 parameters:
   node-version:
-    default: '12.22'
+    default: '16.14'
     type: string
 
 executor:

--- a/orb/src/jobs/e2e-test-review.yml
+++ b/orb/src/jobs/e2e-test-review.yml
@@ -1,6 +1,6 @@
 parameters:
   node-version:
-    default: "12.22-browsers"
+    default: "16.14-browsers"
     type: string
 
 executor:

--- a/orb/src/jobs/e2e-test-staging.yml
+++ b/orb/src/jobs/e2e-test-staging.yml
@@ -1,6 +1,6 @@
 parameters:
   node-version:
-    default: "12.22-browsers"
+    default: "16.14-browsers"
     type: string
 
 executor:

--- a/orb/src/jobs/heroku-promote.yml
+++ b/orb/src/jobs/heroku-promote.yml
@@ -1,6 +1,6 @@
 parameters:
   node-version:
-    default: "12.22"
+    default: "16.14"
     type: string
   systemCode:
     default: $CIRCLE_PROJECT_REPONAME

--- a/orb/src/jobs/heroku-provision.yml
+++ b/orb/src/jobs/heroku-provision.yml
@@ -1,6 +1,6 @@
 parameters:
   node-version:
-    default: "12.22"
+    default: "16.14"
     type: string
 
 executor:

--- a/orb/src/jobs/heroku-staging.yml
+++ b/orb/src/jobs/heroku-staging.yml
@@ -1,6 +1,6 @@
 parameters:
   node-version:
-    default: "12.22-browsers"
+    default: "16.14-browsers"
     type: string
 
 executor:

--- a/orb/src/jobs/publish.yml
+++ b/orb/src/jobs/publish.yml
@@ -1,6 +1,6 @@
 parameters:
   node-version:
-    default: '12.22'
+    default: '16.14'
     type: string
 
 executor:

--- a/orb/src/jobs/setup.yml
+++ b/orb/src/jobs/setup.yml
@@ -1,9 +1,9 @@
 parameters:
   node-version:
-    default: '12.22'
+    default: '16.14'
     type: string
   npm-version:
-    default: '7'
+    default: '8'
     type: string
 
 executor:
@@ -12,8 +12,7 @@ executor:
 
 steps:
   - attach-workspace
-  - node/install-npm:
-      version: <<parameters.npm-version>>
+  - run: sudo npm install -g npm@<<parameters.npm-version>>
   - change-api/install-jq
   - node/install-packages
   - persist-workspace:

--- a/orb/src/jobs/test.yml
+++ b/orb/src/jobs/test.yml
@@ -1,6 +1,6 @@
 parameters:
   node-version:
-    default: "12.22"
+    default: "16.14"
     type: string
 
 executor:


### PR DESCRIPTION
This includes bumping the default Node and npm versions used to Node 16 and npm 8. We also update to the latest version of the node orb and replace the removed `install-npm` job with a command to install npm ourselves.

(This is also an opportunity to bump the orb up to v2 that comes with our new semver commitments, as it wasn't included in the original commit releasing 2.0 versions of the packages because of https://github.com/googleapis/release-please/issues/1360)