### PR TITLE
fix: pass environment to Change API

### DIFF
--- a/orb/src/jobs/heroku-promote.yml
+++ b/orb/src/jobs/heroku-promote.yml
@@ -23,4 +23,5 @@ steps:
       name: Deploy to production
       command: npx dotcom-tool-kit deploy:production
   - change-api/generate:
+      environment: production
       systemCode: <<parameters.systemCode>>


### PR DESCRIPTION
The change-api orb [defaults this parameter to "unknown"][1] which means that all our production deploys are associated with the "test" environment [in the Change API interface][2].

[Example job output of this behaviour is available][3].

[1]: https://github.com/Financial-Times/change-api-orb/blob/v0.25.1-patch/src/jobs/release-log.yml#L20
[2]: https://changes.in.ft.com/?productionOnly=true&systems=dotcom-debug-user
[3]: https://app.circleci.com/pipelines/github/Financial-Times/dotcom-debug-user/588/workflows/5f7e0034-d731-454c-98ee-b4e227538151/jobs/2201?invite=true#step-103-58

# Checklist:

- [x] My branch has been rebased onto the latest commit on main (don't merge main into your branch)
- [x] My commit messages are [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/), for example: `feat(circleci): add support for nightly workflows`, `fix: set Heroku app name for staging apps too`
