### PR TITLE
Cpp-882 Fix 'There are problems with your Tool Kit configuration'

### DIFF
--- a/core/create/package.json
+++ b/core/create/package.json
@@ -17,7 +17,7 @@
     "@financial-times/package-json": "^3.0.0",
     "@quarterto/parse-makefile-rules": "^1.1.0",
     "dotcom-tool-kit": "^2.1.1",
-    "import-from": "^4.0.0",
+    "import-cwd": "^3.0.0",
     "js-yaml": "^4.1.0",
     "komatsu": "^1.3.0",
     "lodash.partition": "^4.6.0",

--- a/core/create/src/logger.ts
+++ b/core/create/src/logger.ts
@@ -1,4 +1,5 @@
-import { hasToolKitConflicts } from '@dotcom-tool-kit/error'
+import * as ToolkitErrorModule from '@dotcom-tool-kit/error'
+import importFrom from 'import-from'
 import type { Spinner } from 'komatsu'
 import Komatsu from 'komatsu'
 
@@ -58,6 +59,10 @@ export class Logger extends Komatsu {
     } catch (error) {
       const loggerError = error as LoggerError
 
+      const hasToolKitConflicts = (importFrom(
+        process.cwd(),
+        '@dotcom-tool-kit/error'
+      ) as typeof ToolkitErrorModule).hasToolKitConflicts
       // hack to suppress error when installHooks promise fails seeing as it's
       // recoverable
       if (hasToolKitConflicts(error)) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -108,7 +108,7 @@
         "@financial-times/package-json": "^3.0.0",
         "@quarterto/parse-makefile-rules": "^1.1.0",
         "dotcom-tool-kit": "^2.1.1",
-        "import-from": "^4.0.0",
+        "import-cwd": "^3.0.0",
         "js-yaml": "^4.1.0",
         "komatsu": "^1.3.0",
         "lodash.partition": "^4.6.0",
@@ -127,16 +127,6 @@
         "@types/node": "^12.20.24",
         "@types/pacote": "^11.1.3",
         "@types/prompts": "^2.0.14"
-      }
-    },
-    "core/create/node_modules/import-from": {
-      "version": "4.0.0",
-      "license": "MIT",
-      "engines": {
-        "node": ">=12.2"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "core/create/node_modules/tslib": {
@@ -9706,6 +9696,17 @@
       },
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/import-cwd": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/import-cwd/-/import-cwd-3.0.0.tgz",
+      "integrity": "sha512-4pnzH16plW+hgvRECbDWpQl3cqtvSofHWh44met7ESfZ8UZOWWddm8hEyDTqREJ9RbYHY8gi8DqmaelApoOGMg==",
+      "dependencies": {
+        "import-from": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/import-fresh": {
@@ -21384,7 +21385,7 @@
         "@types/pacote": "^11.1.3",
         "@types/prompts": "^2.0.14",
         "dotcom-tool-kit": "^2.1.1",
-        "import-from": "^4.0.0",
+        "import-cwd": "^3.0.0",
         "js-yaml": "^4.1.0",
         "komatsu": "^1.3.0",
         "lodash.partition": "^4.6.0",
@@ -21394,9 +21395,6 @@
         "tslib": "^2.3.1"
       },
       "dependencies": {
-        "import-from": {
-          "version": "4.0.0"
-        },
         "tslib": {
           "version": "2.4.0"
         }
@@ -27102,6 +27100,14 @@
             "brace-expansion": "^2.0.1"
           }
         }
+      }
+    },
+    "import-cwd": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/import-cwd/-/import-cwd-3.0.0.tgz",
+      "integrity": "sha512-4pnzH16plW+hgvRECbDWpQl3cqtvSofHWh44met7ESfZ8UZOWWddm8hEyDTqREJ9RbYHY8gi8DqmaelApoOGMg==",
+      "requires": {
+        "import-from": "^3.0.0"
       }
     },
     "import-fresh": {


### PR DESCRIPTION
This error gets thrown when running `npm init @dotcom-tool-kit` and selecting both Eslint and Mocha, without being properly handled. This PR fixes this by dynamically importing hasToolKitConflicts to stop it from failing the instanceof check.

sidenote: before merging, will squash refactor into fix commit because I want to release the refactor commit as well after merging 