### PR TITLE
Heroku plugin: filter appFormation array by type in scaleDyno.js

### DIFF
--- a/plugins/heroku/src/scaleDyno.ts
+++ b/plugins/heroku/src/scaleDyno.ts
@@ -18,8 +18,7 @@ async function scaleDyno(
     }
   })
 
-  const appFormationFilteredByType = appFormation.filter(formation => formation.type === type);
-  if (appFormationFilteredByType[0].quantity === quantity && appFormationFilteredByType[0].type === type) {
+  if (appFormation.some((formation) => formation.type === type && formation.quantity === quantity)) {
     return
   } else {
     throw new ToolKitError(`something went wrong with scaling the dyno`)

--- a/plugins/heroku/src/scaleDyno.ts
+++ b/plugins/heroku/src/scaleDyno.ts
@@ -18,7 +18,8 @@ async function scaleDyno(
     }
   })
 
-  if (appFormation[0].quantity === quantity && appFormation[0].type === type) {
+  const appFormationFilteredByType = appFormation.filter(formation => formation.type === type);
+  if (appFormationFilteredByType[0].quantity === quantity && appFormationFilteredByType[0].type === type) {
     return
   } else {
     throw new ToolKitError(`something went wrong with scaling the dyno`)


### PR DESCRIPTION
the appFormation array in scaleDyno.js try to check always the position 0 the type that it requested, but not always the type is in the position 0, so we have to be sure that it is in the position 0 always