### PR TITLE
Fix tasks are not valid error

### DIFF
--- a/core/create/package.json
+++ b/core/create/package.json
@@ -17,6 +17,7 @@
     "@financial-times/package-json": "^3.0.0",
     "@quarterto/parse-makefile-rules": "^1.1.0",
     "dotcom-tool-kit": "^2.1.0",
+    "import-from": "^4.0.0",
     "js-yaml": "^4.1.0",
     "komatsu": "^1.3.0",
     "lodash.partition": "^4.6.0",

--- a/core/create/src/index.ts
+++ b/core/create/src/index.ts
@@ -17,6 +17,7 @@ import prompt from 'prompts'
 import { promisify } from 'util'
 import { Logger } from './logger'
 import importFrom from 'import-from'
+import installHooksType from 'dotcom-tool-kit/lib/install'
 
 const exec = promisify(_exec)
 
@@ -141,7 +142,9 @@ async function executeMigration(deleteConfig: boolean): Promise<Config> {
 
   await logger.logPromise(exec('npm install'), 'installing dependencies')
   // we need to import installHooks from the app itself instead of npx or else loadPlugin will load rawPlugin from npx and Task will be loaded from the app, leading to task.prototype failing the instanceof Task check
-  const installHooks: any = ((await importFrom(process.cwd(), 'dotcom-tool-kit/lib/install')) as any).default
+  const installHooks = (importFrom(process.cwd(), 'dotcom-tool-kit/lib/install') as {
+    default: typeof installHooksType
+  }).default
 
   const configPromise = logger.logPromise(
     fs.writeFile(configPath, configFile),
@@ -211,8 +214,9 @@ sound alright?`
     // Clear config cache now that config has been updated
     explorer.clearSearchCache()
 
-    const installHooks: any = ((await importFrom(process.cwd(), 'dotcom-tool-kit/lib/install')) as any)
-      .default
+    const installHooks = (importFrom(process.cwd(), 'dotcom-tool-kit/lib/install') as {
+      default: typeof installHooksType
+    }).default
 
     return logger.logPromiseWait(configPromise, installHooks, 'installing Tool Kit hooks again')
   }

--- a/core/create/src/index.ts
+++ b/core/create/src/index.ts
@@ -5,7 +5,6 @@ import loadPackageJson from '@financial-times/package-json'
 import parseMakefileRules from '@quarterto/parse-makefile-rules'
 import { exec as _exec } from 'child_process'
 import { ValidConfig } from 'dotcom-tool-kit/lib/config'
-import installHooks from 'dotcom-tool-kit/lib/install'
 import { explorer, RCFile } from 'dotcom-tool-kit/lib/rc-file'
 import type { Config } from 'dotcom-tool-kit/src/config'
 import { promises as fs } from 'fs'
@@ -17,6 +16,7 @@ import path from 'path'
 import prompt from 'prompts'
 import { promisify } from 'util'
 import { Logger } from './logger'
+import importFrom from 'import-from'
 
 const exec = promisify(_exec)
 
@@ -121,7 +121,7 @@ sound good?`
   })
 }
 
-async function executeMigration(deleteConfig: boolean) {
+async function executeMigration(deleteConfig: boolean): Promise<Config> {
   for (const pkg of packagesToInstall) {
     const { version } = await pacote.manifest(pkg)
     packageJson.requireDependency({
@@ -139,7 +139,9 @@ async function executeMigration(deleteConfig: boolean) {
 
   packageJson.writeChanges()
 
-  const installPromise = logger.logPromise(exec('npm install'), 'installing dependencies')
+  await logger.logPromise(exec('npm install'), 'installing dependencies')
+  // we need to import installHooks from the app itself instead of npx or else loadPlugin will load rawPlugin from npx and Task will be loaded from the app, leading to task.prototype failing the instanceof Task check
+  const installHooks: any = ((await importFrom(process.cwd(), 'dotcom-tool-kit/lib/install')) as any).default
 
   const configPromise = logger.logPromise(
     fs.writeFile(configPath, configFile),
@@ -150,12 +152,12 @@ async function executeMigration(deleteConfig: boolean) {
     ? logger.logPromise(fs.unlink(circleConfigPath), 'removing old CircleCI config')
     : Promise.resolve()
 
-  const initialTasks = Promise.all([installPromise, configPromise, unlinkPromise]).then(() => winstonLogger)
+  const initialTasks = Promise.all([configPromise, unlinkPromise]).then(() => winstonLogger)
 
   return logger.logPromiseWait(initialTasks, installHooks, 'installing Tool Kit hooks')
 }
 
-async function handleTaskConflict(error: ToolKitConflictError) {
+async function handleTaskConflict(error: ToolKitConflictError): Promise<Config | undefined> {
   const orderedHooks: { [hook: string]: string[] } = {}
 
   for (const conflict of error.conflicts) {
@@ -208,6 +210,10 @@ sound alright?`
     )
     // Clear config cache now that config has been updated
     explorer.clearSearchCache()
+
+    const installHooks: any = ((await importFrom(process.cwd(), 'dotcom-tool-kit/lib/install')) as any)
+      .default
+
     return logger.logPromiseWait(configPromise, installHooks, 'installing Tool Kit hooks again')
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -108,6 +108,7 @@
         "@financial-times/package-json": "^3.0.0",
         "@quarterto/parse-makefile-rules": "^1.1.0",
         "dotcom-tool-kit": "^2.1.0",
+        "import-from": "^4.0.0",
         "js-yaml": "^4.1.0",
         "komatsu": "^1.3.0",
         "lodash.partition": "^4.6.0",
@@ -126,6 +127,17 @@
         "@types/node": "^12.20.24",
         "@types/pacote": "^11.1.3",
         "@types/prompts": "^2.0.14"
+      }
+    },
+    "core/create/node_modules/import-from": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/import-from/-/import-from-4.0.0.tgz",
+      "integrity": "sha512-P9J71vT5nLlDeV8FHs5nNxaLbrpfAV5cF5srvbZfpwpcJoM/xZR3hiv+q+SAnuSmuGbXMWud063iIMx/V/EWZQ==",
+      "engines": {
+        "node": ">=12.2"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "core/create/node_modules/tslib": {
@@ -20821,6 +20833,7 @@
         "@types/pacote": "^11.1.3",
         "@types/prompts": "^2.0.14",
         "dotcom-tool-kit": "^2.1.0",
+        "import-from": "^4.0.0",
         "js-yaml": "^4.1.0",
         "komatsu": "^1.3.0",
         "lodash.partition": "^4.6.0",
@@ -20830,6 +20843,11 @@
         "tslib": "^2.3.1"
       },
       "dependencies": {
+        "import-from": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/import-from/-/import-from-4.0.0.tgz",
+          "integrity": "sha512-P9J71vT5nLlDeV8FHs5nNxaLbrpfAV5cF5srvbZfpwpcJoM/xZR3hiv+q+SAnuSmuGbXMWud063iIMx/V/EWZQ=="
+        },
         "tslib": {
           "version": "2.4.0"
         }


### PR DESCRIPTION
The tasks are not valid error was introduced in commit [463124a](https://github.com/Financial-Times/dotcom-tool-kit/commit/463124add8fd89dea013dfa892a5ebebf8b5537c), where version ranges caused toolkit core/create to import installHooks from .npm node_modules instead of the app level node_modules. This caused the Task function location to be `.npm/_npx/4fc902e927bad53b/node_modules/@dotcom-tool-kit/types/lib/index.js:9` and the rawPlugin tasks prototype location to be `empty_app/node_modules/@dotcom-tool-kit/types/lib/index.js:9` thus making `instantiatePlugin` fail at the `task.prototype instanceof Task` typecheck, throwing 'tasks are not valid'. We fix this by making sure we import installHooks at the app level's node_modules.
