### PR TITLE
Allow arbitrary arguments to be set for node process in options

### DIFF
--- a/lib/types/src/schema/node.ts
+++ b/lib/types/src/schema/node.ts
@@ -1,7 +1,8 @@
 import { SchemaOutput } from '../schema'
 
 export const NodeSchema = {
-  entry: 'string?'
+  entry: 'string?',
+  args: 'array.string?'
 } as const
 export type NodeOptions = SchemaOutput<typeof NodeSchema>
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -45,7 +45,7 @@
     },
     "core/cli": {
       "name": "dotcom-tool-kit",
-      "version": "2.2.0",
+      "version": "2.2.1",
       "license": "MIT",
       "dependencies": {
         "@dotcom-tool-kit/error": "^2.0.0",
@@ -65,12 +65,12 @@
       },
       "devDependencies": {
         "@dotcom-tool-kit/babel": "^2.0.2",
-        "@dotcom-tool-kit/backend-app": "^2.0.3",
+        "@dotcom-tool-kit/backend-app": "^2.0.4",
         "@dotcom-tool-kit/circleci": "^2.1.0",
-        "@dotcom-tool-kit/circleci-heroku": "^2.0.3",
-        "@dotcom-tool-kit/eslint": "^2.1.0",
-        "@dotcom-tool-kit/frontend-app": "^2.1.1",
-        "@dotcom-tool-kit/heroku": "^2.0.2",
+        "@dotcom-tool-kit/circleci-heroku": "^2.0.4",
+        "@dotcom-tool-kit/eslint": "^2.1.1",
+        "@dotcom-tool-kit/frontend-app": "^2.1.2",
+        "@dotcom-tool-kit/heroku": "^2.0.3",
         "@dotcom-tool-kit/mocha": "^2.0.2",
         "@dotcom-tool-kit/n-test": "^2.0.2",
         "@dotcom-tool-kit/npm": "^2.0.3",
@@ -107,7 +107,7 @@
     },
     "core/create": {
       "name": "@dotcom-tool-kit/create",
-      "version": "2.0.3",
+      "version": "2.0.4",
       "license": "ISC",
       "dependencies": {
         "@dotcom-tool-kit/error": "^2.0.0",
@@ -115,7 +115,7 @@
         "@dotcom-tool-kit/types": "^2.2.0",
         "@financial-times/package-json": "^3.0.0",
         "@quarterto/parse-makefile-rules": "^1.1.0",
-        "dotcom-tool-kit": "^2.2.0",
+        "dotcom-tool-kit": "^2.2.1",
         "import-cwd": "^3.0.0",
         "js-yaml": "^4.1.0",
         "komatsu": "^1.3.0",
@@ -19322,10 +19322,10 @@
     },
     "plugins/backend-app": {
       "name": "@dotcom-tool-kit/backend-app",
-      "version": "2.0.3",
+      "version": "2.0.4",
       "license": "ISC",
       "dependencies": {
-        "@dotcom-tool-kit/circleci-heroku": "^2.0.3",
+        "@dotcom-tool-kit/circleci-heroku": "^2.0.4",
         "@dotcom-tool-kit/node": "^2.0.2",
         "@dotcom-tool-kit/npm": "^2.0.3"
       },
@@ -19358,11 +19358,11 @@
     },
     "plugins/circleci-heroku": {
       "name": "@dotcom-tool-kit/circleci-heroku",
-      "version": "2.0.3",
+      "version": "2.0.4",
       "license": "ISC",
       "dependencies": {
         "@dotcom-tool-kit/circleci": "^2.1.0",
-        "@dotcom-tool-kit/heroku": "^2.0.2"
+        "@dotcom-tool-kit/heroku": "^2.0.3"
       },
       "peerDependencies": {
         "dotcom-tool-kit": "2.x"
@@ -19383,7 +19383,7 @@
     },
     "plugins/eslint": {
       "name": "@dotcom-tool-kit/eslint",
-      "version": "2.1.0",
+      "version": "2.1.1",
       "license": "ISC",
       "dependencies": {
         "@dotcom-tool-kit/error": "^2.0.0",
@@ -19595,10 +19595,10 @@
     },
     "plugins/frontend-app": {
       "name": "@dotcom-tool-kit/frontend-app",
-      "version": "2.1.1",
+      "version": "2.1.2",
       "license": "ISC",
       "dependencies": {
-        "@dotcom-tool-kit/backend-app": "^2.0.3",
+        "@dotcom-tool-kit/backend-app": "^2.0.4",
         "@dotcom-tool-kit/webpack": "^2.1.1"
       },
       "peerDependencies": {
@@ -19607,7 +19607,7 @@
     },
     "plugins/heroku": {
       "name": "@dotcom-tool-kit/heroku",
-      "version": "2.0.2",
+      "version": "2.0.3",
       "license": "ISC",
       "dependencies": {
         "@dotcom-tool-kit/error": "^2.0.0",
@@ -21332,7 +21332,7 @@
     "@dotcom-tool-kit/backend-app": {
       "version": "file:plugins/backend-app",
       "requires": {
-        "@dotcom-tool-kit/circleci-heroku": "^2.0.3",
+        "@dotcom-tool-kit/circleci-heroku": "^2.0.4",
         "@dotcom-tool-kit/node": "^2.0.2",
         "@dotcom-tool-kit/npm": "^2.0.3"
       }
@@ -21357,7 +21357,7 @@
       "version": "file:plugins/circleci-heroku",
       "requires": {
         "@dotcom-tool-kit/circleci": "^2.1.0",
-        "@dotcom-tool-kit/heroku": "^2.0.2"
+        "@dotcom-tool-kit/heroku": "^2.0.3"
       }
     },
     "@dotcom-tool-kit/circleci-npm": {
@@ -21382,7 +21382,7 @@
         "@types/node": "^12.20.24",
         "@types/pacote": "^11.1.3",
         "@types/prompts": "^2.0.14",
-        "dotcom-tool-kit": "^2.2.0",
+        "dotcom-tool-kit": "^2.2.1",
         "import-cwd": "^3.0.0",
         "js-yaml": "^4.1.0",
         "komatsu": "^1.3.0",
@@ -21546,7 +21546,7 @@
     "@dotcom-tool-kit/frontend-app": {
       "version": "file:plugins/frontend-app",
       "requires": {
-        "@dotcom-tool-kit/backend-app": "^2.0.3",
+        "@dotcom-tool-kit/backend-app": "^2.0.4",
         "@dotcom-tool-kit/webpack": "^2.1.1"
       }
     },
@@ -25459,13 +25459,13 @@
       "version": "file:core/cli",
       "requires": {
         "@dotcom-tool-kit/babel": "^2.0.2",
-        "@dotcom-tool-kit/backend-app": "^2.0.3",
+        "@dotcom-tool-kit/backend-app": "^2.0.4",
         "@dotcom-tool-kit/circleci": "^2.1.0",
-        "@dotcom-tool-kit/circleci-heroku": "^2.0.3",
+        "@dotcom-tool-kit/circleci-heroku": "^2.0.4",
         "@dotcom-tool-kit/error": "^2.0.0",
-        "@dotcom-tool-kit/eslint": "^2.1.0",
-        "@dotcom-tool-kit/frontend-app": "^2.1.1",
-        "@dotcom-tool-kit/heroku": "^2.0.2",
+        "@dotcom-tool-kit/eslint": "^2.1.1",
+        "@dotcom-tool-kit/frontend-app": "^2.1.2",
+        "@dotcom-tool-kit/heroku": "^2.0.3",
         "@dotcom-tool-kit/logger": "^2.0.0",
         "@dotcom-tool-kit/mocha": "^2.0.2",
         "@dotcom-tool-kit/n-test": "^2.0.2",

--- a/plugins/node/src/tasks/node.ts
+++ b/plugins/node/src/tasks/node.ts
@@ -16,7 +16,7 @@ export default class Node extends Task<typeof NodeSchema> {
   }
 
   async run(): Promise<void> {
-    const { entry } = this.options
+    const { entry, args } = this.options
     const vault = new VaultEnvVars(this.logger, {
       environment: 'development'
     })
@@ -37,7 +37,7 @@ export default class Node extends Task<typeof NodeSchema> {
     }
 
     this.logger.verbose('starting the child node process...')
-    const child = fork(entry, {
+    const child = fork(entry, args, {
       env: {
         ...vaultEnv,
         PORT: port.toString(),


### PR DESCRIPTION
These could be either options for node like `--inspect` or arguments for the Node process you're starting. There's not a simpler way to do this seeing as there are no generalised configuration files applicable (unlike for `nodemon`.)