### PR TITLE
fix: update PORT preference so the PORT set in Vault is not override

### DIFF
--- a/plugins/nodemon/src/tasks/nodemon.ts
+++ b/plugins/nodemon/src/tasks/nodemon.ts
@@ -39,8 +39,8 @@ export default class Nodemon extends Task<typeof NodemonSchema> {
     this.logger.verbose('starting the child nodemon process...')
 
     const env = {
-      ...vaultEnv,
       PORT: port.toString(),
+      ...vaultEnv,
       ...process.env
     }
     nodemon({ script: entry, env, stdout: false, configFile: configPath })


### PR DESCRIPTION
# Description

At this moment, if you set a PORT env var in Vault /development (eg. [dotcom pages](https://vault.in.ft.com:8080/ui/vault/secrets/secret/show/teams/next/dotcom-pages/development)) the value doesn't have the correct preference and it uses the default port [3001, 3002, 3003].

In this PR we change the preference to make so we use:
- 1st: env var
- 2nd: Vault value
- 3rd: default values [3001, 3002, 3003]

# Checklist:

- [x] My branch has been rebased onto the latest commit on main (don't merge main into your branch)
- [x] My commit messages are [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/), for example: `feat(circleci): add support for nightly workflows`, `fix: set Heroku app name for staging apps too`
