### PR TITLE
fix(upload-assets-to-s3): fix destination folder

### DIFF
--- a/plugins/upload-assets-to-s3/src/tasks/upload-assets-to-s3.ts
+++ b/plugins/upload-assets-to-s3/src/tasks/upload-assets-to-s3.ts
@@ -32,7 +32,7 @@ export default class UploadAssetsToS3 extends Task<typeof UploadAssetsToS3Schema
     const basename = file.split('/').splice(1).join('/') // remove first directory only
     const type = getFileType(basename)
     const encoding = getFileEncoding(basename)
-    const key = path.posix.join(options.destination, basename)
+    const key = options.destination
 
     const bucketByEnv = process.env.NODE_ENV === 'branch' ? options.reviewBucket : options.prodBucket
     let currentBucket = ''


### PR DESCRIPTION
# Description

The plugin upload-assets-to-s3 force to upload the assets with the same structure as "directory" property has ,this property indicates the folder to obtain the files. This situation is not convenient some times , for example in a project where the public folder is in a child project or in different folder that the root but you need to move this files directly to "destination" property without adding "directory" folders.


# Checklist:

- [x] My branch has been rebased onto the latest commit on main (don't merge main into your branch)
- [x] My commit messages are [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/), for example: `feat(circleci): add support for nightly workflows`, `fix: set Heroku app name for staging apps too`
