### PR TITLE
Bump create version

### DIFF
--- a/core/create/src/index.ts
+++ b/core/create/src/index.ts
@@ -141,7 +141,7 @@ async function executeMigration(deleteConfig: boolean): Promise<Config> {
   packageJson.writeChanges()
 
   await logger.logPromise(exec('npm install'), 'installing dependencies')
-  // we need to import installHooks from the app itself instead of npx or else loadPlugin will load rawPlugin from npx and Task will be loaded from the app, leading to task.prototype failing the instanceof Task check
+  // we need to import installHooks from the app itself instead of npx or else loadPlugin will load rawPlugin from npx and Task will be loaded from the app, leading to task.prototype failing the instanceof Task check.
   const installHooks = (importFrom(process.cwd(), 'dotcom-tool-kit/lib/install') as {
     default: typeof installHooksType
   }).default


### PR DESCRIPTION
- the current release version for core/create in main is [2.0.1](https://github.com/Financial-Times/dotcom-tool-kit/blob/main/core/create/package.json#L3), I want to bump it up to 2.0.2 
- the prerelease works 

https://user-images.githubusercontent.com/20088576/167165188-3da1d38c-59c0-4672-ba45-6e7f617c689d.mov


