### PR TITLE
CPP-898 Allow mocha to read config files

### DIFF
--- a/lib/types/src/schema/mocha.ts
+++ b/lib/types/src/schema/mocha.ts
@@ -1,7 +1,8 @@
 import { SchemaOutput } from '../schema'
 
 export const MochaSchema = {
-  files: 'string'
+  files: 'string',
+  configPath: 'string?'
 } as const
 export type MochaOptions = SchemaOutput<typeof MochaSchema>
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -45,7 +45,7 @@
     },
     "core/cli": {
       "name": "dotcom-tool-kit",
-      "version": "2.2.0",
+      "version": "2.2.1",
       "license": "MIT",
       "dependencies": {
         "@dotcom-tool-kit/error": "^2.0.0",
@@ -65,12 +65,12 @@
       },
       "devDependencies": {
         "@dotcom-tool-kit/babel": "^2.0.2",
-        "@dotcom-tool-kit/backend-app": "^2.0.3",
+        "@dotcom-tool-kit/backend-app": "^2.0.4",
         "@dotcom-tool-kit/circleci": "^2.1.0",
-        "@dotcom-tool-kit/circleci-heroku": "^2.0.3",
-        "@dotcom-tool-kit/eslint": "^2.1.0",
-        "@dotcom-tool-kit/frontend-app": "^2.1.1",
-        "@dotcom-tool-kit/heroku": "^2.0.2",
+        "@dotcom-tool-kit/circleci-heroku": "^2.0.4",
+        "@dotcom-tool-kit/eslint": "^2.1.1",
+        "@dotcom-tool-kit/frontend-app": "^2.1.2",
+        "@dotcom-tool-kit/heroku": "^2.0.3",
         "@dotcom-tool-kit/mocha": "^2.0.2",
         "@dotcom-tool-kit/n-test": "^2.0.2",
         "@dotcom-tool-kit/npm": "^2.0.3",
@@ -107,7 +107,7 @@
     },
     "core/create": {
       "name": "@dotcom-tool-kit/create",
-      "version": "2.0.3",
+      "version": "2.0.4",
       "license": "ISC",
       "dependencies": {
         "@dotcom-tool-kit/error": "^2.0.0",
@@ -115,7 +115,7 @@
         "@dotcom-tool-kit/types": "^2.2.0",
         "@financial-times/package-json": "^3.0.0",
         "@quarterto/parse-makefile-rules": "^1.1.0",
-        "dotcom-tool-kit": "^2.2.0",
+        "dotcom-tool-kit": "^2.2.1",
         "import-cwd": "^3.0.0",
         "js-yaml": "^4.1.0",
         "komatsu": "^1.3.0",
@@ -19322,10 +19322,10 @@
     },
     "plugins/backend-app": {
       "name": "@dotcom-tool-kit/backend-app",
-      "version": "2.0.3",
+      "version": "2.0.4",
       "license": "ISC",
       "dependencies": {
-        "@dotcom-tool-kit/circleci-heroku": "^2.0.3",
+        "@dotcom-tool-kit/circleci-heroku": "^2.0.4",
         "@dotcom-tool-kit/node": "^2.0.2",
         "@dotcom-tool-kit/npm": "^2.0.3"
       },
@@ -19358,11 +19358,11 @@
     },
     "plugins/circleci-heroku": {
       "name": "@dotcom-tool-kit/circleci-heroku",
-      "version": "2.0.3",
+      "version": "2.0.4",
       "license": "ISC",
       "dependencies": {
         "@dotcom-tool-kit/circleci": "^2.1.0",
-        "@dotcom-tool-kit/heroku": "^2.0.2"
+        "@dotcom-tool-kit/heroku": "^2.0.3"
       },
       "peerDependencies": {
         "dotcom-tool-kit": "2.x"
@@ -19383,7 +19383,7 @@
     },
     "plugins/eslint": {
       "name": "@dotcom-tool-kit/eslint",
-      "version": "2.1.0",
+      "version": "2.1.1",
       "license": "ISC",
       "dependencies": {
         "@dotcom-tool-kit/error": "^2.0.0",
@@ -19595,10 +19595,10 @@
     },
     "plugins/frontend-app": {
       "name": "@dotcom-tool-kit/frontend-app",
-      "version": "2.1.1",
+      "version": "2.1.2",
       "license": "ISC",
       "dependencies": {
-        "@dotcom-tool-kit/backend-app": "^2.0.3",
+        "@dotcom-tool-kit/backend-app": "^2.0.4",
         "@dotcom-tool-kit/webpack": "^2.1.1"
       },
       "peerDependencies": {
@@ -19607,7 +19607,7 @@
     },
     "plugins/heroku": {
       "name": "@dotcom-tool-kit/heroku",
-      "version": "2.0.2",
+      "version": "2.0.3",
       "license": "ISC",
       "dependencies": {
         "@dotcom-tool-kit/error": "^2.0.0",
@@ -21332,7 +21332,7 @@
     "@dotcom-tool-kit/backend-app": {
       "version": "file:plugins/backend-app",
       "requires": {
-        "@dotcom-tool-kit/circleci-heroku": "^2.0.3",
+        "@dotcom-tool-kit/circleci-heroku": "^2.0.4",
         "@dotcom-tool-kit/node": "^2.0.2",
         "@dotcom-tool-kit/npm": "^2.0.3"
       }
@@ -21357,7 +21357,7 @@
       "version": "file:plugins/circleci-heroku",
       "requires": {
         "@dotcom-tool-kit/circleci": "^2.1.0",
-        "@dotcom-tool-kit/heroku": "^2.0.2"
+        "@dotcom-tool-kit/heroku": "^2.0.3"
       }
     },
     "@dotcom-tool-kit/circleci-npm": {
@@ -21382,7 +21382,7 @@
         "@types/node": "^12.20.24",
         "@types/pacote": "^11.1.3",
         "@types/prompts": "^2.0.14",
-        "dotcom-tool-kit": "^2.2.0",
+        "dotcom-tool-kit": "^2.2.1",
         "import-cwd": "^3.0.0",
         "js-yaml": "^4.1.0",
         "komatsu": "^1.3.0",
@@ -21546,7 +21546,7 @@
     "@dotcom-tool-kit/frontend-app": {
       "version": "file:plugins/frontend-app",
       "requires": {
-        "@dotcom-tool-kit/backend-app": "^2.0.3",
+        "@dotcom-tool-kit/backend-app": "^2.0.4",
         "@dotcom-tool-kit/webpack": "^2.1.1"
       }
     },
@@ -25459,13 +25459,13 @@
       "version": "file:core/cli",
       "requires": {
         "@dotcom-tool-kit/babel": "^2.0.2",
-        "@dotcom-tool-kit/backend-app": "^2.0.3",
+        "@dotcom-tool-kit/backend-app": "^2.0.4",
         "@dotcom-tool-kit/circleci": "^2.1.0",
-        "@dotcom-tool-kit/circleci-heroku": "^2.0.3",
+        "@dotcom-tool-kit/circleci-heroku": "^2.0.4",
         "@dotcom-tool-kit/error": "^2.0.0",
-        "@dotcom-tool-kit/eslint": "^2.1.0",
-        "@dotcom-tool-kit/frontend-app": "^2.1.1",
-        "@dotcom-tool-kit/heroku": "^2.0.2",
+        "@dotcom-tool-kit/eslint": "^2.1.1",
+        "@dotcom-tool-kit/frontend-app": "^2.1.2",
+        "@dotcom-tool-kit/heroku": "^2.0.3",
         "@dotcom-tool-kit/logger": "^2.0.0",
         "@dotcom-tool-kit/mocha": "^2.0.2",
         "@dotcom-tool-kit/n-test": "^2.0.2",

--- a/plugins/mocha/src/tasks/mocha.ts
+++ b/plugins/mocha/src/tasks/mocha.ts
@@ -3,6 +3,7 @@ import { Task } from '@dotcom-tool-kit/types'
 import { glob } from 'glob'
 import { MochaOptions, MochaSchema } from '@dotcom-tool-kit/types/lib/schema/mocha'
 import { fork } from 'child_process'
+import { promisify } from 'util'
 const mochaCLIPath = require.resolve('mocha/bin/mocha')
 
 export default class Mocha extends Task<typeof MochaSchema> {
@@ -13,7 +14,7 @@ export default class Mocha extends Task<typeof MochaSchema> {
   }
 
   async run(): Promise<void> {
-    const files = glob.sync(this.options.files)
+    const files = await promisify(glob)(this.options.files)
 
     const args = [this.options.configPath ? `--config=${this.options.configPath}` : '', ...files]
     this.logger.info(`running mocha ${args.join(' ')}`)

--- a/plugins/mocha/src/tasks/mocha.ts
+++ b/plugins/mocha/src/tasks/mocha.ts
@@ -1,9 +1,9 @@
-import { hookConsole, styles } from '@dotcom-tool-kit/logger'
+import { hookFork, waitOnExit } from '@dotcom-tool-kit/logger'
 import { Task } from '@dotcom-tool-kit/types'
-import MochaCore from 'mocha'
 import { glob } from 'glob'
-import { ToolKitError } from '@dotcom-tool-kit/error'
 import { MochaOptions, MochaSchema } from '@dotcom-tool-kit/types/lib/schema/mocha'
+import { fork } from 'child_process'
+const mochaCLIPath = require.resolve('mocha/bin/mocha')
 
 export default class Mocha extends Task<typeof MochaSchema> {
   static description = ''
@@ -13,34 +13,12 @@ export default class Mocha extends Task<typeof MochaSchema> {
   }
 
   async run(): Promise<void> {
-    const mocha = new MochaCore()
-
     const files = glob.sync(this.options.files)
-    if (files.length === 0) {
-      const error = new ToolKitError('No test files found')
-      error.details = `We looked for files matching ${styles.filepath(
-        this.options.files
-      )}, but there weren't any. Set ${styles.title(
-        'options."@dotcom-tool-kit/mocha".files'
-      )} in your Tool Kit configuration to change this file pattern.`
-      throw error
-    }
 
-    files.forEach((file) => {
-      mocha.addFile(file)
-    })
-
-    const unhook = hookConsole(this.logger, 'mocha')
-    await new Promise<void>((resolve, reject) => {
-      mocha.run((failures) => {
-        if (failures > 0) {
-          const error = new ToolKitError('mocha tests failed')
-          error.details = 'please fix the test failures and retry'
-          reject(error)
-        } else {
-          resolve()
-        }
-      })
-    }).finally(() => unhook())
+    const args = [this.options.configPath ? `--config=${this.options.configPath}` : '', ...files]
+    this.logger.info(`running mocha ${args.join(' ')}`)
+    const child = fork(mochaCLIPath, args, { silent: true })
+    hookFork(this.logger, 'mocha', child)
+    return waitOnExit('mocha', child)
   }
 }


### PR DESCRIPTION
We want to delegate as much configuration to tools themselves rather than exposing options via Tool Kit. Unfortunately, the mocha plugin was invoking mocha with a low-level API and skipping the code which reads configuration files, meaning that users could not set options like they can with plugins such as Jest and Webpack.

To solve this let's just invoke the mocha CLI directly rather than via a lower-level API so that it calls all the setup code it would for a normal invocation, including looking for configuration files. The user can also set the path for the config file explicitly in the Tool Kit options.

The files that mocha reads can now be set in its own configuration file so we don't really need to have them be set by Tool Kit. The option to do so might be removed in a future major release of the plugin.