### PR TITLE
CPP-915 Allow Pa11y to use config defined in .pa11yci

### DIFF
--- a/lib/types/src/schema/pa11y.ts
+++ b/lib/types/src/schema/pa11y.ts
@@ -1,13 +1,7 @@
 import { SchemaOutput } from '../schema'
 
 export const Pa11ySchema = {
-  host: 'string?',
-  wait: 'number?',
-  tests: 'array.string?',
-  exceptions: 'array.string?',
-  hide: 'array.string?',
-  viewports: 'array.string?',
-  screenCapturePath: 'string?'
+  configFile: 'string?'
 } as const
 export type Pa11yOptions = SchemaOutput<typeof Pa11ySchema>
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -45,13 +45,13 @@
     },
     "core/cli": {
       "name": "dotcom-tool-kit",
-      "version": "2.2.1",
+      "version": "2.2.2",
       "license": "MIT",
       "dependencies": {
         "@dotcom-tool-kit/error": "^2.0.0",
         "@dotcom-tool-kit/logger": "^2.0.0",
-        "@dotcom-tool-kit/options": "^2.0.2",
-        "@dotcom-tool-kit/types": "^2.2.0",
+        "@dotcom-tool-kit/options": "^2.0.3",
+        "@dotcom-tool-kit/types": "^2.3.0",
         "@dotcom-tool-kit/wait-for-ok": "^2.0.0",
         "cosmiconfig": "^7.0.0",
         "lodash.merge": "^4.6.2",
@@ -64,17 +64,17 @@
         "dotcom-tool-kit": "bin/run"
       },
       "devDependencies": {
-        "@dotcom-tool-kit/babel": "^2.0.2",
-        "@dotcom-tool-kit/backend-app": "^2.0.4",
-        "@dotcom-tool-kit/circleci": "^2.1.0",
-        "@dotcom-tool-kit/circleci-heroku": "^2.0.4",
-        "@dotcom-tool-kit/eslint": "^2.1.1",
-        "@dotcom-tool-kit/frontend-app": "^2.1.2",
-        "@dotcom-tool-kit/heroku": "^2.0.3",
-        "@dotcom-tool-kit/mocha": "^2.0.2",
-        "@dotcom-tool-kit/n-test": "^2.0.2",
-        "@dotcom-tool-kit/npm": "^2.0.3",
-        "@dotcom-tool-kit/webpack": "^2.1.1",
+        "@dotcom-tool-kit/babel": "^2.0.3",
+        "@dotcom-tool-kit/backend-app": "^2.0.5",
+        "@dotcom-tool-kit/circleci": "^2.1.1",
+        "@dotcom-tool-kit/circleci-heroku": "^2.0.5",
+        "@dotcom-tool-kit/eslint": "^2.1.2",
+        "@dotcom-tool-kit/frontend-app": "^2.1.3",
+        "@dotcom-tool-kit/heroku": "^2.0.4",
+        "@dotcom-tool-kit/mocha": "^2.1.0",
+        "@dotcom-tool-kit/n-test": "^2.0.3",
+        "@dotcom-tool-kit/npm": "^2.0.4",
+        "@dotcom-tool-kit/webpack": "^2.1.2",
         "@jest/globals": "^27.4.6",
         "@types/lodash.merge": "^4.6.6",
         "@types/node": "^12.20.24",
@@ -107,15 +107,15 @@
     },
     "core/create": {
       "name": "@dotcom-tool-kit/create",
-      "version": "2.0.4",
+      "version": "2.0.5",
       "license": "ISC",
       "dependencies": {
         "@dotcom-tool-kit/error": "^2.0.0",
         "@dotcom-tool-kit/logger": "^2.0.0",
-        "@dotcom-tool-kit/types": "^2.2.0",
+        "@dotcom-tool-kit/types": "^2.3.0",
         "@financial-times/package-json": "^3.0.0",
         "@quarterto/parse-makefile-rules": "^1.1.0",
-        "dotcom-tool-kit": "^2.2.1",
+        "dotcom-tool-kit": "^2.2.2",
         "import-cwd": "^3.0.0",
         "js-yaml": "^4.1.0",
         "komatsu": "^1.3.0",
@@ -189,10 +189,10 @@
     },
     "lib/options": {
       "name": "@dotcom-tool-kit/options",
-      "version": "2.0.2",
+      "version": "2.0.3",
       "license": "ISC",
       "dependencies": {
-        "@dotcom-tool-kit/types": "^2.2.0"
+        "@dotcom-tool-kit/types": "^2.3.0"
       }
     },
     "lib/package-json-hook": {
@@ -214,7 +214,7 @@
     },
     "lib/types": {
       "name": "@dotcom-tool-kit/types",
-      "version": "2.2.0",
+      "version": "2.3.0",
       "license": "ISC",
       "dependencies": {
         "@dotcom-tool-kit/error": "^2.0.0",
@@ -234,12 +234,12 @@
     },
     "lib/vault": {
       "name": "@dotcom-tool-kit/vault",
-      "version": "2.0.2",
+      "version": "2.0.3",
       "license": "ISC",
       "dependencies": {
         "@dotcom-tool-kit/error": "^2.0.0",
-        "@dotcom-tool-kit/options": "^2.0.2",
-        "@dotcom-tool-kit/types": "^2.2.0",
+        "@dotcom-tool-kit/options": "^2.0.3",
+        "@dotcom-tool-kit/types": "^2.3.0",
         "@financial-times/n-fetch": "^1.0.0-beta.7",
         "fs": "0.0.1-security",
         "os": "^0.1.2",
@@ -4243,7 +4243,8 @@
     },
     "node_modules/@types/yauzl": {
       "version": "2.10.0",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/@types/yauzl/-/yauzl-2.10.0.tgz",
+      "integrity": "sha512-Cn6WYCm0tXv8p6k+A8PvbDG763EDpBoTzHdA+Q/MF6H3sapGjCm9NzoaJncJS9tUKSuCoDs9XHxYYsQDgxR6kw==",
       "optional": true,
       "dependencies": {
         "@types/node": "*"
@@ -4960,6 +4961,14 @@
         "node": ">=8"
       }
     },
+    "node_modules/array-uniq": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/array-uniq/-/array-uniq-1.0.3.tgz",
+      "integrity": "sha512-MNha4BWQ6JbwhFhj03YK552f7cb3AzoE8SzeljgChvL1dl3IcvggXVz1DilzySZkCja+CXuZbdW7yATchWn8/Q==",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/array-unique": {
       "version": "0.3.2",
       "license": "MIT",
@@ -5184,10 +5193,11 @@
       "license": "MIT"
     },
     "node_modules/axe-core": {
-      "version": "4.2.4",
-      "license": "MPL-2.0",
+      "version": "4.4.2",
+      "resolved": "https://registry.npmjs.org/axe-core/-/axe-core-4.4.2.tgz",
+      "integrity": "sha512-LVAaGp/wkkgYJcjmHsoKx4juT1aQvJyPcW09MLCjVTh3V2cc6PnyempiLMNH5iMdfIX/zdbjUx2KDjMLCTdPeA==",
       "engines": {
-        "node": ">=4"
+        "node": ">=12"
       }
     },
     "node_modules/babel-jest": {
@@ -5419,7 +5429,8 @@
     },
     "node_modules/bfj": {
       "version": "7.0.2",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/bfj/-/bfj-7.0.2.tgz",
+      "integrity": "sha512-+e/UqUzwmzJamNF50tBV6tZPTORow7gQ96iFow+8b562OdMpEK0BcJEq2OSPEDmAbSMBQ7PKZ87ubFkgxpYWgw==",
       "dependencies": {
         "bluebird": "^3.5.5",
         "check-types": "^11.1.1",
@@ -5493,7 +5504,6 @@
     },
     "node_modules/boolbase": {
       "version": "1.0.0",
-      "dev": true,
       "license": "ISC"
     },
     "node_modules/boxen": {
@@ -5971,7 +5981,172 @@
     },
     "node_modules/check-types": {
       "version": "11.1.2",
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/check-types/-/check-types-11.1.2.tgz",
+      "integrity": "sha512-tzWzvgePgLORb9/3a0YenggReLKAIb2owL03H2Xdoe5pKcUyWRSEQ8xfCar8t2SIAuEDwtmx2da1YB52YuHQMQ=="
+    },
+    "node_modules/cheerio": {
+      "version": "1.0.0-rc.12",
+      "resolved": "https://registry.npmjs.org/cheerio/-/cheerio-1.0.0-rc.12.tgz",
+      "integrity": "sha512-VqR8m68vM46BNnuZ5NtnGBKIE/DfN0cRIzg9n40EIq9NOv90ayxLBXA8fXC5gquFRGJSTRqBq25Jt2ECLR431Q==",
+      "dependencies": {
+        "cheerio-select": "^2.1.0",
+        "dom-serializer": "^2.0.0",
+        "domhandler": "^5.0.3",
+        "domutils": "^3.0.1",
+        "htmlparser2": "^8.0.1",
+        "parse5": "^7.0.0",
+        "parse5-htmlparser2-tree-adapter": "^7.0.0"
+      },
+      "engines": {
+        "node": ">= 6"
+      },
+      "funding": {
+        "url": "https://github.com/cheeriojs/cheerio?sponsor=1"
+      }
+    },
+    "node_modules/cheerio-select": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/cheerio-select/-/cheerio-select-2.1.0.tgz",
+      "integrity": "sha512-9v9kG0LvzrlcungtnJtpGNxY+fzECQKhK4EGJX2vByejiMX84MFNQw4UxPJl3bFbTMw+Dfs37XaIkCwTZfLh4g==",
+      "dependencies": {
+        "boolbase": "^1.0.0",
+        "css-select": "^5.1.0",
+        "css-what": "^6.1.0",
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.3",
+        "domutils": "^3.0.1"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/fb55"
+      }
+    },
+    "node_modules/cheerio-select/node_modules/css-select": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/css-select/-/css-select-5.1.0.tgz",
+      "integrity": "sha512-nwoRF1rvRRnnCqqY7updORDsuqKzqYJ28+oSMaJMMgOauh3fvwHqMS7EZpIPqK8GL+g9mKxF1vP/ZjSeNjEVHg==",
+      "dependencies": {
+        "boolbase": "^1.0.0",
+        "css-what": "^6.1.0",
+        "domhandler": "^5.0.2",
+        "domutils": "^3.0.1",
+        "nth-check": "^2.0.1"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/fb55"
+      }
+    },
+    "node_modules/cheerio-select/node_modules/dom-serializer": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-2.0.0.tgz",
+      "integrity": "sha512-wIkAryiqt/nV5EQKqQpo3SToSOV9J0DnbJqwK7Wv/Trc92zIAYZ4FlMu+JPFW1DfGFt81ZTCGgDEabffXeLyJg==",
+      "dependencies": {
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.2",
+        "entities": "^4.2.0"
+      },
+      "funding": {
+        "url": "https://github.com/cheeriojs/dom-serializer?sponsor=1"
+      }
+    },
+    "node_modules/cheerio-select/node_modules/domhandler": {
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-5.0.3.tgz",
+      "integrity": "sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w==",
+      "dependencies": {
+        "domelementtype": "^2.3.0"
+      },
+      "engines": {
+        "node": ">= 4"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/domhandler?sponsor=1"
+      }
+    },
+    "node_modules/cheerio-select/node_modules/domutils": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/domutils/-/domutils-3.0.1.tgz",
+      "integrity": "sha512-z08c1l761iKhDFtfXO04C7kTdPBLi41zwOZl00WS8b5eiaebNpY00HKbztwBq+e3vyqWNwWF3mP9YLUeqIrF+Q==",
+      "dependencies": {
+        "dom-serializer": "^2.0.0",
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.1"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/domutils?sponsor=1"
+      }
+    },
+    "node_modules/cheerio-select/node_modules/entities": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-4.3.0.tgz",
+      "integrity": "sha512-/iP1rZrSEJ0DTlPiX+jbzlA3eVkY/e8L8SozroF395fIqE3TYF/Nz7YOMAawta+vLmyJ/hkGNNPcSbMADCCXbg==",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
+    "node_modules/cheerio/node_modules/dom-serializer": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-2.0.0.tgz",
+      "integrity": "sha512-wIkAryiqt/nV5EQKqQpo3SToSOV9J0DnbJqwK7Wv/Trc92zIAYZ4FlMu+JPFW1DfGFt81ZTCGgDEabffXeLyJg==",
+      "dependencies": {
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.2",
+        "entities": "^4.2.0"
+      },
+      "funding": {
+        "url": "https://github.com/cheeriojs/dom-serializer?sponsor=1"
+      }
+    },
+    "node_modules/cheerio/node_modules/domhandler": {
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-5.0.3.tgz",
+      "integrity": "sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w==",
+      "dependencies": {
+        "domelementtype": "^2.3.0"
+      },
+      "engines": {
+        "node": ">= 4"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/domhandler?sponsor=1"
+      }
+    },
+    "node_modules/cheerio/node_modules/domutils": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/domutils/-/domutils-3.0.1.tgz",
+      "integrity": "sha512-z08c1l761iKhDFtfXO04C7kTdPBLi41zwOZl00WS8b5eiaebNpY00HKbztwBq+e3vyqWNwWF3mP9YLUeqIrF+Q==",
+      "dependencies": {
+        "dom-serializer": "^2.0.0",
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.1"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/domutils?sponsor=1"
+      }
+    },
+    "node_modules/cheerio/node_modules/entities": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-4.3.0.tgz",
+      "integrity": "sha512-/iP1rZrSEJ0DTlPiX+jbzlA3eVkY/e8L8SozroF395fIqE3TYF/Nz7YOMAawta+vLmyJ/hkGNNPcSbMADCCXbg==",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
+    "node_modules/cheerio/node_modules/parse5": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-7.0.0.tgz",
+      "integrity": "sha512-y/t8IXSPWTuRZqXc0ajH/UwDj4mnqLEbSttNbThcFhGrZuOyoyvNBO85PBp2jQa55wY9d07PBNjsK8ZP3K5U6g==",
+      "dependencies": {
+        "entities": "^4.3.0"
+      },
+      "funding": {
+        "url": "https://github.com/inikulin/parse5?sponsor=1"
+      }
     },
     "node_modules/chokidar": {
       "version": "3.5.3",
@@ -6286,7 +6461,6 @@
     },
     "node_modules/commander": {
       "version": "6.2.1",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 6"
@@ -6850,7 +7024,6 @@
     },
     "node_modules/css-what": {
       "version": "6.1.0",
-      "dev": true,
       "license": "BSD-2-Clause",
       "engines": {
         "node": ">= 6"
@@ -7118,7 +7291,8 @@
     },
     "node_modules/devtools-protocol": {
       "version": "0.0.869402",
-      "license": "BSD-3-Clause"
+      "resolved": "https://registry.npmjs.org/devtools-protocol/-/devtools-protocol-0.0.869402.tgz",
+      "integrity": "sha512-VvlVYY+VDJe639yHs5PHISzdWTLL3Aw8rO4cvUtwvoxFd6FHbE4OpHHcde52M6096uYYazAmd4l0o5VuFRO2WA=="
     },
     "node_modules/diff": {
       "version": "5.0.0",
@@ -7196,7 +7370,6 @@
     },
     "node_modules/domelementtype": {
       "version": "2.3.0",
-      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -8501,6 +8674,14 @@
       "license": "MIT",
       "optional": true
     },
+    "node_modules/file-url": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/file-url/-/file-url-3.0.0.tgz",
+      "integrity": "sha512-g872QGsHexznxkIAdK8UiZRe7SkE6kvylShU4Nsj8NvfvZag7S0QuQ4IgvPDkk75HxgjIVDwycFTDAgIiO4nDA==",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/fill-range": {
       "version": "7.0.1",
       "license": "MIT",
@@ -9469,6 +9650,41 @@
         "minimalistic-crypto-utils": "^1.0.1"
       }
     },
+    "node_modules/hogan.js": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/hogan.js/-/hogan.js-3.0.2.tgz",
+      "integrity": "sha512-RqGs4wavGYJWE07t35JQccByczmNUXQT0E12ZYV1VKYu5UiAU9lsos/yBAcf840+zrUQQxgVduCR5/B8nNtibg==",
+      "dependencies": {
+        "mkdirp": "0.3.0",
+        "nopt": "1.0.10"
+      },
+      "bin": {
+        "hulk": "bin/hulk"
+      }
+    },
+    "node_modules/hogan.js/node_modules/mkdirp": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.3.0.tgz",
+      "integrity": "sha512-OHsdUcVAQ6pOtg5JYWpCBo9W/GySVuwvP9hueRMW7UqshC0tbfzLv8wjySTPm3tfUZ/21CE9E1pJagOA91Pxew==",
+      "deprecated": "Legacy versions of mkdirp are no longer supported. Please update to mkdirp 1.x. (Note that the API surface has changed to use Promises in 1.x.)",
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/hogan.js/node_modules/nopt": {
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/nopt/-/nopt-1.0.10.tgz",
+      "integrity": "sha512-NWmpvLSqUrgrAC9HCuxEvb+PSloHpqVu+FqcO4eeF2h5qYRhA7ev6KvelyQAKtegUbC6RypJnlEOhd8vloNKYg==",
+      "dependencies": {
+        "abbrev": "1"
+      },
+      "bin": {
+        "nopt": "bin/nopt.js"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
     "node_modules/hook-std": {
       "version": "2.0.0",
       "license": "MIT",
@@ -9478,7 +9694,8 @@
     },
     "node_modules/hoopy": {
       "version": "0.1.4",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/hoopy/-/hoopy-0.1.4.tgz",
+      "integrity": "sha512-HRcs+2mr52W0K+x8RzcLzuPPmVIKMSv97RGHy0Ea9y/mpcaK+xTrjICA04KAHi4GRzxliNqNJEFYWHghy3rSfQ==",
       "engines": {
         "node": ">= 6.0.0"
       }
@@ -9509,7 +9726,8 @@
     },
     "node_modules/html_codesniffer": {
       "version": "2.5.1",
-      "license": "BSD-3-Clause",
+      "resolved": "https://registry.npmjs.org/html_codesniffer/-/html_codesniffer-2.5.1.tgz",
+      "integrity": "sha512-vcz0yAaX/OaV6sdNHuT9alBOKkSxYb8h5Yq26dUqgi7XmCgGUSa7U9PiY1PBXQFMjKv1wVPs5/QzHlGuxPDUGg==",
       "engines": {
         "node": ">=6"
       }
@@ -9527,6 +9745,75 @@
     "node_modules/html-escaper": {
       "version": "2.0.2",
       "license": "MIT"
+    },
+    "node_modules/htmlparser2": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-8.0.1.tgz",
+      "integrity": "sha512-4lVbmc1diZC7GUJQtRQ5yBAeUCL1exyMwmForWkRLnwyzWBFxN633SALPMGYaWZvKe9j1pRZJpauvmxENSp/EA==",
+      "funding": [
+        "https://github.com/fb55/htmlparser2?sponsor=1",
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fb55"
+        }
+      ],
+      "dependencies": {
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.2",
+        "domutils": "^3.0.1",
+        "entities": "^4.3.0"
+      }
+    },
+    "node_modules/htmlparser2/node_modules/dom-serializer": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-2.0.0.tgz",
+      "integrity": "sha512-wIkAryiqt/nV5EQKqQpo3SToSOV9J0DnbJqwK7Wv/Trc92zIAYZ4FlMu+JPFW1DfGFt81ZTCGgDEabffXeLyJg==",
+      "dependencies": {
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.2",
+        "entities": "^4.2.0"
+      },
+      "funding": {
+        "url": "https://github.com/cheeriojs/dom-serializer?sponsor=1"
+      }
+    },
+    "node_modules/htmlparser2/node_modules/domhandler": {
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-5.0.3.tgz",
+      "integrity": "sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w==",
+      "dependencies": {
+        "domelementtype": "^2.3.0"
+      },
+      "engines": {
+        "node": ">= 4"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/domhandler?sponsor=1"
+      }
+    },
+    "node_modules/htmlparser2/node_modules/domutils": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/domutils/-/domutils-3.0.1.tgz",
+      "integrity": "sha512-z08c1l761iKhDFtfXO04C7kTdPBLi41zwOZl00WS8b5eiaebNpY00HKbztwBq+e3vyqWNwWF3mP9YLUeqIrF+Q==",
+      "dependencies": {
+        "dom-serializer": "^2.0.0",
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.1"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/domutils?sponsor=1"
+      }
+    },
+    "node_modules/htmlparser2/node_modules/entities": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-4.3.0.tgz",
+      "integrity": "sha512-/iP1rZrSEJ0DTlPiX+jbzlA3eVkY/e8L8SozroF395fIqE3TYF/Nz7YOMAawta+vLmyJ/hkGNNPcSbMADCCXbg==",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
     },
     "node_modules/http-cache-semantics": {
       "version": "4.1.0",
@@ -9929,7 +10216,8 @@
     },
     "node_modules/is": {
       "version": "3.3.0",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/is/-/is-3.3.0.tgz",
+      "integrity": "sha512-nW24QBoPcFGGHJGUwnfpI7Yc5CdqWNdsyHQszVE/z2pKHXzh7FZ5GWhJqSyaQ9wMkQnsTx+kAI8bHlCX4tKdbg==",
       "engines": {
         "node": "*"
       }
@@ -12543,7 +12831,8 @@
     },
     "node_modules/mkdirp-classic": {
       "version": "0.5.3",
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/mkdirp-classic/-/mkdirp-classic-0.5.3.tgz",
+      "integrity": "sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A=="
     },
     "node_modules/mocha": {
       "version": "8.4.0",
@@ -12832,13 +13121,6 @@
     "node_modules/ms": {
       "version": "2.1.2",
       "license": "MIT"
-    },
-    "node_modules/mustache": {
-      "version": "4.2.0",
-      "license": "MIT",
-      "bin": {
-        "mustache": "bin/mustache"
-      }
     },
     "node_modules/mute-stream": {
       "version": "0.0.8",
@@ -13180,7 +13462,8 @@
     },
     "node_modules/node.extend": {
       "version": "2.0.2",
-      "license": "(MIT OR GPL-2.0)",
+      "resolved": "https://registry.npmjs.org/node.extend/-/node.extend-2.0.2.tgz",
+      "integrity": "sha512-pDT4Dchl94/+kkgdwyS2PauDFjZG0Hk0IcHIB+LkW27HLDtdoeMxHTxZh39DYbPP8UflWXWj9JcdDozF+YDOpQ==",
       "dependencies": {
         "has": "^1.0.3",
         "is": "^3.2.1"
@@ -13702,7 +13985,6 @@
     },
     "node_modules/nth-check": {
       "version": "2.0.1",
-      "dev": true,
       "license": "BSD-2-Clause",
       "dependencies": {
         "boolbase": "^1.0.0"
@@ -14014,16 +14296,17 @@
       }
     },
     "node_modules/pa11y": {
-      "version": "6.2.3",
-      "license": "LGPL-3.0-only",
+      "version": "6.1.1",
+      "resolved": "https://registry.npmjs.org/pa11y/-/pa11y-6.1.1.tgz",
+      "integrity": "sha512-2NzqA3D9CUlDWj8WuOI4fM2P0qM1d/IUxsRRpzCOfDT5eMR1oEgmUwW2TAk+f90ff/GVck0BewdYT4et4BANew==",
       "dependencies": {
-        "axe-core": "~4.2.1",
+        "axe-core": "^4.0.2",
         "bfj": "~7.0.2",
         "commander": "~8.0.0",
         "envinfo": "~7.8.1",
-        "html_codesniffer": "~2.5.1",
+        "hogan.js": "^3.0.2",
+        "html_codesniffer": "^2.5.1",
         "kleur": "~4.1.4",
-        "mustache": "~4.2.0",
         "node.extend": "~2.0.2",
         "p-timeout": "~4.1.0",
         "puppeteer": "~9.1.1",
@@ -14036,16 +14319,208 @@
         "node": ">=12"
       }
     },
+    "node_modules/pa11y-ci": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/pa11y-ci/-/pa11y-ci-3.0.1.tgz",
+      "integrity": "sha512-DUtEIhEG3Ofds7qRuplq0DdCb9doILRlzcRctFNzo4QUNmVy4iZfM3u51A9cqoPo2irCJZoo5BzfiFrcriY2IQ==",
+      "dependencies": {
+        "async": "~2.6.3",
+        "cheerio": "~1.0.0-rc.10",
+        "commander": "~6.2.1",
+        "globby": "~6.1.0",
+        "kleur": "~4.1.4",
+        "lodash": "~4.17.21",
+        "node-fetch": "~2.6.1",
+        "pa11y": "~6.1.0",
+        "protocolify": "~3.0.0",
+        "puppeteer": "~9.1.1",
+        "wordwrap": "~1.0.0"
+      },
+      "bin": {
+        "pa11y-ci": "bin/pa11y-ci.js"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/pa11y-ci/node_modules/array-union": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/array-union/-/array-union-1.0.2.tgz",
+      "integrity": "sha512-Dxr6QJj/RdU/hCaBjOfxW+q6lyuVE6JFWIrAUpuOOhoJJoQ99cUn3igRaHVB5P9WrgFVN0FfArM3x0cueOU8ng==",
+      "dependencies": {
+        "array-uniq": "^1.0.1"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/pa11y-ci/node_modules/async": {
+      "version": "2.6.4",
+      "resolved": "https://registry.npmjs.org/async/-/async-2.6.4.tgz",
+      "integrity": "sha512-mzo5dfJYwAn29PeiJ0zvwTo04zj8HDJj0Mn8TD7sno7q12prdbnasKJHhkm2c1LgrhlJ0teaea8860oxi51mGA==",
+      "dependencies": {
+        "lodash": "^4.17.14"
+      }
+    },
+    "node_modules/pa11y-ci/node_modules/extract-zip": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/extract-zip/-/extract-zip-2.0.1.tgz",
+      "integrity": "sha512-GDhU9ntwuKyGXdZBUgTIe+vXnWj0fppUEtMDL0+idd5Sta8TGpHssn/eusA9mrPr9qNDym6SxAYZjNvCn/9RBg==",
+      "dependencies": {
+        "debug": "^4.1.1",
+        "get-stream": "^5.1.0",
+        "yauzl": "^2.10.0"
+      },
+      "bin": {
+        "extract-zip": "cli.js"
+      },
+      "engines": {
+        "node": ">= 10.17.0"
+      },
+      "optionalDependencies": {
+        "@types/yauzl": "^2.9.1"
+      }
+    },
+    "node_modules/pa11y-ci/node_modules/find-up": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
+      "integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
+      "dependencies": {
+        "locate-path": "^5.0.0",
+        "path-exists": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/pa11y-ci/node_modules/get-stream": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-5.2.0.tgz",
+      "integrity": "sha512-nBF+F1rAZVCu/p7rjzgA+Yb4lfYXrpl7a6VmJrU8wF9I1CKvP/QwPNZHnOlwbTkY6dvtFIzFMSyQXbLoTQPRpA==",
+      "dependencies": {
+        "pump": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/pa11y-ci/node_modules/globby": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/globby/-/globby-6.1.0.tgz",
+      "integrity": "sha512-KVbFv2TQtbzCoxAnfD6JcHZTYCzyliEaaeM/gH8qQdkKr5s0OP9scEgvdcngyk7AVdY6YVW/TJHd+lQ/Df3Daw==",
+      "dependencies": {
+        "array-union": "^1.0.1",
+        "glob": "^7.0.3",
+        "object-assign": "^4.0.1",
+        "pify": "^2.0.0",
+        "pinkie-promise": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/pa11y-ci/node_modules/kleur": {
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/kleur/-/kleur-4.1.5.tgz",
+      "integrity": "sha512-o+NO+8WrRiQEE4/7nwRJhN1HWpVmJm511pBHUxPLtp0BUISzlBplORYSmTclCnJvQq2tKu/sgl3xVpkc7ZWuQQ==",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/pa11y-ci/node_modules/locate-path": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
+      "integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
+      "dependencies": {
+        "p-locate": "^4.1.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/pa11y-ci/node_modules/p-limit": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
+      "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
+      "dependencies": {
+        "p-try": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/pa11y-ci/node_modules/p-locate": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
+      "integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
+      "dependencies": {
+        "p-limit": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/pa11y-ci/node_modules/pify": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
+      "integrity": "sha512-udgsAY+fTnvv7kI7aaxbqwWNb0AHiB0qBO89PZKPkoTmGOgdbrHDKD+0B2X4uTfJ/FT1R09r9gTsjUjNJotuog==",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/pa11y-ci/node_modules/pkg-dir": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-4.2.0.tgz",
+      "integrity": "sha512-HRDzbaKjC+AOWVXxAU/x54COGeIv9eb+6CkDSQoNTt4XyWoIJvuPsXizxu/Fr23EiekbtZwmh1IcIG/l/a10GQ==",
+      "dependencies": {
+        "find-up": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/pa11y-ci/node_modules/puppeteer": {
+      "version": "9.1.1",
+      "resolved": "https://registry.npmjs.org/puppeteer/-/puppeteer-9.1.1.tgz",
+      "integrity": "sha512-W+nOulP2tYd/ZG99WuZC/I5ljjQQ7EUw/jQGcIb9eu8mDlZxNY2SgcJXTLG9h5gRvqA3uJOe4hZXYsd3EqioMw==",
+      "deprecated": "Version no longer supported. Upgrade to @latest",
+      "hasInstallScript": true,
+      "dependencies": {
+        "debug": "^4.1.0",
+        "devtools-protocol": "0.0.869402",
+        "extract-zip": "^2.0.0",
+        "https-proxy-agent": "^5.0.0",
+        "node-fetch": "^2.6.1",
+        "pkg-dir": "^4.2.0",
+        "progress": "^2.0.1",
+        "proxy-from-env": "^1.1.0",
+        "rimraf": "^3.0.2",
+        "tar-fs": "^2.0.0",
+        "unbzip2-stream": "^1.3.3",
+        "ws": "^7.2.3"
+      },
+      "engines": {
+        "node": ">=10.18.1"
+      }
+    },
     "node_modules/pa11y/node_modules/commander": {
       "version": "8.0.0",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-8.0.0.tgz",
+      "integrity": "sha512-Xvf85aAtu6v22+E5hfVoLHqyul/jyxh91zvqk/ioJTQuJR7Z78n7H558vMPKanPSRgIEeZemT92I2g9Y8LPbSQ==",
       "engines": {
         "node": ">= 12"
       }
     },
     "node_modules/pa11y/node_modules/extract-zip": {
       "version": "2.0.1",
-      "license": "BSD-2-Clause",
+      "resolved": "https://registry.npmjs.org/extract-zip/-/extract-zip-2.0.1.tgz",
+      "integrity": "sha512-GDhU9ntwuKyGXdZBUgTIe+vXnWj0fppUEtMDL0+idd5Sta8TGpHssn/eusA9mrPr9qNDym6SxAYZjNvCn/9RBg==",
       "dependencies": {
         "debug": "^4.1.1",
         "get-stream": "^5.1.0",
@@ -14063,7 +14538,8 @@
     },
     "node_modules/pa11y/node_modules/find-up": {
       "version": "4.1.0",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
+      "integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
       "dependencies": {
         "locate-path": "^5.0.0",
         "path-exists": "^4.0.0"
@@ -14074,7 +14550,8 @@
     },
     "node_modules/pa11y/node_modules/get-stream": {
       "version": "5.2.0",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-5.2.0.tgz",
+      "integrity": "sha512-nBF+F1rAZVCu/p7rjzgA+Yb4lfYXrpl7a6VmJrU8wF9I1CKvP/QwPNZHnOlwbTkY6dvtFIzFMSyQXbLoTQPRpA==",
       "dependencies": {
         "pump": "^3.0.0"
       },
@@ -14086,15 +14563,17 @@
       }
     },
     "node_modules/pa11y/node_modules/kleur": {
-      "version": "4.1.4",
-      "license": "MIT",
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/kleur/-/kleur-4.1.5.tgz",
+      "integrity": "sha512-o+NO+8WrRiQEE4/7nwRJhN1HWpVmJm511pBHUxPLtp0BUISzlBplORYSmTclCnJvQq2tKu/sgl3xVpkc7ZWuQQ==",
       "engines": {
         "node": ">=6"
       }
     },
     "node_modules/pa11y/node_modules/locate-path": {
       "version": "5.0.0",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
+      "integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
       "dependencies": {
         "p-locate": "^4.1.0"
       },
@@ -14104,7 +14583,8 @@
     },
     "node_modules/pa11y/node_modules/p-limit": {
       "version": "2.3.0",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
+      "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
       "dependencies": {
         "p-try": "^2.0.0"
       },
@@ -14117,7 +14597,8 @@
     },
     "node_modules/pa11y/node_modules/p-locate": {
       "version": "4.1.0",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
+      "integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
       "dependencies": {
         "p-limit": "^2.2.0"
       },
@@ -14127,14 +14608,16 @@
     },
     "node_modules/pa11y/node_modules/p-timeout": {
       "version": "4.1.0",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/p-timeout/-/p-timeout-4.1.0.tgz",
+      "integrity": "sha512-+/wmHtzJuWii1sXn3HCuH/FTwGhrp4tmJTxSKJbfS+vkipci6osxXM5mY0jUiRzWKMTgUT8l7HFbeSwZAynqHw==",
       "engines": {
         "node": ">=10"
       }
     },
     "node_modules/pa11y/node_modules/pkg-dir": {
       "version": "4.2.0",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-4.2.0.tgz",
+      "integrity": "sha512-HRDzbaKjC+AOWVXxAU/x54COGeIv9eb+6CkDSQoNTt4XyWoIJvuPsXizxu/Fr23EiekbtZwmh1IcIG/l/a10GQ==",
       "dependencies": {
         "find-up": "^4.0.0"
       },
@@ -14144,8 +14627,10 @@
     },
     "node_modules/pa11y/node_modules/puppeteer": {
       "version": "9.1.1",
+      "resolved": "https://registry.npmjs.org/puppeteer/-/puppeteer-9.1.1.tgz",
+      "integrity": "sha512-W+nOulP2tYd/ZG99WuZC/I5ljjQQ7EUw/jQGcIb9eu8mDlZxNY2SgcJXTLG9h5gRvqA3uJOe4hZXYsd3EqioMw==",
+      "deprecated": "Version no longer supported. Upgrade to @latest",
       "hasInstallScript": true,
-      "license": "Apache-2.0",
       "dependencies": {
         "debug": "^4.1.0",
         "devtools-protocol": "0.0.869402",
@@ -14608,6 +15093,54 @@
       "version": "6.0.1",
       "license": "MIT"
     },
+    "node_modules/parse5-htmlparser2-tree-adapter": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/parse5-htmlparser2-tree-adapter/-/parse5-htmlparser2-tree-adapter-7.0.0.tgz",
+      "integrity": "sha512-B77tOZrqqfUfnVcOrUvfdLbz4pu4RopLD/4vmu3HUPswwTA8OH0EMW9BlWR2B0RCoiZRAHEUu7IxeP1Pd1UU+g==",
+      "dependencies": {
+        "domhandler": "^5.0.2",
+        "parse5": "^7.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/inikulin/parse5?sponsor=1"
+      }
+    },
+    "node_modules/parse5-htmlparser2-tree-adapter/node_modules/domhandler": {
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-5.0.3.tgz",
+      "integrity": "sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w==",
+      "dependencies": {
+        "domelementtype": "^2.3.0"
+      },
+      "engines": {
+        "node": ">= 4"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/domhandler?sponsor=1"
+      }
+    },
+    "node_modules/parse5-htmlparser2-tree-adapter/node_modules/entities": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-4.3.0.tgz",
+      "integrity": "sha512-/iP1rZrSEJ0DTlPiX+jbzlA3eVkY/e8L8SozroF395fIqE3TYF/Nz7YOMAawta+vLmyJ/hkGNNPcSbMADCCXbg==",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
+    "node_modules/parse5-htmlparser2-tree-adapter/node_modules/parse5": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-7.0.0.tgz",
+      "integrity": "sha512-y/t8IXSPWTuRZqXc0ajH/UwDj4mnqLEbSttNbThcFhGrZuOyoyvNBO85PBp2jQa55wY9d07PBNjsK8ZP3K5U6g==",
+      "dependencies": {
+        "entities": "^4.3.0"
+      },
+      "funding": {
+        "url": "https://github.com/inikulin/parse5?sponsor=1"
+      }
+    },
     "node_modules/parseurl": {
       "version": "1.3.3",
       "license": "MIT",
@@ -14720,6 +15253,25 @@
       "license": "MIT",
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/pinkie": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz",
+      "integrity": "sha512-MnUuEycAemtSaeFSjXKW/aroV7akBbY+Sv+RkyqFjgAe73F+MR0TBWKBRDkmfWq/HiFmdavfZ1G7h4SPZXaCSg==",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/pinkie-promise": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
+      "integrity": "sha512-0Gni6D4UcLTbv9c57DfxDGdr41XfgUjqWZu492f0cIGr16zDU06BWP/RAEvOuo7CQ0CNjHaLlM59YJJFm3NWlw==",
+      "dependencies": {
+        "pinkie": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/pirates": {
@@ -14883,6 +15435,26 @@
       },
       "engines": {
         "node": ">= 6"
+      }
+    },
+    "node_modules/protocolify": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/protocolify/-/protocolify-3.0.0.tgz",
+      "integrity": "sha512-PuvDJOkKJMVQx8jSNf8E5g0bJw/UTKm30mTjFHg4N30c8sefgA5Qr/f8INKqYBKfvP/MUSJrj+z1Smjbq4/3rQ==",
+      "dependencies": {
+        "file-url": "^3.0.0",
+        "prepend-http": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/protocolify/node_modules/prepend-http": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/prepend-http/-/prepend-http-3.0.1.tgz",
+      "integrity": "sha512-BLxfZh+m6UiAiCPZFJ4+vYoL7NrRs5XgCTRrjseATAggXhdZKKxn+JUNmuVYWY23bDHgaEHodxw8mnmtVEDtHw==",
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/proxy-from-env": {
@@ -16986,7 +17558,8 @@
     },
     "node_modules/tar-fs": {
       "version": "2.1.1",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-2.1.1.tgz",
+      "integrity": "sha512-V0r2Y9scmbDRLCNex/+hYzvp/zyYjvFbHPNgVTKfQvVrb6guiE/fxP+XblDNR011utopbkex2nM4dHNV6GDsng==",
       "dependencies": {
         "chownr": "^1.1.1",
         "mkdirp-classic": "^0.5.2",
@@ -16996,7 +17569,8 @@
     },
     "node_modules/tar-fs/node_modules/chownr": {
       "version": "1.1.4",
-      "license": "ISC"
+      "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.4.tgz",
+      "integrity": "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg=="
     },
     "node_modules/tar-stream": {
       "version": "2.2.0",
@@ -17495,7 +18069,8 @@
     },
     "node_modules/tryer": {
       "version": "1.0.1",
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/tryer/-/tryer-1.0.1.tgz",
+      "integrity": "sha512-c3zayb8/kWWpycWYg87P71E1S1ZL6b6IJxfb5fvsUgsf0S2MVGaDhDXXjDMpdCpfWXqptc+4mXwmiy1ypXqRAA=="
     },
     "node_modules/ts-jest": {
       "version": "27.1.4",
@@ -17715,7 +18290,8 @@
     },
     "node_modules/unbzip2-stream": {
       "version": "1.4.3",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/unbzip2-stream/-/unbzip2-stream-1.4.3.tgz",
+      "integrity": "sha512-mlExGW4w71ebDJviH16lQLtZS32VKqsSfk80GCfUlwT/4/hNRFsoscrF/c++9xinkMzECL1uL9DDwXqFWkruPg==",
       "dependencies": {
         "buffer": "^5.2.1",
         "through": "^2.3.8"
@@ -17723,6 +18299,8 @@
     },
     "node_modules/unbzip2-stream/node_modules/buffer": {
       "version": "5.7.1",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
+      "integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
       "funding": [
         {
           "type": "github",
@@ -17737,7 +18315,6 @@
           "url": "https://feross.org/support"
         }
       ],
-      "license": "MIT",
       "dependencies": {
         "base64-js": "^1.3.1",
         "ieee754": "^1.1.13"
@@ -18999,7 +19576,6 @@
     },
     "node_modules/wordwrap": {
       "version": "1.0.0",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/worker-farm": {
@@ -19312,12 +19888,12 @@
     },
     "plugins/babel": {
       "name": "@dotcom-tool-kit/babel",
-      "version": "2.0.2",
+      "version": "2.0.3",
       "license": "MIT",
       "dependencies": {
         "@dotcom-tool-kit/error": "^2.0.0",
         "@dotcom-tool-kit/logger": "^2.0.0",
-        "@dotcom-tool-kit/types": "^2.2.0",
+        "@dotcom-tool-kit/types": "^2.3.0",
         "fast-glob": "^3.2.11"
       },
       "devDependencies": {
@@ -19332,12 +19908,12 @@
     },
     "plugins/backend-app": {
       "name": "@dotcom-tool-kit/backend-app",
-      "version": "2.0.4",
+      "version": "2.0.5",
       "license": "ISC",
       "dependencies": {
-        "@dotcom-tool-kit/circleci-heroku": "^2.0.4",
-        "@dotcom-tool-kit/node": "^2.0.2",
-        "@dotcom-tool-kit/npm": "^2.0.3"
+        "@dotcom-tool-kit/circleci-heroku": "^2.0.5",
+        "@dotcom-tool-kit/node": "^2.1.0",
+        "@dotcom-tool-kit/npm": "^2.0.4"
       },
       "peerDependencies": {
         "dotcom-tool-kit": "2.x"
@@ -19345,13 +19921,13 @@
     },
     "plugins/circleci": {
       "name": "@dotcom-tool-kit/circleci",
-      "version": "2.1.0",
+      "version": "2.1.1",
       "license": "ISC",
       "dependencies": {
         "@dotcom-tool-kit/error": "^2.0.0",
         "@dotcom-tool-kit/logger": "^2.0.0",
         "@dotcom-tool-kit/state": "^2.0.0",
-        "@dotcom-tool-kit/types": "^2.2.0",
+        "@dotcom-tool-kit/types": "^2.3.0",
         "js-yaml": "^4.1.0",
         "lodash.isequal": "^4.5.0"
       },
@@ -19368,11 +19944,11 @@
     },
     "plugins/circleci-heroku": {
       "name": "@dotcom-tool-kit/circleci-heroku",
-      "version": "2.0.4",
+      "version": "2.0.5",
       "license": "ISC",
       "dependencies": {
-        "@dotcom-tool-kit/circleci": "^2.1.0",
-        "@dotcom-tool-kit/heroku": "^2.0.3"
+        "@dotcom-tool-kit/circleci": "^2.1.1",
+        "@dotcom-tool-kit/heroku": "^2.0.4"
       },
       "peerDependencies": {
         "dotcom-tool-kit": "2.x"
@@ -19380,12 +19956,12 @@
     },
     "plugins/circleci-npm": {
       "name": "@dotcom-tool-kit/circleci-npm",
-      "version": "2.0.3",
+      "version": "2.0.4",
       "license": "ISC",
       "dependencies": {
-        "@dotcom-tool-kit/circleci": "^2.1.0",
-        "@dotcom-tool-kit/npm": "^2.0.3",
-        "@dotcom-tool-kit/types": "^2.2.0"
+        "@dotcom-tool-kit/circleci": "^2.1.1",
+        "@dotcom-tool-kit/npm": "^2.0.4",
+        "@dotcom-tool-kit/types": "^2.3.0"
       },
       "peerDependencies": {
         "dotcom-tool-kit": "2.x"
@@ -19393,12 +19969,12 @@
     },
     "plugins/eslint": {
       "name": "@dotcom-tool-kit/eslint",
-      "version": "2.1.1",
+      "version": "2.1.2",
       "license": "ISC",
       "dependencies": {
         "@dotcom-tool-kit/error": "^2.0.0",
         "@dotcom-tool-kit/logger": "^2.0.0",
-        "@dotcom-tool-kit/types": "^2.2.0"
+        "@dotcom-tool-kit/types": "^2.3.0"
       },
       "devDependencies": {
         "@jest/globals": "^27.4.6",
@@ -19605,11 +20181,11 @@
     },
     "plugins/frontend-app": {
       "name": "@dotcom-tool-kit/frontend-app",
-      "version": "2.1.2",
+      "version": "2.1.3",
       "license": "ISC",
       "dependencies": {
-        "@dotcom-tool-kit/backend-app": "^2.0.4",
-        "@dotcom-tool-kit/webpack": "^2.1.1"
+        "@dotcom-tool-kit/backend-app": "^2.0.5",
+        "@dotcom-tool-kit/webpack": "^2.1.2"
       },
       "peerDependencies": {
         "dotcom-tool-kit": "2.x"
@@ -19617,16 +20193,16 @@
     },
     "plugins/heroku": {
       "name": "@dotcom-tool-kit/heroku",
-      "version": "2.0.3",
+      "version": "2.0.4",
       "license": "ISC",
       "dependencies": {
         "@dotcom-tool-kit/error": "^2.0.0",
         "@dotcom-tool-kit/logger": "^2.0.0",
-        "@dotcom-tool-kit/npm": "^2.0.3",
+        "@dotcom-tool-kit/npm": "^2.0.4",
         "@dotcom-tool-kit/package-json-hook": "^2.1.0",
         "@dotcom-tool-kit/state": "^2.0.0",
-        "@dotcom-tool-kit/types": "^2.2.0",
-        "@dotcom-tool-kit/vault": "^2.0.2",
+        "@dotcom-tool-kit/types": "^2.3.0",
+        "@dotcom-tool-kit/vault": "^2.0.3",
         "@dotcom-tool-kit/wait-for-ok": "^2.0.0",
         "@octokit/request": "^5.6.0",
         "@octokit/request-error": "^2.1.0",
@@ -19658,11 +20234,11 @@
     },
     "plugins/jest": {
       "name": "@dotcom-tool-kit/jest",
-      "version": "2.0.2",
+      "version": "2.0.3",
       "license": "ISC",
       "dependencies": {
         "@dotcom-tool-kit/logger": "^2.0.0",
-        "@dotcom-tool-kit/types": "^2.2.0"
+        "@dotcom-tool-kit/types": "^2.3.0"
       },
       "devDependencies": {
         "@jest/globals": "^27.4.6",
@@ -19675,12 +20251,12 @@
     },
     "plugins/lint-staged": {
       "name": "@dotcom-tool-kit/lint-staged",
-      "version": "2.1.2",
+      "version": "2.1.3",
       "license": "ISC",
       "dependencies": {
         "@dotcom-tool-kit/logger": "^2.0.0",
         "@dotcom-tool-kit/package-json-hook": "^2.1.0",
-        "@dotcom-tool-kit/types": "^2.2.0",
+        "@dotcom-tool-kit/types": "^2.3.0",
         "lint-staged": "^11.2.3"
       },
       "peerDependencies": {
@@ -19689,12 +20265,12 @@
     },
     "plugins/lint-staged-npm": {
       "name": "@dotcom-tool-kit/lint-staged-npm",
-      "version": "2.0.3",
+      "version": "2.0.4",
       "license": "ISC",
       "dependencies": {
         "@dotcom-tool-kit/husky-npm": "^2.1.0",
-        "@dotcom-tool-kit/lint-staged": "^2.1.2",
-        "@dotcom-tool-kit/options": "^2.0.2"
+        "@dotcom-tool-kit/lint-staged": "^2.1.3",
+        "@dotcom-tool-kit/options": "^2.0.3"
       },
       "peerDependencies": {
         "dotcom-tool-kit": "2.x"
@@ -19752,12 +20328,12 @@
     },
     "plugins/mocha": {
       "name": "@dotcom-tool-kit/mocha",
-      "version": "2.0.2",
+      "version": "2.1.0",
       "license": "ISC",
       "dependencies": {
         "@dotcom-tool-kit/error": "^2.0.0",
         "@dotcom-tool-kit/logger": "^2.0.0",
-        "@dotcom-tool-kit/types": "^2.2.0",
+        "@dotcom-tool-kit/types": "^2.3.0",
         "fs": "0.0.1-security",
         "glob": "^7.1.7",
         "mocha": "^8.3.2"
@@ -19774,12 +20350,12 @@
     },
     "plugins/n-test": {
       "name": "@dotcom-tool-kit/n-test",
-      "version": "2.0.2",
+      "version": "2.0.3",
       "license": "ISC",
       "dependencies": {
         "@dotcom-tool-kit/logger": "^2.0.0",
         "@dotcom-tool-kit/state": "^2.0.0",
-        "@dotcom-tool-kit/types": "^2.2.0",
+        "@dotcom-tool-kit/types": "^2.3.0",
         "@financial-times/n-test": "^3.0.1"
       },
       "devDependencies": {
@@ -19793,14 +20369,14 @@
     },
     "plugins/next-router": {
       "name": "@dotcom-tool-kit/next-router",
-      "version": "2.0.2",
+      "version": "2.0.3",
       "license": "ISC",
       "dependencies": {
         "@dotcom-tool-kit/error": "^2.0.0",
         "@dotcom-tool-kit/logger": "^2.0.0",
         "@dotcom-tool-kit/state": "^2.0.0",
-        "@dotcom-tool-kit/types": "^2.2.0",
-        "@dotcom-tool-kit/vault": "^2.0.2",
+        "@dotcom-tool-kit/types": "^2.3.0",
+        "@dotcom-tool-kit/vault": "^2.0.3",
         "ft-next-router": "^1.0.0"
       },
       "peerDependencies": {
@@ -19809,13 +20385,13 @@
     },
     "plugins/node": {
       "name": "@dotcom-tool-kit/node",
-      "version": "2.0.2",
+      "version": "2.1.0",
       "license": "ISC",
       "dependencies": {
         "@dotcom-tool-kit/error": "^2.0.0",
         "@dotcom-tool-kit/state": "^2.0.0",
-        "@dotcom-tool-kit/types": "^2.2.0",
-        "@dotcom-tool-kit/vault": "^2.0.2",
+        "@dotcom-tool-kit/types": "^2.3.0",
+        "@dotcom-tool-kit/vault": "^2.0.3",
         "get-port": "^5.1.1",
         "wait-port": "^0.2.9"
       },
@@ -19825,13 +20401,13 @@
     },
     "plugins/nodemon": {
       "name": "@dotcom-tool-kit/nodemon",
-      "version": "2.0.2",
+      "version": "2.0.3",
       "license": "ISC",
       "dependencies": {
         "@dotcom-tool-kit/error": "^2.0.0",
         "@dotcom-tool-kit/state": "^2.0.0",
-        "@dotcom-tool-kit/types": "^2.2.0",
-        "@dotcom-tool-kit/vault": "^2.0.2",
+        "@dotcom-tool-kit/types": "^2.3.0",
+        "@dotcom-tool-kit/vault": "^2.0.3",
         "get-port": "^5.1.1"
       },
       "devDependencies": {
@@ -19844,14 +20420,14 @@
     },
     "plugins/npm": {
       "name": "@dotcom-tool-kit/npm",
-      "version": "2.0.3",
+      "version": "2.0.4",
       "license": "ISC",
       "dependencies": {
         "@actions/exec": "^1.1.0",
         "@dotcom-tool-kit/error": "^2.0.0",
         "@dotcom-tool-kit/package-json-hook": "^2.1.0",
         "@dotcom-tool-kit/state": "^2.0.0",
-        "@dotcom-tool-kit/types": "^2.2.0",
+        "@dotcom-tool-kit/types": "^2.3.0",
         "libnpmpack": "^3.1.0",
         "libnpmpublish": "^5.0.1",
         "pacote": "^12.0.3",
@@ -20002,11 +20578,11 @@
     },
     "plugins/pa11y": {
       "name": "@dotcom-tool-kit/pa11y",
-      "version": "0.1.1",
+      "version": "0.1.3",
       "license": "ISC",
       "dependencies": {
-        "@dotcom-tool-kit/types": "^2.2.0",
-        "pa11y": "^6.2.3"
+        "@dotcom-tool-kit/types": "^2.3.0",
+        "pa11y-ci": "^3.0.1"
       },
       "devDependencies": {
         "@types/pa11y": "^5.3.4"
@@ -20017,13 +20593,13 @@
     },
     "plugins/prettier": {
       "name": "@dotcom-tool-kit/prettier",
-      "version": "2.0.3",
+      "version": "2.0.4",
       "license": "ISC",
       "dependencies": {
         "@dotcom-tool-kit/error": "^2.0.0",
         "@dotcom-tool-kit/logger": "^2.0.0",
         "@dotcom-tool-kit/package-json-hook": "^2.1.0",
-        "@dotcom-tool-kit/types": "^2.2.0",
+        "@dotcom-tool-kit/types": "^2.3.0",
         "fast-glob": "^3.2.7",
         "hook-std": "^2.0.0",
         "prettier": "^2.2.1"
@@ -20040,11 +20616,11 @@
     },
     "plugins/secret-squirrel": {
       "name": "@dotcom-tool-kit/secret-squirrel",
-      "version": "1.0.1",
+      "version": "1.0.2",
       "license": "ISC",
       "dependencies": {
         "@dotcom-tool-kit/logger": "^2.0.0",
-        "@dotcom-tool-kit/types": "^2.2.0"
+        "@dotcom-tool-kit/types": "^2.3.0"
       },
       "peerDependencies": {
         "@financial-times/secret-squirrel": "2.x",
@@ -20053,12 +20629,12 @@
     },
     "plugins/upload-assets-to-s3": {
       "name": "@dotcom-tool-kit/upload-assets-to-s3",
-      "version": "2.0.2",
+      "version": "2.0.3",
       "license": "ISC",
       "dependencies": {
         "@dotcom-tool-kit/error": "^2.0.0",
         "@dotcom-tool-kit/logger": "^2.0.0",
-        "@dotcom-tool-kit/types": "^2.2.0",
+        "@dotcom-tool-kit/types": "^2.3.0",
         "aws-sdk": "^2.901.0",
         "glob": "^7.1.6",
         "mime": "^2.5.2"
@@ -20077,12 +20653,12 @@
     },
     "plugins/webpack": {
       "name": "@dotcom-tool-kit/webpack",
-      "version": "2.1.1",
+      "version": "2.1.2",
       "license": "MIT",
       "dependencies": {
         "@dotcom-tool-kit/error": "^2.0.0",
         "@dotcom-tool-kit/logger": "^2.0.0",
-        "@dotcom-tool-kit/types": "^2.2.0",
+        "@dotcom-tool-kit/types": "^2.3.0",
         "webpack-cli": "^4.6.0"
       },
       "devDependencies": {
@@ -21333,7 +21909,7 @@
         "@babel/preset-env": "^7.16.11",
         "@dotcom-tool-kit/error": "^2.0.0",
         "@dotcom-tool-kit/logger": "^2.0.0",
-        "@dotcom-tool-kit/types": "^2.2.0",
+        "@dotcom-tool-kit/types": "^2.3.0",
         "@jest/globals": "^27.4.6",
         "fast-glob": "^3.2.11",
         "winston": "^3.5.1"
@@ -21342,9 +21918,9 @@
     "@dotcom-tool-kit/backend-app": {
       "version": "file:plugins/backend-app",
       "requires": {
-        "@dotcom-tool-kit/circleci-heroku": "^2.0.4",
-        "@dotcom-tool-kit/node": "^2.0.2",
-        "@dotcom-tool-kit/npm": "^2.0.3"
+        "@dotcom-tool-kit/circleci-heroku": "^2.0.5",
+        "@dotcom-tool-kit/node": "^2.1.0",
+        "@dotcom-tool-kit/npm": "^2.0.4"
       }
     },
     "@dotcom-tool-kit/circleci": {
@@ -21353,7 +21929,7 @@
         "@dotcom-tool-kit/error": "^2.0.0",
         "@dotcom-tool-kit/logger": "^2.0.0",
         "@dotcom-tool-kit/state": "^2.0.0",
-        "@dotcom-tool-kit/types": "^2.2.0",
+        "@dotcom-tool-kit/types": "^2.3.0",
         "@jest/globals": "^27.4.6",
         "@types/jest": "^27.4.0",
         "@types/js-yaml": "^4.0.3",
@@ -21366,16 +21942,16 @@
     "@dotcom-tool-kit/circleci-heroku": {
       "version": "file:plugins/circleci-heroku",
       "requires": {
-        "@dotcom-tool-kit/circleci": "^2.1.0",
-        "@dotcom-tool-kit/heroku": "^2.0.3"
+        "@dotcom-tool-kit/circleci": "^2.1.1",
+        "@dotcom-tool-kit/heroku": "^2.0.4"
       }
     },
     "@dotcom-tool-kit/circleci-npm": {
       "version": "file:plugins/circleci-npm",
       "requires": {
-        "@dotcom-tool-kit/circleci": "^2.1.0",
-        "@dotcom-tool-kit/npm": "^2.0.3",
-        "@dotcom-tool-kit/types": "^2.2.0"
+        "@dotcom-tool-kit/circleci": "^2.1.1",
+        "@dotcom-tool-kit/npm": "^2.0.4",
+        "@dotcom-tool-kit/types": "^2.3.0"
       }
     },
     "@dotcom-tool-kit/create": {
@@ -21383,7 +21959,7 @@
       "requires": {
         "@dotcom-tool-kit/error": "^2.0.0",
         "@dotcom-tool-kit/logger": "^2.0.0",
-        "@dotcom-tool-kit/types": "^2.2.0",
+        "@dotcom-tool-kit/types": "^2.3.0",
         "@financial-times/package-json": "^3.0.0",
         "@quarterto/parse-makefile-rules": "^1.1.0",
         "@types/financial-times__package-json": "^1.9.0",
@@ -21392,7 +21968,7 @@
         "@types/node": "^12.20.24",
         "@types/pacote": "^11.1.3",
         "@types/prompts": "^2.0.14",
-        "dotcom-tool-kit": "^2.2.1",
+        "dotcom-tool-kit": "^2.2.2",
         "import-cwd": "^3.0.0",
         "js-yaml": "^4.1.0",
         "komatsu": "^1.3.0",
@@ -21416,7 +21992,7 @@
       "requires": {
         "@dotcom-tool-kit/error": "^2.0.0",
         "@dotcom-tool-kit/logger": "^2.0.0",
-        "@dotcom-tool-kit/types": "^2.2.0",
+        "@dotcom-tool-kit/types": "^2.3.0",
         "@jest/globals": "^27.4.6",
         "@types/eslint": "^7.2.13",
         "eslint": "^8.15.0",
@@ -21556,8 +22132,8 @@
     "@dotcom-tool-kit/frontend-app": {
       "version": "file:plugins/frontend-app",
       "requires": {
-        "@dotcom-tool-kit/backend-app": "^2.0.4",
-        "@dotcom-tool-kit/webpack": "^2.1.1"
+        "@dotcom-tool-kit/backend-app": "^2.0.5",
+        "@dotcom-tool-kit/webpack": "^2.1.2"
       }
     },
     "@dotcom-tool-kit/heroku": {
@@ -21565,11 +22141,11 @@
       "requires": {
         "@dotcom-tool-kit/error": "^2.0.0",
         "@dotcom-tool-kit/logger": "^2.0.0",
-        "@dotcom-tool-kit/npm": "^2.0.3",
+        "@dotcom-tool-kit/npm": "^2.0.4",
         "@dotcom-tool-kit/package-json-hook": "^2.1.0",
         "@dotcom-tool-kit/state": "^2.0.0",
-        "@dotcom-tool-kit/types": "^2.2.0",
-        "@dotcom-tool-kit/vault": "^2.0.2",
+        "@dotcom-tool-kit/types": "^2.3.0",
+        "@dotcom-tool-kit/vault": "^2.0.3",
         "@dotcom-tool-kit/wait-for-ok": "^2.0.0",
         "@octokit/request": "^5.6.0",
         "@octokit/request-error": "^2.1.0",
@@ -21592,7 +22168,7 @@
       "version": "file:plugins/jest",
       "requires": {
         "@dotcom-tool-kit/logger": "^2.0.0",
-        "@dotcom-tool-kit/types": "^2.2.0",
+        "@dotcom-tool-kit/types": "^2.3.0",
         "@jest/globals": "^27.4.6",
         "winston": "^3.5.1"
       }
@@ -21602,7 +22178,7 @@
       "requires": {
         "@dotcom-tool-kit/logger": "^2.0.0",
         "@dotcom-tool-kit/package-json-hook": "^2.1.0",
-        "@dotcom-tool-kit/types": "^2.2.0",
+        "@dotcom-tool-kit/types": "^2.3.0",
         "lint-staged": "^11.2.3"
       },
       "dependencies": {
@@ -21643,8 +22219,8 @@
       "version": "file:plugins/lint-staged-npm",
       "requires": {
         "@dotcom-tool-kit/husky-npm": "^2.1.0",
-        "@dotcom-tool-kit/lint-staged": "^2.1.2",
-        "@dotcom-tool-kit/options": "^2.0.2"
+        "@dotcom-tool-kit/lint-staged": "^2.1.3",
+        "@dotcom-tool-kit/options": "^2.0.3"
       }
     },
     "@dotcom-tool-kit/logger": {
@@ -21664,7 +22240,7 @@
       "requires": {
         "@dotcom-tool-kit/error": "^2.0.0",
         "@dotcom-tool-kit/logger": "^2.0.0",
-        "@dotcom-tool-kit/types": "^2.2.0",
+        "@dotcom-tool-kit/types": "^2.3.0",
         "@jest/globals": "^27.4.6",
         "@types/glob": "^7.1.3",
         "@types/mocha": "^8.2.2",
@@ -21679,7 +22255,7 @@
       "requires": {
         "@dotcom-tool-kit/logger": "^2.0.0",
         "@dotcom-tool-kit/state": "^2.0.0",
-        "@dotcom-tool-kit/types": "^2.2.0",
+        "@dotcom-tool-kit/types": "^2.3.0",
         "@financial-times/n-test": "^3.0.1",
         "@jest/globals": "^27.4.6",
         "@types/jest": "^27.4.0",
@@ -21692,8 +22268,8 @@
         "@dotcom-tool-kit/error": "^2.0.0",
         "@dotcom-tool-kit/logger": "^2.0.0",
         "@dotcom-tool-kit/state": "^2.0.0",
-        "@dotcom-tool-kit/types": "^2.2.0",
-        "@dotcom-tool-kit/vault": "^2.0.2",
+        "@dotcom-tool-kit/types": "^2.3.0",
+        "@dotcom-tool-kit/vault": "^2.0.3",
         "ft-next-router": "^1.0.0"
       }
     },
@@ -21702,8 +22278,8 @@
       "requires": {
         "@dotcom-tool-kit/error": "^2.0.0",
         "@dotcom-tool-kit/state": "^2.0.0",
-        "@dotcom-tool-kit/types": "^2.2.0",
-        "@dotcom-tool-kit/vault": "^2.0.2",
+        "@dotcom-tool-kit/types": "^2.3.0",
+        "@dotcom-tool-kit/vault": "^2.0.3",
         "get-port": "^5.1.1",
         "wait-port": "^0.2.9"
       }
@@ -21713,8 +22289,8 @@
       "requires": {
         "@dotcom-tool-kit/error": "^2.0.0",
         "@dotcom-tool-kit/state": "^2.0.0",
-        "@dotcom-tool-kit/types": "^2.2.0",
-        "@dotcom-tool-kit/vault": "^2.0.2",
+        "@dotcom-tool-kit/types": "^2.3.0",
+        "@dotcom-tool-kit/vault": "^2.0.3",
         "@types/nodemon": "^1.19.1",
         "get-port": "^5.1.1"
       }
@@ -21726,7 +22302,7 @@
         "@dotcom-tool-kit/error": "^2.0.0",
         "@dotcom-tool-kit/package-json-hook": "^2.1.0",
         "@dotcom-tool-kit/state": "^2.0.0",
-        "@dotcom-tool-kit/types": "^2.2.0",
+        "@dotcom-tool-kit/types": "^2.3.0",
         "@types/libnpmpublish": "^4.0.1",
         "@types/pacote": "^11.1.3",
         "@types/tar": "^6.1.1",
@@ -21837,15 +22413,15 @@
     "@dotcom-tool-kit/options": {
       "version": "file:lib/options",
       "requires": {
-        "@dotcom-tool-kit/types": "^2.2.0"
+        "@dotcom-tool-kit/types": "^2.3.0"
       }
     },
     "@dotcom-tool-kit/pa11y": {
       "version": "file:plugins/pa11y",
       "requires": {
-        "@dotcom-tool-kit/types": "^2.2.0",
+        "@dotcom-tool-kit/types": "^2.3.0",
         "@types/pa11y": "^5.3.4",
-        "pa11y": "^6.2.3"
+        "pa11y-ci": "*"
       }
     },
     "@dotcom-tool-kit/package-json-hook": {
@@ -21862,7 +22438,7 @@
         "@dotcom-tool-kit/error": "^2.0.0",
         "@dotcom-tool-kit/logger": "^2.0.0",
         "@dotcom-tool-kit/package-json-hook": "^2.1.0",
-        "@dotcom-tool-kit/types": "^2.2.0",
+        "@dotcom-tool-kit/types": "^2.3.0",
         "@jest/globals": "^27.4.6",
         "fast-glob": "^3.2.7",
         "hook-std": "^2.0.0",
@@ -21899,7 +22475,7 @@
       "version": "file:plugins/secret-squirrel",
       "requires": {
         "@dotcom-tool-kit/logger": "^2.0.0",
-        "@dotcom-tool-kit/types": "^2.2.0"
+        "@dotcom-tool-kit/types": "^2.3.0"
       }
     },
     "@dotcom-tool-kit/state": {
@@ -21927,7 +22503,7 @@
         "@aws-sdk/types": "^3.13.1",
         "@dotcom-tool-kit/error": "^2.0.0",
         "@dotcom-tool-kit/logger": "^2.0.0",
-        "@dotcom-tool-kit/types": "^2.2.0",
+        "@dotcom-tool-kit/types": "^2.3.0",
         "@jest/globals": "^27.4.6",
         "@types/glob": "^7.1.3",
         "@types/jest": "^27.4.0",
@@ -21942,8 +22518,8 @@
       "version": "file:lib/vault",
       "requires": {
         "@dotcom-tool-kit/error": "^2.0.0",
-        "@dotcom-tool-kit/options": "^2.0.2",
-        "@dotcom-tool-kit/types": "^2.2.0",
+        "@dotcom-tool-kit/options": "^2.0.3",
+        "@dotcom-tool-kit/types": "^2.3.0",
         "@financial-times/n-fetch": "^1.0.0-beta.7",
         "@types/jest": "^27.0.2",
         "fs": "0.0.1-security",
@@ -21982,7 +22558,7 @@
       "requires": {
         "@dotcom-tool-kit/error": "^2.0.0",
         "@dotcom-tool-kit/logger": "^2.0.0",
-        "@dotcom-tool-kit/types": "^2.2.0",
+        "@dotcom-tool-kit/types": "^2.3.0",
         "@jest/globals": "^27.4.6",
         "ts-node": "^10.0.0",
         "webpack": "^4.42.1",
@@ -23501,6 +24077,8 @@
     },
     "@types/yauzl": {
       "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/@types/yauzl/-/yauzl-2.10.0.tgz",
+      "integrity": "sha512-Cn6WYCm0tXv8p6k+A8PvbDG763EDpBoTzHdA+Q/MF6H3sapGjCm9NzoaJncJS9tUKSuCoDs9XHxYYsQDgxR6kw==",
       "optional": true,
       "requires": {
         "@types/node": "*"
@@ -23963,6 +24541,11 @@
       "version": "2.1.0",
       "dev": true
     },
+    "array-uniq": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/array-uniq/-/array-uniq-1.0.3.tgz",
+      "integrity": "sha512-MNha4BWQ6JbwhFhj03YK552f7cb3AzoE8SzeljgChvL1dl3IcvggXVz1DilzySZkCja+CXuZbdW7yATchWn8/Q=="
+    },
     "array-unique": {
       "version": "0.3.2"
     },
@@ -24117,7 +24700,9 @@
       "version": "1.11.0"
     },
     "axe-core": {
-      "version": "4.2.4"
+      "version": "4.4.2",
+      "resolved": "https://registry.npmjs.org/axe-core/-/axe-core-4.4.2.tgz",
+      "integrity": "sha512-LVAaGp/wkkgYJcjmHsoKx4juT1aQvJyPcW09MLCjVTh3V2cc6PnyempiLMNH5iMdfIX/zdbjUx2KDjMLCTdPeA=="
     },
     "babel-jest": {
       "version": "27.5.1",
@@ -24272,6 +24857,8 @@
     },
     "bfj": {
       "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/bfj/-/bfj-7.0.2.tgz",
+      "integrity": "sha512-+e/UqUzwmzJamNF50tBV6tZPTORow7gQ96iFow+8b562OdMpEK0BcJEq2OSPEDmAbSMBQ7PKZ87ubFkgxpYWgw==",
       "requires": {
         "bluebird": "^3.5.5",
         "check-types": "^11.1.1",
@@ -24316,8 +24903,7 @@
       "version": "5.2.0"
     },
     "boolbase": {
-      "version": "1.0.0",
-      "dev": true
+      "version": "1.0.0"
     },
     "boxen": {
       "version": "5.1.2",
@@ -24630,7 +25216,126 @@
       "dev": true
     },
     "check-types": {
-      "version": "11.1.2"
+      "version": "11.1.2",
+      "resolved": "https://registry.npmjs.org/check-types/-/check-types-11.1.2.tgz",
+      "integrity": "sha512-tzWzvgePgLORb9/3a0YenggReLKAIb2owL03H2Xdoe5pKcUyWRSEQ8xfCar8t2SIAuEDwtmx2da1YB52YuHQMQ=="
+    },
+    "cheerio": {
+      "version": "1.0.0-rc.12",
+      "resolved": "https://registry.npmjs.org/cheerio/-/cheerio-1.0.0-rc.12.tgz",
+      "integrity": "sha512-VqR8m68vM46BNnuZ5NtnGBKIE/DfN0cRIzg9n40EIq9NOv90ayxLBXA8fXC5gquFRGJSTRqBq25Jt2ECLR431Q==",
+      "requires": {
+        "cheerio-select": "^2.1.0",
+        "dom-serializer": "^2.0.0",
+        "domhandler": "^5.0.3",
+        "domutils": "^3.0.1",
+        "htmlparser2": "^8.0.1",
+        "parse5": "^7.0.0",
+        "parse5-htmlparser2-tree-adapter": "^7.0.0"
+      },
+      "dependencies": {
+        "dom-serializer": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-2.0.0.tgz",
+          "integrity": "sha512-wIkAryiqt/nV5EQKqQpo3SToSOV9J0DnbJqwK7Wv/Trc92zIAYZ4FlMu+JPFW1DfGFt81ZTCGgDEabffXeLyJg==",
+          "requires": {
+            "domelementtype": "^2.3.0",
+            "domhandler": "^5.0.2",
+            "entities": "^4.2.0"
+          }
+        },
+        "domhandler": {
+          "version": "5.0.3",
+          "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-5.0.3.tgz",
+          "integrity": "sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w==",
+          "requires": {
+            "domelementtype": "^2.3.0"
+          }
+        },
+        "domutils": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/domutils/-/domutils-3.0.1.tgz",
+          "integrity": "sha512-z08c1l761iKhDFtfXO04C7kTdPBLi41zwOZl00WS8b5eiaebNpY00HKbztwBq+e3vyqWNwWF3mP9YLUeqIrF+Q==",
+          "requires": {
+            "dom-serializer": "^2.0.0",
+            "domelementtype": "^2.3.0",
+            "domhandler": "^5.0.1"
+          }
+        },
+        "entities": {
+          "version": "4.3.0",
+          "resolved": "https://registry.npmjs.org/entities/-/entities-4.3.0.tgz",
+          "integrity": "sha512-/iP1rZrSEJ0DTlPiX+jbzlA3eVkY/e8L8SozroF395fIqE3TYF/Nz7YOMAawta+vLmyJ/hkGNNPcSbMADCCXbg=="
+        },
+        "parse5": {
+          "version": "7.0.0",
+          "resolved": "https://registry.npmjs.org/parse5/-/parse5-7.0.0.tgz",
+          "integrity": "sha512-y/t8IXSPWTuRZqXc0ajH/UwDj4mnqLEbSttNbThcFhGrZuOyoyvNBO85PBp2jQa55wY9d07PBNjsK8ZP3K5U6g==",
+          "requires": {
+            "entities": "^4.3.0"
+          }
+        }
+      }
+    },
+    "cheerio-select": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/cheerio-select/-/cheerio-select-2.1.0.tgz",
+      "integrity": "sha512-9v9kG0LvzrlcungtnJtpGNxY+fzECQKhK4EGJX2vByejiMX84MFNQw4UxPJl3bFbTMw+Dfs37XaIkCwTZfLh4g==",
+      "requires": {
+        "boolbase": "^1.0.0",
+        "css-select": "^5.1.0",
+        "css-what": "^6.1.0",
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.3",
+        "domutils": "^3.0.1"
+      },
+      "dependencies": {
+        "css-select": {
+          "version": "5.1.0",
+          "resolved": "https://registry.npmjs.org/css-select/-/css-select-5.1.0.tgz",
+          "integrity": "sha512-nwoRF1rvRRnnCqqY7updORDsuqKzqYJ28+oSMaJMMgOauh3fvwHqMS7EZpIPqK8GL+g9mKxF1vP/ZjSeNjEVHg==",
+          "requires": {
+            "boolbase": "^1.0.0",
+            "css-what": "^6.1.0",
+            "domhandler": "^5.0.2",
+            "domutils": "^3.0.1",
+            "nth-check": "^2.0.1"
+          }
+        },
+        "dom-serializer": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-2.0.0.tgz",
+          "integrity": "sha512-wIkAryiqt/nV5EQKqQpo3SToSOV9J0DnbJqwK7Wv/Trc92zIAYZ4FlMu+JPFW1DfGFt81ZTCGgDEabffXeLyJg==",
+          "requires": {
+            "domelementtype": "^2.3.0",
+            "domhandler": "^5.0.2",
+            "entities": "^4.2.0"
+          }
+        },
+        "domhandler": {
+          "version": "5.0.3",
+          "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-5.0.3.tgz",
+          "integrity": "sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w==",
+          "requires": {
+            "domelementtype": "^2.3.0"
+          }
+        },
+        "domutils": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/domutils/-/domutils-3.0.1.tgz",
+          "integrity": "sha512-z08c1l761iKhDFtfXO04C7kTdPBLi41zwOZl00WS8b5eiaebNpY00HKbztwBq+e3vyqWNwWF3mP9YLUeqIrF+Q==",
+          "requires": {
+            "dom-serializer": "^2.0.0",
+            "domelementtype": "^2.3.0",
+            "domhandler": "^5.0.1"
+          }
+        },
+        "entities": {
+          "version": "4.3.0",
+          "resolved": "https://registry.npmjs.org/entities/-/entities-4.3.0.tgz",
+          "integrity": "sha512-/iP1rZrSEJ0DTlPiX+jbzlA3eVkY/e8L8SozroF395fIqE3TYF/Nz7YOMAawta+vLmyJ/hkGNNPcSbMADCCXbg=="
+        }
+      }
     },
     "chokidar": {
       "version": "3.5.3",
@@ -24834,8 +25539,7 @@
       }
     },
     "commander": {
-      "version": "6.2.1",
-      "dev": true
+      "version": "6.2.1"
     },
     "commondir": {
       "version": "1.0.1"
@@ -25229,8 +25933,7 @@
       "version": "0.0.1"
     },
     "css-what": {
-      "version": "6.1.0",
-      "dev": true
+      "version": "6.1.0"
     },
     "cssom": {
       "version": "0.4.4"
@@ -25387,7 +26090,9 @@
       "version": "3.1.0"
     },
     "devtools-protocol": {
-      "version": "0.0.869402"
+      "version": "0.0.869402",
+      "resolved": "https://registry.npmjs.org/devtools-protocol/-/devtools-protocol-0.0.869402.tgz",
+      "integrity": "sha512-VvlVYY+VDJe639yHs5PHISzdWTLL3Aw8rO4cvUtwvoxFd6FHbE4OpHHcde52M6096uYYazAmd4l0o5VuFRO2WA=="
     },
     "diff": {
       "version": "5.0.0"
@@ -25438,8 +26143,7 @@
       "version": "1.2.0"
     },
     "domelementtype": {
-      "version": "2.3.0",
-      "dev": true
+      "version": "2.3.0"
     },
     "domexception": {
       "version": "2.0.1",
@@ -25477,22 +26181,22 @@
     "dotcom-tool-kit": {
       "version": "file:core/cli",
       "requires": {
-        "@dotcom-tool-kit/babel": "^2.0.2",
-        "@dotcom-tool-kit/backend-app": "^2.0.4",
-        "@dotcom-tool-kit/circleci": "^2.1.0",
-        "@dotcom-tool-kit/circleci-heroku": "^2.0.4",
+        "@dotcom-tool-kit/babel": "^2.0.3",
+        "@dotcom-tool-kit/backend-app": "^2.0.5",
+        "@dotcom-tool-kit/circleci": "^2.1.1",
+        "@dotcom-tool-kit/circleci-heroku": "^2.0.5",
         "@dotcom-tool-kit/error": "^2.0.0",
-        "@dotcom-tool-kit/eslint": "^2.1.1",
-        "@dotcom-tool-kit/frontend-app": "^2.1.2",
-        "@dotcom-tool-kit/heroku": "^2.0.3",
+        "@dotcom-tool-kit/eslint": "^2.1.2",
+        "@dotcom-tool-kit/frontend-app": "^2.1.3",
+        "@dotcom-tool-kit/heroku": "^2.0.4",
         "@dotcom-tool-kit/logger": "^2.0.0",
-        "@dotcom-tool-kit/mocha": "^2.0.2",
-        "@dotcom-tool-kit/n-test": "^2.0.2",
-        "@dotcom-tool-kit/npm": "^2.0.3",
-        "@dotcom-tool-kit/options": "^2.0.2",
-        "@dotcom-tool-kit/types": "^2.2.0",
+        "@dotcom-tool-kit/mocha": "^2.1.0",
+        "@dotcom-tool-kit/n-test": "^2.0.3",
+        "@dotcom-tool-kit/npm": "^2.0.4",
+        "@dotcom-tool-kit/options": "^2.0.3",
+        "@dotcom-tool-kit/types": "^2.3.0",
         "@dotcom-tool-kit/wait-for-ok": "^2.0.0",
-        "@dotcom-tool-kit/webpack": "^2.1.1",
+        "@dotcom-tool-kit/webpack": "^2.1.2",
         "@jest/globals": "^27.4.6",
         "@types/lodash.merge": "^4.6.6",
         "@types/node": "^12.20.24",
@@ -26377,6 +27081,11 @@
       "version": "1.0.0",
       "optional": true
     },
+    "file-url": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/file-url/-/file-url-3.0.0.tgz",
+      "integrity": "sha512-g872QGsHexznxkIAdK8UiZRe7SkE6kvylShU4Nsj8NvfvZag7S0QuQ4IgvPDkk75HxgjIVDwycFTDAgIiO4nDA=="
+    },
     "fill-range": {
       "version": "7.0.1",
       "requires": {
@@ -26992,11 +27701,37 @@
         "minimalistic-crypto-utils": "^1.0.1"
       }
     },
+    "hogan.js": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/hogan.js/-/hogan.js-3.0.2.tgz",
+      "integrity": "sha512-RqGs4wavGYJWE07t35JQccByczmNUXQT0E12ZYV1VKYu5UiAU9lsos/yBAcf840+zrUQQxgVduCR5/B8nNtibg==",
+      "requires": {
+        "mkdirp": "0.3.0",
+        "nopt": "1.0.10"
+      },
+      "dependencies": {
+        "mkdirp": {
+          "version": "0.3.0",
+          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.3.0.tgz",
+          "integrity": "sha512-OHsdUcVAQ6pOtg5JYWpCBo9W/GySVuwvP9hueRMW7UqshC0tbfzLv8wjySTPm3tfUZ/21CE9E1pJagOA91Pxew=="
+        },
+        "nopt": {
+          "version": "1.0.10",
+          "resolved": "https://registry.npmjs.org/nopt/-/nopt-1.0.10.tgz",
+          "integrity": "sha512-NWmpvLSqUrgrAC9HCuxEvb+PSloHpqVu+FqcO4eeF2h5qYRhA7ev6KvelyQAKtegUbC6RypJnlEOhd8vloNKYg==",
+          "requires": {
+            "abbrev": "1"
+          }
+        }
+      }
+    },
     "hook-std": {
       "version": "2.0.0"
     },
     "hoopy": {
-      "version": "0.1.4"
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/hoopy/-/hoopy-0.1.4.tgz",
+      "integrity": "sha512-HRcs+2mr52W0K+x8RzcLzuPPmVIKMSv97RGHy0Ea9y/mpcaK+xTrjICA04KAHi4GRzxliNqNJEFYWHghy3rSfQ=="
     },
     "hosted-git-info": {
       "version": "4.1.0",
@@ -27016,7 +27751,9 @@
       }
     },
     "html_codesniffer": {
-      "version": "2.5.1"
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/html_codesniffer/-/html_codesniffer-2.5.1.tgz",
+      "integrity": "sha512-vcz0yAaX/OaV6sdNHuT9alBOKkSxYb8h5Yq26dUqgi7XmCgGUSa7U9PiY1PBXQFMjKv1wVPs5/QzHlGuxPDUGg=="
     },
     "html-encoding-sniffer": {
       "version": "2.0.1",
@@ -27026,6 +27763,52 @@
     },
     "html-escaper": {
       "version": "2.0.2"
+    },
+    "htmlparser2": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-8.0.1.tgz",
+      "integrity": "sha512-4lVbmc1diZC7GUJQtRQ5yBAeUCL1exyMwmForWkRLnwyzWBFxN633SALPMGYaWZvKe9j1pRZJpauvmxENSp/EA==",
+      "requires": {
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.2",
+        "domutils": "^3.0.1",
+        "entities": "^4.3.0"
+      },
+      "dependencies": {
+        "dom-serializer": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-2.0.0.tgz",
+          "integrity": "sha512-wIkAryiqt/nV5EQKqQpo3SToSOV9J0DnbJqwK7Wv/Trc92zIAYZ4FlMu+JPFW1DfGFt81ZTCGgDEabffXeLyJg==",
+          "requires": {
+            "domelementtype": "^2.3.0",
+            "domhandler": "^5.0.2",
+            "entities": "^4.2.0"
+          }
+        },
+        "domhandler": {
+          "version": "5.0.3",
+          "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-5.0.3.tgz",
+          "integrity": "sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w==",
+          "requires": {
+            "domelementtype": "^2.3.0"
+          }
+        },
+        "domutils": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/domutils/-/domutils-3.0.1.tgz",
+          "integrity": "sha512-z08c1l761iKhDFtfXO04C7kTdPBLi41zwOZl00WS8b5eiaebNpY00HKbztwBq+e3vyqWNwWF3mP9YLUeqIrF+Q==",
+          "requires": {
+            "dom-serializer": "^2.0.0",
+            "domelementtype": "^2.3.0",
+            "domhandler": "^5.0.1"
+          }
+        },
+        "entities": {
+          "version": "4.3.0",
+          "resolved": "https://registry.npmjs.org/entities/-/entities-4.3.0.tgz",
+          "integrity": "sha512-/iP1rZrSEJ0DTlPiX+jbzlA3eVkY/e8L8SozroF395fIqE3TYF/Nz7YOMAawta+vLmyJ/hkGNNPcSbMADCCXbg=="
+        }
+      }
     },
     "http-cache-semantics": {
       "version": "4.1.0"
@@ -27272,7 +28055,9 @@
       "version": "4.3.0"
     },
     "is": {
-      "version": "3.3.0"
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/is/-/is-3.3.0.tgz",
+      "integrity": "sha512-nW24QBoPcFGGHJGUwnfpI7Yc5CdqWNdsyHQszVE/z2pKHXzh7FZ5GWhJqSyaQ9wMkQnsTx+kAI8bHlCX4tKdbg=="
     },
     "is-accessor-descriptor": {
       "version": "0.1.6",
@@ -28973,7 +29758,9 @@
       "version": "1.0.4"
     },
     "mkdirp-classic": {
-      "version": "0.5.3"
+      "version": "0.5.3",
+      "resolved": "https://registry.npmjs.org/mkdirp-classic/-/mkdirp-classic-0.5.3.tgz",
+      "integrity": "sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A=="
     },
     "mocha": {
       "version": "8.4.0",
@@ -29163,9 +29950,6 @@
     },
     "ms": {
       "version": "2.1.2"
-    },
-    "mustache": {
-      "version": "4.2.0"
     },
     "mute-stream": {
       "version": "0.0.8"
@@ -29417,6 +30201,8 @@
     },
     "node.extend": {
       "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/node.extend/-/node.extend-2.0.2.tgz",
+      "integrity": "sha512-pDT4Dchl94/+kkgdwyS2PauDFjZG0Hk0IcHIB+LkW27HLDtdoeMxHTxZh39DYbPP8UflWXWj9JcdDozF+YDOpQ==",
       "requires": {
         "has": "^1.0.3",
         "is": "^3.2.1"
@@ -29771,7 +30557,6 @@
     },
     "nth-check": {
       "version": "2.0.1",
-      "dev": true,
       "requires": {
         "boolbase": "^1.0.0"
       }
@@ -29951,15 +30736,17 @@
       "version": "2.2.0"
     },
     "pa11y": {
-      "version": "6.2.3",
+      "version": "6.1.1",
+      "resolved": "https://registry.npmjs.org/pa11y/-/pa11y-6.1.1.tgz",
+      "integrity": "sha512-2NzqA3D9CUlDWj8WuOI4fM2P0qM1d/IUxsRRpzCOfDT5eMR1oEgmUwW2TAk+f90ff/GVck0BewdYT4et4BANew==",
       "requires": {
-        "axe-core": "~4.2.1",
+        "axe-core": "^4.0.2",
         "bfj": "~7.0.2",
         "commander": "~8.0.0",
         "envinfo": "~7.8.1",
-        "html_codesniffer": "~2.5.1",
+        "hogan.js": "^3.0.2",
+        "html_codesniffer": "^2.5.1",
         "kleur": "~4.1.4",
-        "mustache": "~4.2.0",
         "node.extend": "~2.0.2",
         "p-timeout": "~4.1.0",
         "puppeteer": "~9.1.1",
@@ -29967,10 +30754,14 @@
       },
       "dependencies": {
         "commander": {
-          "version": "8.0.0"
+          "version": "8.0.0",
+          "resolved": "https://registry.npmjs.org/commander/-/commander-8.0.0.tgz",
+          "integrity": "sha512-Xvf85aAtu6v22+E5hfVoLHqyul/jyxh91zvqk/ioJTQuJR7Z78n7H558vMPKanPSRgIEeZemT92I2g9Y8LPbSQ=="
         },
         "extract-zip": {
           "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/extract-zip/-/extract-zip-2.0.1.tgz",
+          "integrity": "sha512-GDhU9ntwuKyGXdZBUgTIe+vXnWj0fppUEtMDL0+idd5Sta8TGpHssn/eusA9mrPr9qNDym6SxAYZjNvCn/9RBg==",
           "requires": {
             "@types/yauzl": "^2.9.1",
             "debug": "^4.1.1",
@@ -29980,6 +30771,8 @@
         },
         "find-up": {
           "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
+          "integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
           "requires": {
             "locate-path": "^5.0.0",
             "path-exists": "^4.0.0"
@@ -29987,42 +30780,195 @@
         },
         "get-stream": {
           "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-5.2.0.tgz",
+          "integrity": "sha512-nBF+F1rAZVCu/p7rjzgA+Yb4lfYXrpl7a6VmJrU8wF9I1CKvP/QwPNZHnOlwbTkY6dvtFIzFMSyQXbLoTQPRpA==",
           "requires": {
             "pump": "^3.0.0"
           }
         },
         "kleur": {
-          "version": "4.1.4"
+          "version": "4.1.5",
+          "resolved": "https://registry.npmjs.org/kleur/-/kleur-4.1.5.tgz",
+          "integrity": "sha512-o+NO+8WrRiQEE4/7nwRJhN1HWpVmJm511pBHUxPLtp0BUISzlBplORYSmTclCnJvQq2tKu/sgl3xVpkc7ZWuQQ=="
         },
         "locate-path": {
           "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
+          "integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
           "requires": {
             "p-locate": "^4.1.0"
           }
         },
         "p-limit": {
           "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
+          "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
           "requires": {
             "p-try": "^2.0.0"
           }
         },
         "p-locate": {
           "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
+          "integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
           "requires": {
             "p-limit": "^2.2.0"
           }
         },
         "p-timeout": {
-          "version": "4.1.0"
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/p-timeout/-/p-timeout-4.1.0.tgz",
+          "integrity": "sha512-+/wmHtzJuWii1sXn3HCuH/FTwGhrp4tmJTxSKJbfS+vkipci6osxXM5mY0jUiRzWKMTgUT8l7HFbeSwZAynqHw=="
         },
         "pkg-dir": {
           "version": "4.2.0",
+          "resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-4.2.0.tgz",
+          "integrity": "sha512-HRDzbaKjC+AOWVXxAU/x54COGeIv9eb+6CkDSQoNTt4XyWoIJvuPsXizxu/Fr23EiekbtZwmh1IcIG/l/a10GQ==",
           "requires": {
             "find-up": "^4.0.0"
           }
         },
         "puppeteer": {
           "version": "9.1.1",
+          "resolved": "https://registry.npmjs.org/puppeteer/-/puppeteer-9.1.1.tgz",
+          "integrity": "sha512-W+nOulP2tYd/ZG99WuZC/I5ljjQQ7EUw/jQGcIb9eu8mDlZxNY2SgcJXTLG9h5gRvqA3uJOe4hZXYsd3EqioMw==",
+          "requires": {
+            "debug": "^4.1.0",
+            "devtools-protocol": "0.0.869402",
+            "extract-zip": "^2.0.0",
+            "https-proxy-agent": "^5.0.0",
+            "node-fetch": "^2.6.1",
+            "pkg-dir": "^4.2.0",
+            "progress": "^2.0.1",
+            "proxy-from-env": "^1.1.0",
+            "rimraf": "^3.0.2",
+            "tar-fs": "^2.0.0",
+            "unbzip2-stream": "^1.3.3",
+            "ws": "^7.2.3"
+          }
+        }
+      }
+    },
+    "pa11y-ci": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/pa11y-ci/-/pa11y-ci-3.0.1.tgz",
+      "integrity": "sha512-DUtEIhEG3Ofds7qRuplq0DdCb9doILRlzcRctFNzo4QUNmVy4iZfM3u51A9cqoPo2irCJZoo5BzfiFrcriY2IQ==",
+      "requires": {
+        "async": "~2.6.3",
+        "cheerio": "~1.0.0-rc.10",
+        "commander": "~6.2.1",
+        "globby": "~6.1.0",
+        "kleur": "~4.1.4",
+        "lodash": "~4.17.21",
+        "node-fetch": "~2.6.1",
+        "pa11y": "~6.1.0",
+        "protocolify": "~3.0.0",
+        "puppeteer": "~9.1.1",
+        "wordwrap": "~1.0.0"
+      },
+      "dependencies": {
+        "array-union": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/array-union/-/array-union-1.0.2.tgz",
+          "integrity": "sha512-Dxr6QJj/RdU/hCaBjOfxW+q6lyuVE6JFWIrAUpuOOhoJJoQ99cUn3igRaHVB5P9WrgFVN0FfArM3x0cueOU8ng==",
+          "requires": {
+            "array-uniq": "^1.0.1"
+          }
+        },
+        "async": {
+          "version": "2.6.4",
+          "resolved": "https://registry.npmjs.org/async/-/async-2.6.4.tgz",
+          "integrity": "sha512-mzo5dfJYwAn29PeiJ0zvwTo04zj8HDJj0Mn8TD7sno7q12prdbnasKJHhkm2c1LgrhlJ0teaea8860oxi51mGA==",
+          "requires": {
+            "lodash": "^4.17.14"
+          }
+        },
+        "extract-zip": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/extract-zip/-/extract-zip-2.0.1.tgz",
+          "integrity": "sha512-GDhU9ntwuKyGXdZBUgTIe+vXnWj0fppUEtMDL0+idd5Sta8TGpHssn/eusA9mrPr9qNDym6SxAYZjNvCn/9RBg==",
+          "requires": {
+            "@types/yauzl": "^2.9.1",
+            "debug": "^4.1.1",
+            "get-stream": "^5.1.0",
+            "yauzl": "^2.10.0"
+          }
+        },
+        "find-up": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
+          "integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
+          "requires": {
+            "locate-path": "^5.0.0",
+            "path-exists": "^4.0.0"
+          }
+        },
+        "get-stream": {
+          "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-5.2.0.tgz",
+          "integrity": "sha512-nBF+F1rAZVCu/p7rjzgA+Yb4lfYXrpl7a6VmJrU8wF9I1CKvP/QwPNZHnOlwbTkY6dvtFIzFMSyQXbLoTQPRpA==",
+          "requires": {
+            "pump": "^3.0.0"
+          }
+        },
+        "globby": {
+          "version": "6.1.0",
+          "resolved": "https://registry.npmjs.org/globby/-/globby-6.1.0.tgz",
+          "integrity": "sha512-KVbFv2TQtbzCoxAnfD6JcHZTYCzyliEaaeM/gH8qQdkKr5s0OP9scEgvdcngyk7AVdY6YVW/TJHd+lQ/Df3Daw==",
+          "requires": {
+            "array-union": "^1.0.1",
+            "glob": "^7.0.3",
+            "object-assign": "^4.0.1",
+            "pify": "^2.0.0",
+            "pinkie-promise": "^2.0.0"
+          }
+        },
+        "kleur": {
+          "version": "4.1.5",
+          "resolved": "https://registry.npmjs.org/kleur/-/kleur-4.1.5.tgz",
+          "integrity": "sha512-o+NO+8WrRiQEE4/7nwRJhN1HWpVmJm511pBHUxPLtp0BUISzlBplORYSmTclCnJvQq2tKu/sgl3xVpkc7ZWuQQ=="
+        },
+        "locate-path": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
+          "integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
+          "requires": {
+            "p-locate": "^4.1.0"
+          }
+        },
+        "p-limit": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
+          "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
+          "requires": {
+            "p-try": "^2.0.0"
+          }
+        },
+        "p-locate": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
+          "integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
+          "requires": {
+            "p-limit": "^2.2.0"
+          }
+        },
+        "pify": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
+          "integrity": "sha512-udgsAY+fTnvv7kI7aaxbqwWNb0AHiB0qBO89PZKPkoTmGOgdbrHDKD+0B2X4uTfJ/FT1R09r9gTsjUjNJotuog=="
+        },
+        "pkg-dir": {
+          "version": "4.2.0",
+          "resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-4.2.0.tgz",
+          "integrity": "sha512-HRDzbaKjC+AOWVXxAU/x54COGeIv9eb+6CkDSQoNTt4XyWoIJvuPsXizxu/Fr23EiekbtZwmh1IcIG/l/a10GQ==",
+          "requires": {
+            "find-up": "^4.0.0"
+          }
+        },
+        "puppeteer": {
+          "version": "9.1.1",
+          "resolved": "https://registry.npmjs.org/puppeteer/-/puppeteer-9.1.1.tgz",
+          "integrity": "sha512-W+nOulP2tYd/ZG99WuZC/I5ljjQQ7EUw/jQGcIb9eu8mDlZxNY2SgcJXTLG9h5gRvqA3uJOe4hZXYsd3EqioMw==",
           "requires": {
             "debug": "^4.1.0",
             "devtools-protocol": "0.0.869402",
@@ -30360,6 +31306,38 @@
     "parse5": {
       "version": "6.0.1"
     },
+    "parse5-htmlparser2-tree-adapter": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/parse5-htmlparser2-tree-adapter/-/parse5-htmlparser2-tree-adapter-7.0.0.tgz",
+      "integrity": "sha512-B77tOZrqqfUfnVcOrUvfdLbz4pu4RopLD/4vmu3HUPswwTA8OH0EMW9BlWR2B0RCoiZRAHEUu7IxeP1Pd1UU+g==",
+      "requires": {
+        "domhandler": "^5.0.2",
+        "parse5": "^7.0.0"
+      },
+      "dependencies": {
+        "domhandler": {
+          "version": "5.0.3",
+          "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-5.0.3.tgz",
+          "integrity": "sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w==",
+          "requires": {
+            "domelementtype": "^2.3.0"
+          }
+        },
+        "entities": {
+          "version": "4.3.0",
+          "resolved": "https://registry.npmjs.org/entities/-/entities-4.3.0.tgz",
+          "integrity": "sha512-/iP1rZrSEJ0DTlPiX+jbzlA3eVkY/e8L8SozroF395fIqE3TYF/Nz7YOMAawta+vLmyJ/hkGNNPcSbMADCCXbg=="
+        },
+        "parse5": {
+          "version": "7.0.0",
+          "resolved": "https://registry.npmjs.org/parse5/-/parse5-7.0.0.tgz",
+          "integrity": "sha512-y/t8IXSPWTuRZqXc0ajH/UwDj4mnqLEbSttNbThcFhGrZuOyoyvNBO85PBp2jQa55wY9d07PBNjsK8ZP3K5U6g==",
+          "requires": {
+            "entities": "^4.3.0"
+          }
+        }
+      }
+    },
     "parseurl": {
       "version": "1.3.3"
     },
@@ -30423,6 +31401,19 @@
     },
     "pify": {
       "version": "4.0.1"
+    },
+    "pinkie": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz",
+      "integrity": "sha512-MnUuEycAemtSaeFSjXKW/aroV7akBbY+Sv+RkyqFjgAe73F+MR0TBWKBRDkmfWq/HiFmdavfZ1G7h4SPZXaCSg=="
+    },
+    "pinkie-promise": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
+      "integrity": "sha512-0Gni6D4UcLTbv9c57DfxDGdr41XfgUjqWZu492f0cIGr16zDU06BWP/RAEvOuo7CQ0CNjHaLlM59YJJFm3NWlw==",
+      "requires": {
+        "pinkie": "^2.0.0"
+      }
     },
     "pirates": {
       "version": "4.0.5"
@@ -30511,6 +31502,22 @@
       "requires": {
         "kleur": "^3.0.3",
         "sisteransi": "^1.0.5"
+      }
+    },
+    "protocolify": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/protocolify/-/protocolify-3.0.0.tgz",
+      "integrity": "sha512-PuvDJOkKJMVQx8jSNf8E5g0bJw/UTKm30mTjFHg4N30c8sefgA5Qr/f8INKqYBKfvP/MUSJrj+z1Smjbq4/3rQ==",
+      "requires": {
+        "file-url": "^3.0.0",
+        "prepend-http": "^3.0.0"
+      },
+      "dependencies": {
+        "prepend-http": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/prepend-http/-/prepend-http-3.0.1.tgz",
+          "integrity": "sha512-BLxfZh+m6UiAiCPZFJ4+vYoL7NrRs5XgCTRrjseATAggXhdZKKxn+JUNmuVYWY23bDHgaEHodxw8mnmtVEDtHw=="
+        }
       }
     },
     "proxy-from-env": {
@@ -31961,6 +32968,8 @@
     },
     "tar-fs": {
       "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-2.1.1.tgz",
+      "integrity": "sha512-V0r2Y9scmbDRLCNex/+hYzvp/zyYjvFbHPNgVTKfQvVrb6guiE/fxP+XblDNR011utopbkex2nM4dHNV6GDsng==",
       "requires": {
         "chownr": "^1.1.1",
         "mkdirp-classic": "^0.5.2",
@@ -31969,7 +32978,9 @@
       },
       "dependencies": {
         "chownr": {
-          "version": "1.1.4"
+          "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.4.tgz",
+          "integrity": "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg=="
         }
       }
     },
@@ -32267,7 +33278,9 @@
       "version": "1.3.0"
     },
     "tryer": {
-      "version": "1.0.1"
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/tryer/-/tryer-1.0.1.tgz",
+      "integrity": "sha512-c3zayb8/kWWpycWYg87P71E1S1ZL6b6IJxfb5fvsUgsf0S2MVGaDhDXXjDMpdCpfWXqptc+4mXwmiy1ypXqRAA=="
     },
     "ts-jest": {
       "version": "27.1.4",
@@ -32387,6 +33400,8 @@
     },
     "unbzip2-stream": {
       "version": "1.4.3",
+      "resolved": "https://registry.npmjs.org/unbzip2-stream/-/unbzip2-stream-1.4.3.tgz",
+      "integrity": "sha512-mlExGW4w71ebDJviH16lQLtZS32VKqsSfk80GCfUlwT/4/hNRFsoscrF/c++9xinkMzECL1uL9DDwXqFWkruPg==",
       "requires": {
         "buffer": "^5.2.1",
         "through": "^2.3.8"
@@ -32394,6 +33409,8 @@
       "dependencies": {
         "buffer": {
           "version": "5.7.1",
+          "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
+          "integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
           "requires": {
             "base64-js": "^1.3.1",
             "ieee754": "^1.1.13"
@@ -33264,8 +34281,7 @@
       "version": "1.2.3"
     },
     "wordwrap": {
-      "version": "1.0.0",
-      "dev": true
+      "version": "1.0.0"
     },
     "worker-farm": {
       "version": "1.7.0",

--- a/plugins/pa11y/package.json
+++ b/plugins/pa11y/package.json
@@ -13,7 +13,7 @@
   "license": "ISC",
   "dependencies": {
     "@dotcom-tool-kit/types": "^2.4.0",
-    "pa11y": "^6.2.3"
+    "pa11y-ci": "^3.0.1"
   },
   "repository": {
     "type": "git",

--- a/plugins/pa11y/src/tasks/pa11y.ts
+++ b/plugins/pa11y/src/tasks/pa11y.ts
@@ -1,52 +1,17 @@
-import { ToolKitError } from '@dotcom-tool-kit/error'
-import { styles } from '@dotcom-tool-kit/logger'
-import { readState } from '@dotcom-tool-kit/state'
+import { hookFork, waitOnExit } from '@dotcom-tool-kit/logger'
 import { Task } from '@dotcom-tool-kit/types'
 import { Pa11ySchema } from '@dotcom-tool-kit/types/lib/schema/pa11y'
-import pa11y from 'pa11y'
+import { fork } from 'child_process'
 
 export default class Pa11y extends Task<typeof Pa11ySchema> {
   static description = ''
 
   async run(): Promise<void> {
-    const reviewState = readState('review')
-    // if we've built a review app, test against that, not the app in the config
-    if (reviewState) {
-      this.options.host = `https://${reviewState.appName}.herokuapp.com`
-    }
+    const args = this.options.configFile ? ['--config', this.options.configFile] : []
 
-    if (!this.options.host) {
-      const error = new ToolKitError('no host option in your Tool Kit configuration')
-      error.details = `the ${styles.plugin(
-        'Pa11y'
-      )} plugin needs to know the URL it should be testing when running locally. add it to your configuration, e.g.:
-
-options:
-  '@dotcom-tool-kit/pa11y':
-    host: 'example.ft.com'`
-
-      throw error
-    }
-
-    const results = await pa11y(this.options.host, this.options)
-
-    this.logger.info(`Running Pa11y on ${results.pageUrl}, document title ${results.documentTitle}`)
-    if (results.issues?.length > 0) {
-      const errorList: Array<string> = []
-      const error = new ToolKitError('Pa11y found some errors')
-      results.issues.forEach((issue, i, issues) => {
-        const e = `Issue #${i + 1} of ${issues.length}: \n TypeCode: ${issue?.typeCode} \n Type: ${
-          issue?.type
-        } \n Message: ${issue?.message} \n Context: ${issue?.context} \n Selector: ${issue?.selector} \n`
-        errorList.push(
-          issue.typeCode === 1
-            ? 'Pa11y failed to run due to a technical fault:\n' + e
-            : 'Pa11y ran successfully but there were errors in the page:\n' + e
-        )
-      })
-      error.details = errorList.join('\n\n')
-      throw error
-    }
-    this.logger.info('Pa11y ran successfully, and there were no errors')
+    this.logger.info(`running pa11y-ci ${args.join(' ')}`)
+    const child = fork('pa11y-ci', args, { silent: true })
+    hookFork(this.logger, 'pa11y', child)
+    return waitOnExit('pa11y-ci', child)
   }
 }


### PR DESCRIPTION
Instead of passing static options to Pa11y, calling the `pa11y-ci` binary instead reads config defined in a `.pa11yci[.js[on]]` file. Seeing as this can be a `.js` file, the config can be dynamically generated, making the tooling much more flexible. This was how n-gage interfaced with Pa11y.

This also solves an issue that reported validation errors from Pa11y as internal errors within Pa11y.