### PR TITLE
feat: add optional upload-assets-to-s3 plugin when migrating

### DIFF
--- a/core/create/src/index.ts
+++ b/core/create/src/index.ts
@@ -118,7 +118,12 @@ async function mainPrompt() {
           },
           { title: 'ESLint', value: 'eslint', description: 'an open source JavaScript linting utility' },
           { title: 'Prettier', value: 'prettier', description: 'an opinionated code formatter' },
-          { title: 'lint-staged', value: 'lint-staged', description: 'run linters on git staged files' }
+          { title: 'lint-staged', value: 'lint-staged', description: 'run linters on git staged files' },
+          {
+            title: 'Upload assets to S3',
+            value: 'upload-assets-to-s3',
+            description: 'required this to make your app\'s CSS and JS available in production'
+          }
         ].map((choice) => ({ ...choice, title: styles.plugin(choice.title) }))
       },
       {


### PR DESCRIPTION
We've had an incident where an app didn't include the upload-assets-to-s3 plugin and its CSS and JS was unavailable in production. As this plugin is quite important (and used by most of our frontend apps) I think we should offer it during the init script.

# Checklist:

- [x] My branch has been rebased onto the latest commit on main (don't merge main into your branch)
- [x] My commit messages are [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/), for example: `feat(circleci): add support for nightly workflows`, `fix: set Heroku app name for staging apps too`
