### PR TITLE
Resolve path to pa11y-ci binary before forking it

### DIFF
--- a/plugins/pa11y/src/tasks/pa11y.ts
+++ b/plugins/pa11y/src/tasks/pa11y.ts
@@ -3,6 +3,8 @@ import { Task } from '@dotcom-tool-kit/types'
 import type { Pa11ySchema } from '@dotcom-tool-kit/types/lib/schema/pa11y'
 import { fork } from 'child_process'
 
+const pa11yCIPath = require.resolve('pa11y-ci/bin/pa11y-ci')
+
 export default class Pa11y extends Task<typeof Pa11ySchema> {
   static description = ''
 
@@ -10,7 +12,7 @@ export default class Pa11y extends Task<typeof Pa11ySchema> {
     const args = this.options.configFile ? ['--config', this.options.configFile] : []
 
     this.logger.info(`running pa11y-ci ${args.join(' ')}`)
-    const child = fork('pa11y-ci', args, { silent: true })
+    const child = fork(pa11yCIPath, args, { silent: true })
     hookFork(this.logger, 'pa11y', child)
     return waitOnExit('pa11y-ci', child)
   }


### PR DESCRIPTION
# Description

The fork function won't do any path resolution automatically, you need to do it first. This fixes a module resolution error.

# Checklist:

- [x] My branch has been rebased onto the latest commit on main (don't merge main into your branch)
- [x] My commit messages are [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/), for example: `feat(circleci): add support for nightly workflows`, `fix: set Heroku app name for staging apps too`
