### PR TITLE
Properly test if app has been deployed previously

### DIFF
--- a/plugins/heroku/src/declarations.d.ts
+++ b/plugins/heroku/src/declarations.d.ts
@@ -28,6 +28,11 @@ declare module 'heroku-client' {
     stage: string
   }
 
+  export type HerokuApiResGetApp = {
+    id: string
+    slugSize: number | null
+  }
+
   export type HerokuApiResGetReview = {
     id: string
     branch: string

--- a/plugins/heroku/test/tasks/production.test.ts
+++ b/plugins/heroku/test/tasks/production.test.ts
@@ -12,13 +12,17 @@ jest.mock('@dotcom-tool-kit/state', () => {
 })
 
 jest.mock('../../src/scaleDyno')
+const mockPromoteStagingToProduction = jest.spyOn(utils, 'promoteStagingToProduction')
+jest.spyOn(Production.prototype, 'fetchIfAppHasDeployed').mockImplementation(() => Promise.resolve(true))
 
-const mockpromoteStagingToProduction = jest.spyOn(utils, 'promoteStagingToProduction')
-const productionOptions = { systemCode: 'next-health', scaling: { 'test-app': { web: { size: 'standard-1x', quantity: 1 } } } }
+const productionOptions = {
+  systemCode: 'next-health',
+  scaling: { 'test-app': { web: { size: 'standard-1x', quantity: 1 } } }
+}
 
 describe('staging', () => {
   it('should call set slug with slug id and system code', async () => {
-    mockpromoteStagingToProduction.mockImplementation(() => Promise.resolve([]))
+    mockPromoteStagingToProduction.mockImplementation(() => Promise.resolve([]))
     const task = new Production(logger, productionOptions)
     await task.run()
 
@@ -31,7 +35,7 @@ describe('staging', () => {
   })
 
   it('should throw if it completes unsuccessfully', async () => {
-    mockpromoteStagingToProduction.mockImplementation(() => Promise.reject())
+    mockPromoteStagingToProduction.mockImplementation(() => Promise.reject())
     const task = new Production(logger, productionOptions)
     await expect(task.run()).rejects.toThrowError()
   })


### PR DESCRIPTION
# Description

We need different deployment behaviour for Heroku apps depending on whether they've been deployed before or not. Previously, we'd just check for whether an app existed in the pipeline, but this isn't a useful heuristic as apps are apparently created before a build is run. So let's instead call the Heroku API and see what the `slugSize` of an app is: this value appears to be `null` until the app has been build and promoted to production.

This does mean that we're making an extra API call before we deploy an app, but this should hopefully result in more reliable deployments.

# Checklist:

- [x] My branch has been rebased onto the latest commit on main (don't merge main into your branch)
- [x] My commit messages are [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/), for example: `feat(circleci): add support for nightly workflows`, `fix: set Heroku app name for staging apps too`
