### PR TITLE
Use npm 8 in CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -103,7 +103,7 @@ jobs:
       - checkout
       - *restore_cache
       - node/install-npm:
-          version: '7'
+          version: '8'
       - run:
           name: Install project dependencies
           command: npm install


### PR DESCRIPTION
I've seen some [build failures](https://app.circleci.com/pipelines/github/Financial-Times/dotcom-tool-kit/1419/workflows/0848a4d4-2214-4f35-afd5-36366cc3ecd0/jobs/5999) in the CI since adding a lockfile and peer dependencies on `dotcom-tool-kit` that are fixed by using npm 8 rather than npm 7. I think this is a bug in npm's resolution logic that has now been fixed in later releases. It might be worth considering removing npm 7 from our `engines` field but seeing as it's pretty easy to get it working still (just deleting the lockfile does the trick) I think it would be better to leave it in.

Hopefully someone will make a Volta orb before I am forced to.