### PR TITLE
Don't include Babel in frontend-app config

### DIFF
--- a/plugins/frontend-app/.toolkitrc.yml
+++ b/plugins/frontend-app/.toolkitrc.yml
@@ -1,14 +1,3 @@
 plugins:
   - '@dotcom-tool-kit/webpack'
   - '@dotcom-tool-kit/backend-app'
-
-hooks:
-  'build:local':
-    - WebpackDevelopment
-    - BabelDevelopment
-  'build:ci':
-    - WebpackProduction
-    - BabelProduction
-  'build:remote':
-    - WebpackProduction
-    - BabelProduction


### PR DESCRIPTION
We removed Babel from the `backend-app` plugin recently, but we defined a conflict resolution between it and the Webpack plugin for the `frontend-app` plugin which is now causing an error seeing as the Babel hooks are not present in the plugin anymore.