### PR TITLE
Write chosen port for nodemon too

### DIFF
--- a/plugins/nodemon/src/tasks/nodemon.ts
+++ b/plugins/nodemon/src/tasks/nodemon.ts
@@ -2,6 +2,7 @@ import { ToolKitError } from '@dotcom-tool-kit/error'
 import { hookFork, styles } from '@dotcom-tool-kit/logger'
 import { Task } from '@dotcom-tool-kit/types'
 import { NodemonOptions, NodemonSchema } from '@dotcom-tool-kit/types/lib/schema/nodemon'
+import { writeState } from '@dotcom-tool-kit/state'
 import { VaultEnvVars } from '@dotcom-tool-kit/vault'
 import getPort from 'get-port'
 import nodemon from 'nodemon'
@@ -68,5 +69,6 @@ export default class Nodemon extends Task<typeof NodemonSchema> {
       nodemonLogger.log(nodemonToWinstonLogLevel(msg.type), msg.message)
     })
     await new Promise((resolve) => nodemon.on('start', resolve))
+    writeState('local', { port })
   }
 }

--- a/plugins/nodemon/tsconfig.json
+++ b/plugins/nodemon/tsconfig.json
@@ -16,6 +16,9 @@
     },
     {
       "path": "../../lib/options"
+    },
+    {
+      "path": "../../lib/state"
     }
   ],
   "include": ["src/**/*"]


### PR DESCRIPTION
The `node` plugin writes the port it chooses to the `.toolkitstate` which the `next-router` plugin can then read from and register with the `next-router` server. nodemon was missing the same behaviour so let's copy it over.