### PR TITLE
CPP-902 Check staging app name for staging tests

### DIFF
--- a/plugins/n-test/src/tasks/n-test.ts
+++ b/plugins/n-test/src/tasks/n-test.ts
@@ -8,11 +8,11 @@ export default class NTest extends Task<typeof SmokeTestSchema> {
   static description = ''
 
   async run(): Promise<void> {
-    const reviewState = readState('review')
+    const appState = readState('review') ?? readState('staging')
 
-    // if we've built a review app, test against that, not the app in the config
-    if (reviewState) {
-      this.options.host = `https://${reviewState.appName}.herokuapp.com`
+    // if we've built a review or staging app, test against that, not the app in the config
+    if (appState) {
+      this.options.host = `https://${appState.appName}.herokuapp.com`
     }
 
     const smokeTest = new SmokeTest(this.options)

--- a/plugins/pa11y/.toolkitrc.yml
+++ b/plugins/pa11y/.toolkitrc.yml
@@ -3,4 +3,3 @@ plugins:
 
 hooks:
   'test:review': Pa11y
-  'test:staging': Pa11y


### PR DESCRIPTION
We want to run `n-test` for both review and staging Heroku apps, so we should check for written state for both in the `n-test` plugin. Previously, `n-test` was failing if run on a deploy from the `main` branch, as deployments write to the `staging` state rather than `review` state during testing, but the plugin only read the `review` state.

We had also set up the Pa11y plugin to run test when staging but I don't think this is necessary – n-gage never does it. We can add support for it later if desired.