### PR TITLE
Manually specify orb's component name

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -19,6 +19,7 @@
     "lib/vault": {},
     "lib/wait-for-ok": {},
     "orb": {
+      "package-name": "orb",
       "release-type": "simple"
     },
     "plugins/babel": {},


### PR DESCRIPTION
The package name is not inferred for `simple` packages (the `package.json` is read for `node` packages.) We need to specify the package name so that the correct git tag will be created when releasing.