### PR TITLE
Include commits from #245 in release-please release

### DIFF
--- a/core/cli/CHANGELOG.md
+++ b/core/cli/CHANGELOG.md
@@ -1,21 +1,16 @@
 # Changelog
 
-### Dependencies
+## [2.2.3](https://github.com/Financial-Times/dotcom-tool-kit/compare/dotcom-tool-kit-v2.2.2...dotcom-tool-kit-v2.2.3) (2022-07-12)
 
-* The following workspace dependencies were updated
-  * dependencies
-    * @dotcom-tool-kit/options bumped from ^2.0.0 to ^2.0.1
-    * @dotcom-tool-kit/types bumped from ^2.0.0 to ^2.1.0
 
 ### Dependencies
 
 * The following workspace dependencies were updated
   * devDependencies
-    * @dotcom-tool-kit/backend-app bumped from ^2.0.3 to ^2.0.4
-    * @dotcom-tool-kit/heroku bumped from ^2.0.2 to ^2.0.3
-    * @dotcom-tool-kit/circleci-heroku bumped from ^2.0.3 to ^2.0.4
-    * @dotcom-tool-kit/frontend-app bumped from ^2.1.1 to ^2.1.2
-    * @dotcom-tool-kit/eslint bumped from ^2.1.0 to ^2.1.1
+    * @dotcom-tool-kit/n-test bumped from ^2.0.3 to ^2.0.4
+
+## [2.2.2](https://github.com/Financial-Times/dotcom-tool-kit/compare/dotcom-tool-kit-v2.2.1...dotcom-tool-kit-v2.2.2) (2022-06-21)
+
 
 ### Dependencies
 
@@ -36,11 +31,18 @@
     * @dotcom-tool-kit/mocha bumped from ^2.0.2 to ^2.1.0
     * @dotcom-tool-kit/n-test bumped from ^2.0.2 to ^2.0.3
 
+## [2.2.1](https://github.com/Financial-Times/dotcom-tool-kit/compare/dotcom-tool-kit-v2.2.0...dotcom-tool-kit-v2.2.1) (2022-06-08)
+
+
 ### Dependencies
 
 * The following workspace dependencies were updated
   * devDependencies
-    * @dotcom-tool-kit/n-test bumped from ^2.0.3 to ^2.0.4
+    * @dotcom-tool-kit/backend-app bumped from ^2.0.3 to ^2.0.4
+    * @dotcom-tool-kit/heroku bumped from ^2.0.2 to ^2.0.3
+    * @dotcom-tool-kit/circleci-heroku bumped from ^2.0.3 to ^2.0.4
+    * @dotcom-tool-kit/frontend-app bumped from ^2.1.1 to ^2.1.2
+    * @dotcom-tool-kit/eslint bumped from ^2.1.0 to ^2.1.1
 
 ## [2.2.0](https://github.com/Financial-Times/dotcom-tool-kit/compare/dotcom-tool-kit-v2.1.0...dotcom-tool-kit-v2.2.0) (2022-06-07)
 
@@ -75,6 +77,16 @@
     * @dotcom-tool-kit/eslint bumped from ^2.0.0 to ^2.1.0
     * @dotcom-tool-kit/mocha bumped from ^2.0.0 to ^2.0.2
     * @dotcom-tool-kit/n-test bumped from ^2.0.0 to ^2.0.2
+
+## [2.1.1](https://github.com/Financial-Times/dotcom-tool-kit/compare/dotcom-tool-kit-v2.1.0...dotcom-tool-kit-v2.1.1) (2022-05-09)
+
+
+### Dependencies
+
+* The following workspace dependencies were updated
+  * dependencies
+    * @dotcom-tool-kit/options bumped from ^2.0.0 to ^2.0.1
+    * @dotcom-tool-kit/types bumped from ^2.0.0 to ^2.1.0
 
 ## [2.1.0](https://github.com/Financial-Times/dotcom-tool-kit/compare/dotcom-tool-kit-v2.0.0...dotcom-tool-kit-v2.1.0) (2022-05-03)
 

--- a/core/create/CHANGELOG.md
+++ b/core/create/CHANGELOG.md
@@ -1,16 +1,16 @@
 # Changelog
 
-### Dependencies
+## [2.0.6](https://github.com/Financial-Times/dotcom-tool-kit/compare/create-v2.0.5...create-v2.0.6) (2022-07-12)
 
-* The following workspace dependencies were updated
-  * dependencies
-    * dotcom-tool-kit bumped from ^2.0.0 to ^2.1.0
 
 ### Dependencies
 
 * The following workspace dependencies were updated
   * dependencies
-    * dotcom-tool-kit bumped from ^2.2.0 to ^2.2.1
+    * dotcom-tool-kit bumped from ^2.2.2 to ^2.2.3
+
+## [2.0.5](https://github.com/Financial-Times/dotcom-tool-kit/compare/create-v2.0.4...create-v2.0.5) (2022-06-21)
+
 
 ### Dependencies
 
@@ -19,11 +19,14 @@
     * @dotcom-tool-kit/types bumped from ^2.2.0 to ^2.3.0
     * dotcom-tool-kit bumped from ^2.2.1 to ^2.2.2
 
+## [2.0.4](https://github.com/Financial-Times/dotcom-tool-kit/compare/create-v2.0.3...create-v2.0.4) (2022-06-08)
+
+
 ### Dependencies
 
 * The following workspace dependencies were updated
   * dependencies
-    * dotcom-tool-kit bumped from ^2.2.2 to ^2.2.3
+    * dotcom-tool-kit bumped from ^2.2.0 to ^2.2.1
 
 ## [2.0.3](https://github.com/Financial-Times/dotcom-tool-kit/compare/create-v2.0.2...create-v2.0.3) (2022-06-07)
 
@@ -40,7 +43,7 @@
     * @dotcom-tool-kit/types bumped from ^2.1.0 to ^2.2.0
     * dotcom-tool-kit bumped from ^2.1.1 to ^2.2.0
 
-### [2.0.2](https://github.com/Financial-Times/dotcom-tool-kit/compare/create-v2.0.0...create-v2.0.2) (2022-05-06)
+### [2.0.2](https://github.com/Financial-Times/dotcom-tool-kit/compare/create-v2.0.1...create-v2.0.2) (2022-05-06)
 
 
 ### Bug Fixes
@@ -59,6 +62,15 @@
   * dependencies
     * @dotcom-tool-kit/types bumped from ^2.0.0 to ^2.1.0
     * dotcom-tool-kit bumped from ^2.1.0 to ^2.1.1
+
+### [2.0.1](https://github.com/Financial-Times/dotcom-tool-kit/compare/create-v2.0.0...create-v2.0.1) (2022-05-05)
+
+
+### Dependencies
+
+* The following workspace dependencies were updated
+  * dependencies
+    * dotcom-tool-kit bumped from ^2.0.0 to ^2.1.0
 
 ## [2.0.0](https://github.com/Financial-Times/dotcom-tool-kit/compare/create-v1.9.0...create-v2.0.0) (2022-04-19)
 

--- a/lib/logger/src/helpers.ts
+++ b/lib/logger/src/helpers.ts
@@ -38,7 +38,7 @@ function ansiTrim(message: string): string {
 export function hookConsole(logger: Logger, processName: string): () => void {
   function writeShim(stream: NodeJS.WriteStream, level: string): NodeJS.WriteStream['write'] {
     return (message: string, encoding?, writeCallback?) => {
-      // HACK allow winston logs from other threads to go straight through
+      // HACK: allow winston logs from other threads to go straight through
       if (message.startsWith('[')) {
         if (typeof encoding === 'function') {
           return stream.write(message, encoding)
@@ -55,7 +55,7 @@ export function hookConsole(logger: Logger, processName: string): () => void {
     }
   }
 
-  // TODO make this thread-safe?
+  // TODO: make this thread-safe?
   const { write: stdoutWrite } = process.stdout
   process.stdout.write = writeShim(process.stdout, 'info')
   const { write: stderrWrite } = process.stderr

--- a/lib/types/src/index.ts
+++ b/lib/types/src/index.ts
@@ -9,7 +9,7 @@ const packageJsonPath = path.resolve(__dirname, '../package.json')
 const packageJson = JSON.parse(fs.readFileSync(packageJsonPath, 'utf8'))
 const version: string = packageJson.version
 
-// uses Symbol.for, not Symbol, so they're compatible across different
+// uses Symbol.for, not Symbol, so that they're compatible across different
 // @dotcom-tool-kit/types instances
 
 // used as the name for the property we use to identify classes
@@ -112,10 +112,10 @@ abstract class Base {
       }
     }
 
-    // objectToCheck from a plugin is compatible with this CLI if its version
-    // is semver-compatible with the @dotcom-tool-kit/types included
-    // by the CLI (which is what's calling this). so, prepend ^ to
-    // our version, and check our version satisfies that.
+    // an 'objectToCheck' from a plugin is compatible with this CLI if its
+    // version is semver-compatible with the @dotcom-tool-kit/types included by
+    // the CLI (which is what's calling this). so, prepend ^ to our version,
+    // and check our version satisfies that.
 
     // this lets e.g. a CLI that includes types@2.2.0 load any plugin
     // that depends on any higher minor version of types.


### PR DESCRIPTION
Due to https://github.com/googleapis/release-please/issues/1533, the changes in #245, aren't included in the generated release-please PR. I've made a few tweaks to the documentation in all the packages that were changed and appended the relevant commit headers in the footer of the messages, which release-please will interpret as new commit messages to include. This means that as well as calculating the version bumps correctly, the changes will also be listed in the CHANGELOG files and in the release notes.