### PR TITLE
CPP-878 detect conflicts between cousin plugins

### DIFF
--- a/core/cli/test/files/cousins/.toolkitrc.yml
+++ b/core/cli/test/files/cousins/.toolkitrc.yml
@@ -1,0 +1,9 @@
+plugins:
+  - '../../../../../plugins/frontend-app'
+  - '../../../../../plugins/babel'
+  - '../../../../../plugins/npm'
+  - '../../../../../plugins/circleci-heroku'
+
+options:
+
+hooks:

--- a/core/cli/test/index.test.ts
+++ b/core/cli/test/index.test.ts
@@ -72,6 +72,21 @@ describe('cli', () => {
     expect(config).toHaveProperty('hookTasks.build:local.conflicting')
   })
 
+  it('should indicate when there are conflicts between plugins that are cousins in the tree', async () => {
+    const config = await loadConfig(logger, { validate: false })
+
+    await loadPluginConfig(
+      logger,
+      { id: 'conflicted test root', root: path.join(__dirname, 'files/cousins') },
+      config
+    )
+
+    expect(() => validateConfig(config)).rejects.toBeInstanceOf(ToolKitError)
+    expect(config).toHaveProperty('hookTasks.build:ci.conflicting')
+    expect(config).toHaveProperty('hookTasks.build:remote.conflicting')
+    expect(config).toHaveProperty('hookTasks.build:local.conflicting')
+  })
+
   it('should succeed when conflicts are resolved', async () => {
     const config = await loadConfig(logger, { validate: false })
 


### PR DESCRIPTION
currently, we only detect conflicts between sibling plugin hooks, e.g.:

```
├ webpack
╰ babel
```

would correctly raise a conflict, because both are assigning the `build:*` hooks by default.

if, however, the packages are not direct siblings but cousins:

```
├ frontend-app
│ ╰ webpack
╰ babel
```

that conflict wouldn't be noticed, and Tool Kit would silently choose whichever plugin was loaded last to run on that hook without requiring conflict resolution.

this PR fixes that by updating the logic to only allow a plugin to override hooks/options set by their descendants (which was always the intent).

this is a breaking change, since it could mean that apps that work completely fine now might have silently ignored conflicts that this change would error on.