### PR TITLE
CPP-843 Scale dynos before promoting them to production

### DIFF
--- a/plugins/heroku/src/tasks/production.ts
+++ b/plugins/heroku/src/tasks/production.ts
@@ -2,7 +2,7 @@ import { Task } from '@dotcom-tool-kit/types'
 import { ToolKitError } from '@dotcom-tool-kit/error'
 import { readState } from '@dotcom-tool-kit/state'
 import { styles } from '@dotcom-tool-kit/logger'
-import { HerokuSchema, HerokuOptions } from '@dotcom-tool-kit/types/lib/schema/heroku'
+import { HerokuSchema } from '@dotcom-tool-kit/types/lib/schema/heroku'
 import { scaleDyno } from '../scaleDyno'
 import { promoteStagingToProduction } from '../promoteStagingToProduction'
 
@@ -18,12 +18,7 @@ export default class HerokuProduction extends Task<typeof HerokuSchema> {
       }
       const { slugId } = state
 
-      this.logger.verbose('promoting staging to production....')
-      await promoteStagingToProduction(this.logger, slugId, this.options.systemCode)
-
-      this.logger.info('staging has been successfully promoted to production')
-
-      const { scaling } = this.options as HerokuOptions
+      const { scaling } = this.options
 
       if (!scaling) {
         const error = new ToolKitError('your heroku pipeline must have its scaling configured')
@@ -49,6 +44,11 @@ options:
         }
         this.logger.info(`${styles.app(appName)} has been successfully scaled`)
       }
+
+      this.logger.verbose('promoting staging to production....')
+      await promoteStagingToProduction(this.logger, slugId, this.options.systemCode)
+
+      this.logger.info('staging has been successfully promoted to production')
     } catch (err) {
       if (err instanceof ToolKitError) {
         throw err


### PR DESCRIPTION
When the staging app is promoted to production, the pipeline will enter a 'preboot phase' where both the old and new production apps are run in parallel and, once it is ready, requests will start being routed to the new app. This is to minimise downtime.

During the preboot phase, however, the formation cannot be changed, i.e., the app cannot be scaled to a different number of dynos. This process can take a few minutes so we can't just leave Tool Kit running waiting for it to make any scaling changes. Instead, let's scale the app before we promote the new version to production. This will mean that the old app might be scaled as well but I can't think of any reason this would be a concern.