### PR TITLE
Cpp-949 set TEST_URL env var in pa11y task

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -45,7 +45,7 @@
     },
     "core/cli": {
       "name": "dotcom-tool-kit",
-      "version": "2.3.2",
+      "version": "2.3.3",
       "license": "MIT",
       "dependencies": {
         "@dotcom-tool-kit/error": "^2.0.0",
@@ -65,12 +65,12 @@
       },
       "devDependencies": {
         "@dotcom-tool-kit/babel": "^2.0.6",
-        "@dotcom-tool-kit/backend-app": "^2.0.8",
+        "@dotcom-tool-kit/backend-app": "^2.0.9",
         "@dotcom-tool-kit/circleci": "^2.1.4",
-        "@dotcom-tool-kit/circleci-heroku": "^2.0.8",
+        "@dotcom-tool-kit/circleci-heroku": "^2.0.9",
         "@dotcom-tool-kit/eslint": "^2.1.5",
-        "@dotcom-tool-kit/frontend-app": "^2.1.6",
-        "@dotcom-tool-kit/heroku": "^2.0.7",
+        "@dotcom-tool-kit/frontend-app": "^2.1.7",
+        "@dotcom-tool-kit/heroku": "^2.0.8",
         "@dotcom-tool-kit/mocha": "^2.1.3",
         "@dotcom-tool-kit/n-test": "^2.1.1",
         "@dotcom-tool-kit/npm": "^2.0.7",
@@ -107,7 +107,7 @@
     },
     "core/create": {
       "name": "@dotcom-tool-kit/create",
-      "version": "2.1.2",
+      "version": "2.1.3",
       "license": "ISC",
       "dependencies": {
         "@dotcom-tool-kit/error": "^2.0.0",
@@ -115,7 +115,7 @@
         "@dotcom-tool-kit/types": "^2.5.1",
         "@financial-times/package-json": "^3.0.0",
         "@quarterto/parse-makefile-rules": "^1.1.0",
-        "dotcom-tool-kit": "^2.3.2",
+        "dotcom-tool-kit": "^2.3.3",
         "import-cwd": "^3.0.0",
         "js-yaml": "^4.1.0",
         "komatsu": "^1.3.0",
@@ -19911,10 +19911,10 @@
     },
     "plugins/backend-app": {
       "name": "@dotcom-tool-kit/backend-app",
-      "version": "2.0.8",
+      "version": "2.0.9",
       "license": "ISC",
       "dependencies": {
-        "@dotcom-tool-kit/circleci-heroku": "^2.0.8",
+        "@dotcom-tool-kit/circleci-heroku": "^2.0.9",
         "@dotcom-tool-kit/node": "^2.1.3",
         "@dotcom-tool-kit/npm": "^2.0.7"
       },
@@ -19947,11 +19947,11 @@
     },
     "plugins/circleci-heroku": {
       "name": "@dotcom-tool-kit/circleci-heroku",
-      "version": "2.0.8",
+      "version": "2.0.9",
       "license": "ISC",
       "dependencies": {
         "@dotcom-tool-kit/circleci": "^2.1.4",
-        "@dotcom-tool-kit/heroku": "^2.0.7"
+        "@dotcom-tool-kit/heroku": "^2.0.8"
       },
       "peerDependencies": {
         "dotcom-tool-kit": "2.x"
@@ -20184,10 +20184,10 @@
     },
     "plugins/frontend-app": {
       "name": "@dotcom-tool-kit/frontend-app",
-      "version": "2.1.6",
+      "version": "2.1.7",
       "license": "ISC",
       "dependencies": {
-        "@dotcom-tool-kit/backend-app": "^2.0.8",
+        "@dotcom-tool-kit/backend-app": "^2.0.9",
         "@dotcom-tool-kit/webpack": "^2.1.5"
       },
       "peerDependencies": {
@@ -20196,7 +20196,7 @@
     },
     "plugins/heroku": {
       "name": "@dotcom-tool-kit/heroku",
-      "version": "2.0.7",
+      "version": "2.0.8",
       "license": "ISC",
       "dependencies": {
         "@dotcom-tool-kit/error": "^2.0.0",
@@ -20581,7 +20581,7 @@
     },
     "plugins/pa11y": {
       "name": "@dotcom-tool-kit/pa11y",
-      "version": "0.3.1",
+      "version": "0.3.2",
       "license": "ISC",
       "dependencies": {
         "@dotcom-tool-kit/types": "^2.5.1",
@@ -21921,7 +21921,7 @@
     "@dotcom-tool-kit/backend-app": {
       "version": "file:plugins/backend-app",
       "requires": {
-        "@dotcom-tool-kit/circleci-heroku": "^2.0.8",
+        "@dotcom-tool-kit/circleci-heroku": "^2.0.9",
         "@dotcom-tool-kit/node": "^2.1.3",
         "@dotcom-tool-kit/npm": "^2.0.7"
       }
@@ -21946,7 +21946,7 @@
       "version": "file:plugins/circleci-heroku",
       "requires": {
         "@dotcom-tool-kit/circleci": "^2.1.4",
-        "@dotcom-tool-kit/heroku": "^2.0.7"
+        "@dotcom-tool-kit/heroku": "^2.0.8"
       }
     },
     "@dotcom-tool-kit/circleci-npm": {
@@ -21971,7 +21971,7 @@
         "@types/node": "^12.20.24",
         "@types/pacote": "^11.1.3",
         "@types/prompts": "^2.0.14",
-        "dotcom-tool-kit": "^2.3.2",
+        "dotcom-tool-kit": "^2.3.3",
         "import-cwd": "^3.0.0",
         "js-yaml": "^4.1.0",
         "komatsu": "^1.3.0",
@@ -22135,7 +22135,7 @@
     "@dotcom-tool-kit/frontend-app": {
       "version": "file:plugins/frontend-app",
       "requires": {
-        "@dotcom-tool-kit/backend-app": "^2.0.8",
+        "@dotcom-tool-kit/backend-app": "^2.0.9",
         "@dotcom-tool-kit/webpack": "^2.1.5"
       }
     },
@@ -26187,13 +26187,13 @@
       "version": "file:core/cli",
       "requires": {
         "@dotcom-tool-kit/babel": "^2.0.6",
-        "@dotcom-tool-kit/backend-app": "^2.0.8",
+        "@dotcom-tool-kit/backend-app": "^2.0.9",
         "@dotcom-tool-kit/circleci": "^2.1.4",
-        "@dotcom-tool-kit/circleci-heroku": "^2.0.8",
+        "@dotcom-tool-kit/circleci-heroku": "^2.0.9",
         "@dotcom-tool-kit/error": "^2.0.0",
         "@dotcom-tool-kit/eslint": "^2.1.5",
-        "@dotcom-tool-kit/frontend-app": "^2.1.6",
-        "@dotcom-tool-kit/heroku": "^2.0.7",
+        "@dotcom-tool-kit/frontend-app": "^2.1.7",
+        "@dotcom-tool-kit/heroku": "^2.0.8",
         "@dotcom-tool-kit/logger": "^2.1.1",
         "@dotcom-tool-kit/mocha": "^2.1.3",
         "@dotcom-tool-kit/n-test": "^2.1.1",

--- a/plugins/pa11y/jest.config.js
+++ b/plugins/pa11y/jest.config.js
@@ -1,0 +1,5 @@
+const base = require('../../jest.config.base')
+
+module.exports = {
+  ...base
+}

--- a/plugins/pa11y/package.json
+++ b/plugins/pa11y/package.json
@@ -4,7 +4,7 @@
   "description": "pa11y",
   "main": "lib",
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "cd ../../ ; npx jest --silent --projects plugins/pa11y"
   },
   "keywords": [
     "pa11y"

--- a/plugins/pa11y/src/tasks/pa11y.ts
+++ b/plugins/pa11y/src/tasks/pa11y.ts
@@ -2,6 +2,7 @@ import { hookFork, waitOnExit } from '@dotcom-tool-kit/logger'
 import { Task } from '@dotcom-tool-kit/types'
 import type { Pa11ySchema } from '@dotcom-tool-kit/types/lib/schema/pa11y'
 import { fork } from 'child_process'
+import { readState } from '@dotcom-tool-kit/state'
 
 const pa11yCIPath = require.resolve('pa11y-ci/bin/pa11y-ci')
 
@@ -9,6 +10,11 @@ export default class Pa11y extends Task<typeof Pa11ySchema> {
   static description = ''
 
   async run(): Promise<void> {
+    const reviewState = readState('review')
+    if (reviewState) {
+      process.env.TEST_URL = `https://${reviewState.appName}.herokuapp.com`
+    }
+
     const args = this.options.configFile ? ['--config', this.options.configFile] : []
 
     this.logger.info(`running pa11y-ci ${args.join(' ')}`)

--- a/plugins/pa11y/test/pa11y.test.ts
+++ b/plugins/pa11y/test/pa11y.test.ts
@@ -1,0 +1,32 @@
+import { describe, it, expect, jest } from '@jest/globals'
+import Pa11y from '../src/tasks/pa11y'
+import winston, { Logger } from 'winston'
+import EventEmitter from 'events'
+import * as state from '@dotcom-tool-kit/state'
+
+const appName = 'test-app-name'
+const logger = (winston as unknown) as Logger
+
+jest.mock('child_process', () => ({
+  fork: jest.fn(() => {
+    // return a fake emitter that immediately sends an "exit" event, so the pa11y task resolves
+    const emitter = new EventEmitter()
+    process.nextTick(() => {
+      emitter.emit('exit', 0)
+    })
+    return emitter
+  })
+}))
+jest.mock('@dotcom-tool-kit/logger')
+jest.mock('@dotcom-tool-kit/state')
+
+describe('pa11y', () => {
+  it("sets process.env.TEST_URL if readState('review') is truthy", async () => {
+    jest.mocked(state.readState).mockReturnValue({ appName } as state.ReviewState)
+
+    const pa11y = new Pa11y(logger)
+    await pa11y.run()
+
+    expect(process.env.TEST_URL).toBe(`https://${appName}.herokuapp.com`)
+  })
+})


### PR DESCRIPTION
# Description

Currently, in tool-kit’s pa11y plugin, we are running pa11y-ci directly, and there’s no code in the Pa11y Task to set the review app’s url. Looking at n-gage (that runs pa11y-ci directly as well), it exposes a [TEST_URL ](https://github.com/Financial-Times/n-gage/blob/9744dac1abfff71f931c0d71869c202801fa7a71/src/tasks/review-app.mk#L39) env var when generating the heroku review app, for pa11y config to use later. 

This PR sets TEST_URL environment variable to the review app's url in our pa11y task, which the .pa11yci relies on.

# Checklist:

- [x] My branch has been rebased onto the latest commit on main (don't merge main into your branch)
- [x] My commit messages are [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/), for example: `feat(circleci): add support for nightly workflows`, `fix: set Heroku app name for staging apps too`
