### PR TITLE
CPP-942 Fix crash when trying to scale undeployed Heroku apps

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -45,13 +45,13 @@
     },
     "core/cli": {
       "name": "dotcom-tool-kit",
-      "version": "2.2.2",
+      "version": "2.3.2",
       "license": "MIT",
       "dependencies": {
         "@dotcom-tool-kit/error": "^2.0.0",
-        "@dotcom-tool-kit/logger": "^2.0.0",
-        "@dotcom-tool-kit/options": "^2.0.3",
-        "@dotcom-tool-kit/types": "^2.3.0",
+        "@dotcom-tool-kit/logger": "^2.1.1",
+        "@dotcom-tool-kit/options": "^2.0.6",
+        "@dotcom-tool-kit/types": "^2.5.1",
         "@dotcom-tool-kit/wait-for-ok": "^2.0.0",
         "cosmiconfig": "^7.0.0",
         "lodash.merge": "^4.6.2",
@@ -64,17 +64,17 @@
         "dotcom-tool-kit": "bin/run"
       },
       "devDependencies": {
-        "@dotcom-tool-kit/babel": "^2.0.3",
-        "@dotcom-tool-kit/backend-app": "^2.0.5",
-        "@dotcom-tool-kit/circleci": "^2.1.1",
-        "@dotcom-tool-kit/circleci-heroku": "^2.0.5",
-        "@dotcom-tool-kit/eslint": "^2.1.2",
-        "@dotcom-tool-kit/frontend-app": "^2.1.3",
-        "@dotcom-tool-kit/heroku": "^2.0.4",
-        "@dotcom-tool-kit/mocha": "^2.1.0",
-        "@dotcom-tool-kit/n-test": "^2.0.3",
-        "@dotcom-tool-kit/npm": "^2.0.4",
-        "@dotcom-tool-kit/webpack": "^2.1.2",
+        "@dotcom-tool-kit/babel": "^2.0.6",
+        "@dotcom-tool-kit/backend-app": "^2.0.8",
+        "@dotcom-tool-kit/circleci": "^2.1.4",
+        "@dotcom-tool-kit/circleci-heroku": "^2.0.8",
+        "@dotcom-tool-kit/eslint": "^2.1.5",
+        "@dotcom-tool-kit/frontend-app": "^2.1.6",
+        "@dotcom-tool-kit/heroku": "^2.0.7",
+        "@dotcom-tool-kit/mocha": "^2.1.3",
+        "@dotcom-tool-kit/n-test": "^2.1.1",
+        "@dotcom-tool-kit/npm": "^2.0.7",
+        "@dotcom-tool-kit/webpack": "^2.1.5",
         "@jest/globals": "^27.4.6",
         "@types/lodash.merge": "^4.6.6",
         "@types/node": "^12.20.24",
@@ -107,15 +107,15 @@
     },
     "core/create": {
       "name": "@dotcom-tool-kit/create",
-      "version": "2.0.5",
+      "version": "2.1.2",
       "license": "ISC",
       "dependencies": {
         "@dotcom-tool-kit/error": "^2.0.0",
-        "@dotcom-tool-kit/logger": "^2.0.0",
-        "@dotcom-tool-kit/types": "^2.3.0",
+        "@dotcom-tool-kit/logger": "^2.1.1",
+        "@dotcom-tool-kit/types": "^2.5.1",
         "@financial-times/package-json": "^3.0.0",
         "@quarterto/parse-makefile-rules": "^1.1.0",
-        "dotcom-tool-kit": "^2.2.2",
+        "dotcom-tool-kit": "^2.3.2",
         "import-cwd": "^3.0.0",
         "js-yaml": "^4.1.0",
         "komatsu": "^1.3.0",
@@ -173,7 +173,7 @@
     },
     "lib/logger": {
       "name": "@dotcom-tool-kit/logger",
-      "version": "2.0.0",
+      "version": "2.1.1",
       "license": "ISC",
       "dependencies": {
         "@dotcom-tool-kit/error": "^2.0.0",
@@ -189,10 +189,10 @@
     },
     "lib/options": {
       "name": "@dotcom-tool-kit/options",
-      "version": "2.0.3",
+      "version": "2.0.6",
       "license": "ISC",
       "dependencies": {
-        "@dotcom-tool-kit/types": "^2.3.0"
+        "@dotcom-tool-kit/types": "^2.5.1"
       }
     },
     "lib/package-json-hook": {
@@ -214,11 +214,11 @@
     },
     "lib/types": {
       "name": "@dotcom-tool-kit/types",
-      "version": "2.3.0",
+      "version": "2.5.1",
       "license": "ISC",
       "dependencies": {
         "@dotcom-tool-kit/error": "^2.0.0",
-        "@dotcom-tool-kit/logger": "^2.0.0",
+        "@dotcom-tool-kit/logger": "^2.1.1",
         "lodash.isplainobject": "^4.0.6",
         "lodash.mapvalues": "^4.6.0",
         "semver": "^7.3.7"
@@ -234,12 +234,12 @@
     },
     "lib/vault": {
       "name": "@dotcom-tool-kit/vault",
-      "version": "2.0.3",
+      "version": "2.0.6",
       "license": "ISC",
       "dependencies": {
         "@dotcom-tool-kit/error": "^2.0.0",
-        "@dotcom-tool-kit/options": "^2.0.3",
-        "@dotcom-tool-kit/types": "^2.3.0",
+        "@dotcom-tool-kit/options": "^2.0.6",
+        "@dotcom-tool-kit/types": "^2.5.1",
         "@financial-times/n-fetch": "^1.0.0-beta.7",
         "fs": "0.0.1-security",
         "os": "^0.1.2",
@@ -2421,8 +2421,10 @@
       }
     },
     "node_modules/@financial-times/n-test": {
-      "version": "3.1.0",
-      "license": "ISC",
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/@financial-times/n-test/-/n-test-4.0.1.tgz",
+      "integrity": "sha512-QWT5akYnU4DOe4m/masWRiT9paV3E2npL+nsuZASoC53+UxeBDGqqiQ286LR+403PTRUdGo/2uajBQP0kOmDnA==",
+      "hasInstallScript": true,
       "dependencies": {
         "chalk": "^2.3.0",
         "commander": "^3.0.0",
@@ -2437,7 +2439,8 @@
         "n-test": "bin/n-test.js"
       },
       "engines": {
-        "node": "12.x"
+        "node": "14.x || 16.x",
+        "npm": "7.x || 8.x"
       }
     },
     "node_modules/@financial-times/n-test/node_modules/ansi-styles": {
@@ -19888,12 +19891,12 @@
     },
     "plugins/babel": {
       "name": "@dotcom-tool-kit/babel",
-      "version": "2.0.3",
+      "version": "2.0.6",
       "license": "MIT",
       "dependencies": {
         "@dotcom-tool-kit/error": "^2.0.0",
-        "@dotcom-tool-kit/logger": "^2.0.0",
-        "@dotcom-tool-kit/types": "^2.3.0",
+        "@dotcom-tool-kit/logger": "^2.1.1",
+        "@dotcom-tool-kit/types": "^2.5.1",
         "fast-glob": "^3.2.11"
       },
       "devDependencies": {
@@ -19908,12 +19911,12 @@
     },
     "plugins/backend-app": {
       "name": "@dotcom-tool-kit/backend-app",
-      "version": "2.0.5",
+      "version": "2.0.8",
       "license": "ISC",
       "dependencies": {
-        "@dotcom-tool-kit/circleci-heroku": "^2.0.5",
-        "@dotcom-tool-kit/node": "^2.1.0",
-        "@dotcom-tool-kit/npm": "^2.0.4"
+        "@dotcom-tool-kit/circleci-heroku": "^2.0.8",
+        "@dotcom-tool-kit/node": "^2.1.3",
+        "@dotcom-tool-kit/npm": "^2.0.7"
       },
       "peerDependencies": {
         "dotcom-tool-kit": "2.x"
@@ -19921,13 +19924,13 @@
     },
     "plugins/circleci": {
       "name": "@dotcom-tool-kit/circleci",
-      "version": "2.1.1",
+      "version": "2.1.4",
       "license": "ISC",
       "dependencies": {
         "@dotcom-tool-kit/error": "^2.0.0",
-        "@dotcom-tool-kit/logger": "^2.0.0",
+        "@dotcom-tool-kit/logger": "^2.1.1",
         "@dotcom-tool-kit/state": "^2.0.0",
-        "@dotcom-tool-kit/types": "^2.3.0",
+        "@dotcom-tool-kit/types": "^2.5.1",
         "js-yaml": "^4.1.0",
         "lodash.isequal": "^4.5.0"
       },
@@ -19944,11 +19947,11 @@
     },
     "plugins/circleci-heroku": {
       "name": "@dotcom-tool-kit/circleci-heroku",
-      "version": "2.0.5",
+      "version": "2.0.8",
       "license": "ISC",
       "dependencies": {
-        "@dotcom-tool-kit/circleci": "^2.1.1",
-        "@dotcom-tool-kit/heroku": "^2.0.4"
+        "@dotcom-tool-kit/circleci": "^2.1.4",
+        "@dotcom-tool-kit/heroku": "^2.0.7"
       },
       "peerDependencies": {
         "dotcom-tool-kit": "2.x"
@@ -19956,12 +19959,12 @@
     },
     "plugins/circleci-npm": {
       "name": "@dotcom-tool-kit/circleci-npm",
-      "version": "2.0.4",
+      "version": "2.0.7",
       "license": "ISC",
       "dependencies": {
-        "@dotcom-tool-kit/circleci": "^2.1.1",
-        "@dotcom-tool-kit/npm": "^2.0.4",
-        "@dotcom-tool-kit/types": "^2.3.0"
+        "@dotcom-tool-kit/circleci": "^2.1.4",
+        "@dotcom-tool-kit/npm": "^2.0.7",
+        "@dotcom-tool-kit/types": "^2.5.1"
       },
       "peerDependencies": {
         "dotcom-tool-kit": "2.x"
@@ -19969,12 +19972,12 @@
     },
     "plugins/eslint": {
       "name": "@dotcom-tool-kit/eslint",
-      "version": "2.1.2",
+      "version": "2.1.5",
       "license": "ISC",
       "dependencies": {
         "@dotcom-tool-kit/error": "^2.0.0",
-        "@dotcom-tool-kit/logger": "^2.0.0",
-        "@dotcom-tool-kit/types": "^2.3.0"
+        "@dotcom-tool-kit/logger": "^2.1.1",
+        "@dotcom-tool-kit/types": "^2.5.1"
       },
       "devDependencies": {
         "@jest/globals": "^27.4.6",
@@ -20181,11 +20184,11 @@
     },
     "plugins/frontend-app": {
       "name": "@dotcom-tool-kit/frontend-app",
-      "version": "2.1.3",
+      "version": "2.1.6",
       "license": "ISC",
       "dependencies": {
-        "@dotcom-tool-kit/backend-app": "^2.0.5",
-        "@dotcom-tool-kit/webpack": "^2.1.2"
+        "@dotcom-tool-kit/backend-app": "^2.0.8",
+        "@dotcom-tool-kit/webpack": "^2.1.5"
       },
       "peerDependencies": {
         "dotcom-tool-kit": "2.x"
@@ -20193,16 +20196,16 @@
     },
     "plugins/heroku": {
       "name": "@dotcom-tool-kit/heroku",
-      "version": "2.0.4",
+      "version": "2.0.7",
       "license": "ISC",
       "dependencies": {
         "@dotcom-tool-kit/error": "^2.0.0",
-        "@dotcom-tool-kit/logger": "^2.0.0",
-        "@dotcom-tool-kit/npm": "^2.0.4",
+        "@dotcom-tool-kit/logger": "^2.1.1",
+        "@dotcom-tool-kit/npm": "^2.0.7",
         "@dotcom-tool-kit/package-json-hook": "^2.1.0",
         "@dotcom-tool-kit/state": "^2.0.0",
-        "@dotcom-tool-kit/types": "^2.3.0",
-        "@dotcom-tool-kit/vault": "^2.0.3",
+        "@dotcom-tool-kit/types": "^2.5.1",
+        "@dotcom-tool-kit/vault": "^2.0.6",
         "@dotcom-tool-kit/wait-for-ok": "^2.0.0",
         "@octokit/request": "^5.6.0",
         "@octokit/request-error": "^2.1.0",
@@ -20222,7 +20225,7 @@
     },
     "plugins/husky-npm": {
       "name": "@dotcom-tool-kit/husky-npm",
-      "version": "2.1.0",
+      "version": "2.2.0",
       "license": "ISC",
       "dependencies": {
         "@dotcom-tool-kit/package-json-hook": "^2.1.0"
@@ -20234,11 +20237,11 @@
     },
     "plugins/jest": {
       "name": "@dotcom-tool-kit/jest",
-      "version": "2.0.3",
+      "version": "2.0.6",
       "license": "ISC",
       "dependencies": {
-        "@dotcom-tool-kit/logger": "^2.0.0",
-        "@dotcom-tool-kit/types": "^2.3.0"
+        "@dotcom-tool-kit/logger": "^2.1.1",
+        "@dotcom-tool-kit/types": "^2.5.1"
       },
       "devDependencies": {
         "@jest/globals": "^27.4.6",
@@ -20251,12 +20254,12 @@
     },
     "plugins/lint-staged": {
       "name": "@dotcom-tool-kit/lint-staged",
-      "version": "2.1.3",
+      "version": "2.1.6",
       "license": "ISC",
       "dependencies": {
-        "@dotcom-tool-kit/logger": "^2.0.0",
+        "@dotcom-tool-kit/logger": "^2.1.1",
         "@dotcom-tool-kit/package-json-hook": "^2.1.0",
-        "@dotcom-tool-kit/types": "^2.3.0",
+        "@dotcom-tool-kit/types": "^2.5.1",
         "lint-staged": "^11.2.3"
       },
       "peerDependencies": {
@@ -20265,12 +20268,12 @@
     },
     "plugins/lint-staged-npm": {
       "name": "@dotcom-tool-kit/lint-staged-npm",
-      "version": "2.0.4",
+      "version": "2.0.7",
       "license": "ISC",
       "dependencies": {
-        "@dotcom-tool-kit/husky-npm": "^2.1.0",
-        "@dotcom-tool-kit/lint-staged": "^2.1.3",
-        "@dotcom-tool-kit/options": "^2.0.3"
+        "@dotcom-tool-kit/husky-npm": "^2.2.0",
+        "@dotcom-tool-kit/lint-staged": "^2.1.6",
+        "@dotcom-tool-kit/options": "^2.0.6"
       },
       "peerDependencies": {
         "dotcom-tool-kit": "2.x"
@@ -20328,12 +20331,12 @@
     },
     "plugins/mocha": {
       "name": "@dotcom-tool-kit/mocha",
-      "version": "2.1.0",
+      "version": "2.1.3",
       "license": "ISC",
       "dependencies": {
         "@dotcom-tool-kit/error": "^2.0.0",
-        "@dotcom-tool-kit/logger": "^2.0.0",
-        "@dotcom-tool-kit/types": "^2.3.0",
+        "@dotcom-tool-kit/logger": "^2.1.1",
+        "@dotcom-tool-kit/types": "^2.5.1",
         "fs": "0.0.1-security",
         "glob": "^7.1.7",
         "mocha": "^8.3.2"
@@ -20350,13 +20353,13 @@
     },
     "plugins/n-test": {
       "name": "@dotcom-tool-kit/n-test",
-      "version": "2.0.3",
+      "version": "2.1.1",
       "license": "ISC",
       "dependencies": {
-        "@dotcom-tool-kit/logger": "^2.0.0",
+        "@dotcom-tool-kit/logger": "^2.1.1",
         "@dotcom-tool-kit/state": "^2.0.0",
-        "@dotcom-tool-kit/types": "^2.3.0",
-        "@financial-times/n-test": "^3.0.1"
+        "@dotcom-tool-kit/types": "^2.5.1",
+        "@financial-times/n-test": "^4.0.1"
       },
       "devDependencies": {
         "@jest/globals": "^27.4.6",
@@ -20369,14 +20372,14 @@
     },
     "plugins/next-router": {
       "name": "@dotcom-tool-kit/next-router",
-      "version": "2.0.3",
+      "version": "2.0.6",
       "license": "ISC",
       "dependencies": {
         "@dotcom-tool-kit/error": "^2.0.0",
-        "@dotcom-tool-kit/logger": "^2.0.0",
+        "@dotcom-tool-kit/logger": "^2.1.1",
         "@dotcom-tool-kit/state": "^2.0.0",
-        "@dotcom-tool-kit/types": "^2.3.0",
-        "@dotcom-tool-kit/vault": "^2.0.3",
+        "@dotcom-tool-kit/types": "^2.5.1",
+        "@dotcom-tool-kit/vault": "^2.0.6",
         "ft-next-router": "^1.0.0"
       },
       "peerDependencies": {
@@ -20385,13 +20388,13 @@
     },
     "plugins/node": {
       "name": "@dotcom-tool-kit/node",
-      "version": "2.1.0",
+      "version": "2.1.3",
       "license": "ISC",
       "dependencies": {
         "@dotcom-tool-kit/error": "^2.0.0",
         "@dotcom-tool-kit/state": "^2.0.0",
-        "@dotcom-tool-kit/types": "^2.3.0",
-        "@dotcom-tool-kit/vault": "^2.0.3",
+        "@dotcom-tool-kit/types": "^2.5.1",
+        "@dotcom-tool-kit/vault": "^2.0.6",
         "get-port": "^5.1.1",
         "wait-port": "^0.2.9"
       },
@@ -20401,13 +20404,13 @@
     },
     "plugins/nodemon": {
       "name": "@dotcom-tool-kit/nodemon",
-      "version": "2.0.3",
+      "version": "2.0.7",
       "license": "ISC",
       "dependencies": {
         "@dotcom-tool-kit/error": "^2.0.0",
         "@dotcom-tool-kit/state": "^2.0.0",
-        "@dotcom-tool-kit/types": "^2.3.0",
-        "@dotcom-tool-kit/vault": "^2.0.3",
+        "@dotcom-tool-kit/types": "^2.5.1",
+        "@dotcom-tool-kit/vault": "^2.0.6",
         "get-port": "^5.1.1"
       },
       "devDependencies": {
@@ -20420,14 +20423,14 @@
     },
     "plugins/npm": {
       "name": "@dotcom-tool-kit/npm",
-      "version": "2.0.4",
+      "version": "2.0.7",
       "license": "ISC",
       "dependencies": {
         "@actions/exec": "^1.1.0",
         "@dotcom-tool-kit/error": "^2.0.0",
         "@dotcom-tool-kit/package-json-hook": "^2.1.0",
         "@dotcom-tool-kit/state": "^2.0.0",
-        "@dotcom-tool-kit/types": "^2.3.0",
+        "@dotcom-tool-kit/types": "^2.5.1",
         "libnpmpack": "^3.1.0",
         "libnpmpublish": "^5.0.1",
         "pacote": "^12.0.3",
@@ -20578,10 +20581,10 @@
     },
     "plugins/pa11y": {
       "name": "@dotcom-tool-kit/pa11y",
-      "version": "0.1.3",
+      "version": "0.3.1",
       "license": "ISC",
       "dependencies": {
-        "@dotcom-tool-kit/types": "^2.3.0",
+        "@dotcom-tool-kit/types": "^2.5.1",
         "pa11y-ci": "^3.0.1"
       },
       "devDependencies": {
@@ -20593,13 +20596,13 @@
     },
     "plugins/prettier": {
       "name": "@dotcom-tool-kit/prettier",
-      "version": "2.0.4",
+      "version": "2.0.7",
       "license": "ISC",
       "dependencies": {
         "@dotcom-tool-kit/error": "^2.0.0",
-        "@dotcom-tool-kit/logger": "^2.0.0",
+        "@dotcom-tool-kit/logger": "^2.1.1",
         "@dotcom-tool-kit/package-json-hook": "^2.1.0",
-        "@dotcom-tool-kit/types": "^2.3.0",
+        "@dotcom-tool-kit/types": "^2.5.1",
         "fast-glob": "^3.2.7",
         "hook-std": "^2.0.0",
         "prettier": "^2.2.1"
@@ -20616,11 +20619,11 @@
     },
     "plugins/secret-squirrel": {
       "name": "@dotcom-tool-kit/secret-squirrel",
-      "version": "1.0.2",
+      "version": "1.0.5",
       "license": "ISC",
       "dependencies": {
-        "@dotcom-tool-kit/logger": "^2.0.0",
-        "@dotcom-tool-kit/types": "^2.3.0"
+        "@dotcom-tool-kit/logger": "^2.1.1",
+        "@dotcom-tool-kit/types": "^2.5.1"
       },
       "peerDependencies": {
         "@financial-times/secret-squirrel": "2.x",
@@ -20629,12 +20632,12 @@
     },
     "plugins/upload-assets-to-s3": {
       "name": "@dotcom-tool-kit/upload-assets-to-s3",
-      "version": "2.0.3",
+      "version": "2.0.6",
       "license": "ISC",
       "dependencies": {
         "@dotcom-tool-kit/error": "^2.0.0",
-        "@dotcom-tool-kit/logger": "^2.0.0",
-        "@dotcom-tool-kit/types": "^2.3.0",
+        "@dotcom-tool-kit/logger": "^2.1.1",
+        "@dotcom-tool-kit/types": "^2.5.1",
         "aws-sdk": "^2.901.0",
         "glob": "^7.1.6",
         "mime": "^2.5.2"
@@ -20653,12 +20656,12 @@
     },
     "plugins/webpack": {
       "name": "@dotcom-tool-kit/webpack",
-      "version": "2.1.2",
+      "version": "2.1.5",
       "license": "MIT",
       "dependencies": {
         "@dotcom-tool-kit/error": "^2.0.0",
-        "@dotcom-tool-kit/logger": "^2.0.0",
-        "@dotcom-tool-kit/types": "^2.3.0",
+        "@dotcom-tool-kit/logger": "^2.1.1",
+        "@dotcom-tool-kit/types": "^2.5.1",
         "webpack-cli": "^4.6.0"
       },
       "devDependencies": {
@@ -21908,8 +21911,8 @@
       "requires": {
         "@babel/preset-env": "^7.16.11",
         "@dotcom-tool-kit/error": "^2.0.0",
-        "@dotcom-tool-kit/logger": "^2.0.0",
-        "@dotcom-tool-kit/types": "^2.3.0",
+        "@dotcom-tool-kit/logger": "^2.1.1",
+        "@dotcom-tool-kit/types": "^2.5.1",
         "@jest/globals": "^27.4.6",
         "fast-glob": "^3.2.11",
         "winston": "^3.5.1"
@@ -21918,18 +21921,18 @@
     "@dotcom-tool-kit/backend-app": {
       "version": "file:plugins/backend-app",
       "requires": {
-        "@dotcom-tool-kit/circleci-heroku": "^2.0.5",
-        "@dotcom-tool-kit/node": "^2.1.0",
-        "@dotcom-tool-kit/npm": "^2.0.4"
+        "@dotcom-tool-kit/circleci-heroku": "^2.0.8",
+        "@dotcom-tool-kit/node": "^2.1.3",
+        "@dotcom-tool-kit/npm": "^2.0.7"
       }
     },
     "@dotcom-tool-kit/circleci": {
       "version": "file:plugins/circleci",
       "requires": {
         "@dotcom-tool-kit/error": "^2.0.0",
-        "@dotcom-tool-kit/logger": "^2.0.0",
+        "@dotcom-tool-kit/logger": "^2.1.1",
         "@dotcom-tool-kit/state": "^2.0.0",
-        "@dotcom-tool-kit/types": "^2.3.0",
+        "@dotcom-tool-kit/types": "^2.5.1",
         "@jest/globals": "^27.4.6",
         "@types/jest": "^27.4.0",
         "@types/js-yaml": "^4.0.3",
@@ -21942,24 +21945,24 @@
     "@dotcom-tool-kit/circleci-heroku": {
       "version": "file:plugins/circleci-heroku",
       "requires": {
-        "@dotcom-tool-kit/circleci": "^2.1.1",
-        "@dotcom-tool-kit/heroku": "^2.0.4"
+        "@dotcom-tool-kit/circleci": "^2.1.4",
+        "@dotcom-tool-kit/heroku": "^2.0.7"
       }
     },
     "@dotcom-tool-kit/circleci-npm": {
       "version": "file:plugins/circleci-npm",
       "requires": {
-        "@dotcom-tool-kit/circleci": "^2.1.1",
-        "@dotcom-tool-kit/npm": "^2.0.4",
-        "@dotcom-tool-kit/types": "^2.3.0"
+        "@dotcom-tool-kit/circleci": "^2.1.4",
+        "@dotcom-tool-kit/npm": "^2.0.7",
+        "@dotcom-tool-kit/types": "^2.5.1"
       }
     },
     "@dotcom-tool-kit/create": {
       "version": "file:core/create",
       "requires": {
         "@dotcom-tool-kit/error": "^2.0.0",
-        "@dotcom-tool-kit/logger": "^2.0.0",
-        "@dotcom-tool-kit/types": "^2.3.0",
+        "@dotcom-tool-kit/logger": "^2.1.1",
+        "@dotcom-tool-kit/types": "^2.5.1",
         "@financial-times/package-json": "^3.0.0",
         "@quarterto/parse-makefile-rules": "^1.1.0",
         "@types/financial-times__package-json": "^1.9.0",
@@ -21968,7 +21971,7 @@
         "@types/node": "^12.20.24",
         "@types/pacote": "^11.1.3",
         "@types/prompts": "^2.0.14",
-        "dotcom-tool-kit": "^2.2.2",
+        "dotcom-tool-kit": "^2.3.2",
         "import-cwd": "^3.0.0",
         "js-yaml": "^4.1.0",
         "komatsu": "^1.3.0",
@@ -21991,8 +21994,8 @@
       "version": "file:plugins/eslint",
       "requires": {
         "@dotcom-tool-kit/error": "^2.0.0",
-        "@dotcom-tool-kit/logger": "^2.0.0",
-        "@dotcom-tool-kit/types": "^2.3.0",
+        "@dotcom-tool-kit/logger": "^2.1.1",
+        "@dotcom-tool-kit/types": "^2.5.1",
         "@jest/globals": "^27.4.6",
         "@types/eslint": "^7.2.13",
         "eslint": "^8.15.0",
@@ -22132,20 +22135,20 @@
     "@dotcom-tool-kit/frontend-app": {
       "version": "file:plugins/frontend-app",
       "requires": {
-        "@dotcom-tool-kit/backend-app": "^2.0.5",
-        "@dotcom-tool-kit/webpack": "^2.1.2"
+        "@dotcom-tool-kit/backend-app": "^2.0.8",
+        "@dotcom-tool-kit/webpack": "^2.1.5"
       }
     },
     "@dotcom-tool-kit/heroku": {
       "version": "file:plugins/heroku",
       "requires": {
         "@dotcom-tool-kit/error": "^2.0.0",
-        "@dotcom-tool-kit/logger": "^2.0.0",
-        "@dotcom-tool-kit/npm": "^2.0.4",
+        "@dotcom-tool-kit/logger": "^2.1.1",
+        "@dotcom-tool-kit/npm": "^2.0.7",
         "@dotcom-tool-kit/package-json-hook": "^2.1.0",
         "@dotcom-tool-kit/state": "^2.0.0",
-        "@dotcom-tool-kit/types": "^2.3.0",
-        "@dotcom-tool-kit/vault": "^2.0.3",
+        "@dotcom-tool-kit/types": "^2.5.1",
+        "@dotcom-tool-kit/vault": "^2.0.6",
         "@dotcom-tool-kit/wait-for-ok": "^2.0.0",
         "@octokit/request": "^5.6.0",
         "@octokit/request-error": "^2.1.0",
@@ -22167,8 +22170,8 @@
     "@dotcom-tool-kit/jest": {
       "version": "file:plugins/jest",
       "requires": {
-        "@dotcom-tool-kit/logger": "^2.0.0",
-        "@dotcom-tool-kit/types": "^2.3.0",
+        "@dotcom-tool-kit/logger": "^2.1.1",
+        "@dotcom-tool-kit/types": "^2.5.1",
         "@jest/globals": "^27.4.6",
         "winston": "^3.5.1"
       }
@@ -22176,9 +22179,9 @@
     "@dotcom-tool-kit/lint-staged": {
       "version": "file:plugins/lint-staged",
       "requires": {
-        "@dotcom-tool-kit/logger": "^2.0.0",
+        "@dotcom-tool-kit/logger": "^2.1.1",
         "@dotcom-tool-kit/package-json-hook": "^2.1.0",
-        "@dotcom-tool-kit/types": "^2.3.0",
+        "@dotcom-tool-kit/types": "^2.5.1",
         "lint-staged": "^11.2.3"
       },
       "dependencies": {
@@ -22218,9 +22221,9 @@
     "@dotcom-tool-kit/lint-staged-npm": {
       "version": "file:plugins/lint-staged-npm",
       "requires": {
-        "@dotcom-tool-kit/husky-npm": "^2.1.0",
-        "@dotcom-tool-kit/lint-staged": "^2.1.3",
-        "@dotcom-tool-kit/options": "^2.0.3"
+        "@dotcom-tool-kit/husky-npm": "^2.2.0",
+        "@dotcom-tool-kit/lint-staged": "^2.1.6",
+        "@dotcom-tool-kit/options": "^2.0.6"
       }
     },
     "@dotcom-tool-kit/logger": {
@@ -22239,8 +22242,8 @@
       "version": "file:plugins/mocha",
       "requires": {
         "@dotcom-tool-kit/error": "^2.0.0",
-        "@dotcom-tool-kit/logger": "^2.0.0",
-        "@dotcom-tool-kit/types": "^2.3.0",
+        "@dotcom-tool-kit/logger": "^2.1.1",
+        "@dotcom-tool-kit/types": "^2.5.1",
         "@jest/globals": "^27.4.6",
         "@types/glob": "^7.1.3",
         "@types/mocha": "^8.2.2",
@@ -22253,10 +22256,10 @@
     "@dotcom-tool-kit/n-test": {
       "version": "file:plugins/n-test",
       "requires": {
-        "@dotcom-tool-kit/logger": "^2.0.0",
+        "@dotcom-tool-kit/logger": "^2.1.1",
         "@dotcom-tool-kit/state": "^2.0.0",
-        "@dotcom-tool-kit/types": "^2.3.0",
-        "@financial-times/n-test": "^3.0.1",
+        "@dotcom-tool-kit/types": "^2.5.1",
+        "@financial-times/n-test": "^4.0.1",
         "@jest/globals": "^27.4.6",
         "@types/jest": "^27.4.0",
         "winston": "^3.5.1"
@@ -22266,10 +22269,10 @@
       "version": "file:plugins/next-router",
       "requires": {
         "@dotcom-tool-kit/error": "^2.0.0",
-        "@dotcom-tool-kit/logger": "^2.0.0",
+        "@dotcom-tool-kit/logger": "^2.1.1",
         "@dotcom-tool-kit/state": "^2.0.0",
-        "@dotcom-tool-kit/types": "^2.3.0",
-        "@dotcom-tool-kit/vault": "^2.0.3",
+        "@dotcom-tool-kit/types": "^2.5.1",
+        "@dotcom-tool-kit/vault": "^2.0.6",
         "ft-next-router": "^1.0.0"
       }
     },
@@ -22278,8 +22281,8 @@
       "requires": {
         "@dotcom-tool-kit/error": "^2.0.0",
         "@dotcom-tool-kit/state": "^2.0.0",
-        "@dotcom-tool-kit/types": "^2.3.0",
-        "@dotcom-tool-kit/vault": "^2.0.3",
+        "@dotcom-tool-kit/types": "^2.5.1",
+        "@dotcom-tool-kit/vault": "^2.0.6",
         "get-port": "^5.1.1",
         "wait-port": "^0.2.9"
       }
@@ -22289,8 +22292,8 @@
       "requires": {
         "@dotcom-tool-kit/error": "^2.0.0",
         "@dotcom-tool-kit/state": "^2.0.0",
-        "@dotcom-tool-kit/types": "^2.3.0",
-        "@dotcom-tool-kit/vault": "^2.0.3",
+        "@dotcom-tool-kit/types": "^2.5.1",
+        "@dotcom-tool-kit/vault": "^2.0.6",
         "@types/nodemon": "^1.19.1",
         "get-port": "^5.1.1"
       }
@@ -22302,7 +22305,7 @@
         "@dotcom-tool-kit/error": "^2.0.0",
         "@dotcom-tool-kit/package-json-hook": "^2.1.0",
         "@dotcom-tool-kit/state": "^2.0.0",
-        "@dotcom-tool-kit/types": "^2.3.0",
+        "@dotcom-tool-kit/types": "^2.5.1",
         "@types/libnpmpublish": "^4.0.1",
         "@types/pacote": "^11.1.3",
         "@types/tar": "^6.1.1",
@@ -22413,15 +22416,15 @@
     "@dotcom-tool-kit/options": {
       "version": "file:lib/options",
       "requires": {
-        "@dotcom-tool-kit/types": "^2.3.0"
+        "@dotcom-tool-kit/types": "^2.5.1"
       }
     },
     "@dotcom-tool-kit/pa11y": {
       "version": "file:plugins/pa11y",
       "requires": {
-        "@dotcom-tool-kit/types": "^2.3.0",
+        "@dotcom-tool-kit/types": "^2.5.1",
         "@types/pa11y": "^5.3.4",
-        "pa11y-ci": "*"
+        "pa11y-ci": "^3.0.1"
       }
     },
     "@dotcom-tool-kit/package-json-hook": {
@@ -22436,9 +22439,9 @@
       "version": "file:plugins/prettier",
       "requires": {
         "@dotcom-tool-kit/error": "^2.0.0",
-        "@dotcom-tool-kit/logger": "^2.0.0",
+        "@dotcom-tool-kit/logger": "^2.1.1",
         "@dotcom-tool-kit/package-json-hook": "^2.1.0",
-        "@dotcom-tool-kit/types": "^2.3.0",
+        "@dotcom-tool-kit/types": "^2.5.1",
         "@jest/globals": "^27.4.6",
         "fast-glob": "^3.2.7",
         "hook-std": "^2.0.0",
@@ -22474,8 +22477,8 @@
     "@dotcom-tool-kit/secret-squirrel": {
       "version": "file:plugins/secret-squirrel",
       "requires": {
-        "@dotcom-tool-kit/logger": "^2.0.0",
-        "@dotcom-tool-kit/types": "^2.3.0"
+        "@dotcom-tool-kit/logger": "^2.1.1",
+        "@dotcom-tool-kit/types": "^2.5.1"
       }
     },
     "@dotcom-tool-kit/state": {
@@ -22485,7 +22488,7 @@
       "version": "file:lib/types",
       "requires": {
         "@dotcom-tool-kit/error": "^2.0.0",
-        "@dotcom-tool-kit/logger": "^2.0.0",
+        "@dotcom-tool-kit/logger": "^2.1.1",
         "@jest/globals": "^27.4.6",
         "@types/lodash.isplainobject": "^4.0.6",
         "@types/lodash.mapvalues": "^4.6.6",
@@ -22502,8 +22505,8 @@
       "requires": {
         "@aws-sdk/types": "^3.13.1",
         "@dotcom-tool-kit/error": "^2.0.0",
-        "@dotcom-tool-kit/logger": "^2.0.0",
-        "@dotcom-tool-kit/types": "^2.3.0",
+        "@dotcom-tool-kit/logger": "^2.1.1",
+        "@dotcom-tool-kit/types": "^2.5.1",
         "@jest/globals": "^27.4.6",
         "@types/glob": "^7.1.3",
         "@types/jest": "^27.4.0",
@@ -22518,8 +22521,8 @@
       "version": "file:lib/vault",
       "requires": {
         "@dotcom-tool-kit/error": "^2.0.0",
-        "@dotcom-tool-kit/options": "^2.0.3",
-        "@dotcom-tool-kit/types": "^2.3.0",
+        "@dotcom-tool-kit/options": "^2.0.6",
+        "@dotcom-tool-kit/types": "^2.5.1",
         "@financial-times/n-fetch": "^1.0.0-beta.7",
         "@types/jest": "^27.0.2",
         "fs": "0.0.1-security",
@@ -22557,8 +22560,8 @@
       "version": "file:plugins/webpack",
       "requires": {
         "@dotcom-tool-kit/error": "^2.0.0",
-        "@dotcom-tool-kit/logger": "^2.0.0",
-        "@dotcom-tool-kit/types": "^2.3.0",
+        "@dotcom-tool-kit/logger": "^2.1.1",
+        "@dotcom-tool-kit/types": "^2.5.1",
         "@jest/globals": "^27.4.6",
         "ts-node": "^10.0.0",
         "webpack": "^4.42.1",
@@ -22700,7 +22703,9 @@
       }
     },
     "@financial-times/n-test": {
-      "version": "3.1.0",
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/@financial-times/n-test/-/n-test-4.0.1.tgz",
+      "integrity": "sha512-QWT5akYnU4DOe4m/masWRiT9paV3E2npL+nsuZASoC53+UxeBDGqqiQ286LR+403PTRUdGo/2uajBQP0kOmDnA==",
       "requires": {
         "chalk": "^2.3.0",
         "commander": "^3.0.0",
@@ -26181,22 +26186,22 @@
     "dotcom-tool-kit": {
       "version": "file:core/cli",
       "requires": {
-        "@dotcom-tool-kit/babel": "^2.0.3",
-        "@dotcom-tool-kit/backend-app": "^2.0.5",
-        "@dotcom-tool-kit/circleci": "^2.1.1",
-        "@dotcom-tool-kit/circleci-heroku": "^2.0.5",
+        "@dotcom-tool-kit/babel": "^2.0.6",
+        "@dotcom-tool-kit/backend-app": "^2.0.8",
+        "@dotcom-tool-kit/circleci": "^2.1.4",
+        "@dotcom-tool-kit/circleci-heroku": "^2.0.8",
         "@dotcom-tool-kit/error": "^2.0.0",
-        "@dotcom-tool-kit/eslint": "^2.1.2",
-        "@dotcom-tool-kit/frontend-app": "^2.1.3",
-        "@dotcom-tool-kit/heroku": "^2.0.4",
-        "@dotcom-tool-kit/logger": "^2.0.0",
-        "@dotcom-tool-kit/mocha": "^2.1.0",
-        "@dotcom-tool-kit/n-test": "^2.0.3",
-        "@dotcom-tool-kit/npm": "^2.0.4",
-        "@dotcom-tool-kit/options": "^2.0.3",
-        "@dotcom-tool-kit/types": "^2.3.0",
+        "@dotcom-tool-kit/eslint": "^2.1.5",
+        "@dotcom-tool-kit/frontend-app": "^2.1.6",
+        "@dotcom-tool-kit/heroku": "^2.0.7",
+        "@dotcom-tool-kit/logger": "^2.1.1",
+        "@dotcom-tool-kit/mocha": "^2.1.3",
+        "@dotcom-tool-kit/n-test": "^2.1.1",
+        "@dotcom-tool-kit/npm": "^2.0.7",
+        "@dotcom-tool-kit/options": "^2.0.6",
+        "@dotcom-tool-kit/types": "^2.5.1",
         "@dotcom-tool-kit/wait-for-ok": "^2.0.0",
-        "@dotcom-tool-kit/webpack": "^2.1.2",
+        "@dotcom-tool-kit/webpack": "^2.1.5",
         "@jest/globals": "^27.4.6",
         "@types/lodash.merge": "^4.6.6",
         "@types/node": "^12.20.24",

--- a/plugins/heroku/src/getPipelineCouplings.ts
+++ b/plugins/heroku/src/getPipelineCouplings.ts
@@ -13,7 +13,7 @@ async function getPipelineCouplings(logger: Logger, pipelineName: string): Promi
     `/pipelines/${piplelineDetails.id}/pipeline-couplings`
   )
 
-  const stages: Array<keyof State> = ['production', 'staging']
+  const stages = ['production', 'staging'] as const
 
   stages.forEach((stage) => {
     const apps = couplings.filter((app) => app.stage === stage)


### PR DESCRIPTION
# Description

We want to scale apps before promoting them to production as the preboot phase after promotion can take minutes and scaling is not possible during that time. However, scaling will fail if this is the first time the app has been deployed, so do the deployment first then. Hopefully (!), there shouldn't be a preboot phase if we don't need to switch from an old version either so it should be safe to scale the app immediately afterwards.

I've been able to test and confirm that it runs the original code path for next-static (with `appIds.length` totalling `1`) but it would be much harder to confirm the other path is working seeing as we don't have any Heroku pipelines without deployed apps currently. Instead, I've left a log in the code to message the Platforms team if that path is reached.

# Checklist:

- [x] My branch has been rebased onto the latest commit on main (don't merge main into your branch)
- [x] My commit messages are [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/), for example: `feat(circleci): add support for nightly workflows`, `fix: set Heroku app name for staging apps too`
