### PR TITLE
CPP-937 Avoid infinite loops when custom plugins don't have a config file

### DIFF
--- a/core/cli/src/plugin.ts
+++ b/core/cli/src/plugin.ts
@@ -112,11 +112,13 @@ export async function loadPlugin(
     return config.plugins[id]
   }
 
+  const isAppRoot = id === 'app root'
+
   // load plugin relative to the parent plugin
   const root = parent ? parent.root : process.cwd()
   let pluginRoot: string
   try {
-    pluginRoot = id === 'app root' ? root : resolveFrom(root, id)
+    pluginRoot = isAppRoot ? root : resolveFrom(root, id)
   } catch (e) {
     return { valid: false, reasons: [`could not find path for name ${s.filepath(id)}`] }
   }
@@ -133,11 +135,12 @@ export async function loadPlugin(
   config.plugins[id] = plugin
 
   // start loading rc file in the background
-  const rcFilePromise = loadToolKitRC(pluginRoot)
+  const rcFilePromise = loadToolKitRC(logger, pluginRoot, isAppRoot)
 
   // start loading module in the background
-  const pluginModulePromise: Promise<Validated<PluginModule | undefined>> =
-    id === 'app root' ? Promise.resolve({ valid: true, value: undefined }) : importPlugin(pluginRoot)
+  const pluginModulePromise: Promise<Validated<PluginModule | undefined>> = isAppRoot
+    ? Promise.resolve({ valid: true, value: undefined })
+    : importPlugin(pluginRoot)
 
   plugin.value.rcFile = await rcFilePromise
 

--- a/core/cli/src/rc-file.ts
+++ b/core/cli/src/rc-file.ts
@@ -1,19 +1,41 @@
-import { cosmiconfig } from 'cosmiconfig'
+import { styles as s } from '@dotcom-tool-kit/logger'
 import { RCFile } from '@dotcom-tool-kit/types/src'
+import { cosmiconfig } from 'cosmiconfig'
+import * as path from 'path'
+import type { Logger } from 'winston'
 
 export const explorer = cosmiconfig('toolkit', { ignoreEmptySearchPlaces: false })
+const emptyConfig = { plugins: [], hooks: {}, options: {} }
+let rootConfig: string | undefined
 
 type RawRCFile = {
   [key in keyof RCFile]?: RCFile[key] | null
 }
 
-export async function loadToolKitRC(root: string): Promise<RCFile> {
-  const result = (await explorer.search(root)) as { config: RawRCFile | null } | null
-  if (!result || !result.config) return { plugins: [], hooks: {}, options: {} }
+export async function loadToolKitRC(logger: Logger, root: string, isAppRoot: boolean): Promise<RCFile> {
+  const result = await explorer.search(root)
 
+  if (!result?.config) {
+    return emptyConfig
+  }
+  if (isAppRoot) {
+    rootConfig = result.filepath
+  } else if (result.filepath === rootConfig) {
+    // Make sure that custom plugins which don't have a config file won't cause
+    // the resolver to use the root config instead and start an infinite loop
+    // of config resolution.
+    logger.warn(
+      `plugin at ${s.filepath(path.dirname(root))} has no config file. please add an empty ${s.filepath(
+        '.toolkitrc'
+      )} file to avoid potential config resolution issues.`
+    )
+    return emptyConfig
+  }
+
+  const config: RawRCFile = result.config
   return {
-    plugins: result.config.plugins ?? [],
-    hooks: result.config.hooks ?? {},
-    options: result.config.options ?? {}
+    plugins: config.plugins ?? [],
+    hooks: config.hooks ?? {},
+    options: config.options ?? {}
   }
 }


### PR DESCRIPTION
# Description

We've found that it's quite easy to forget to create a `.toolkitrc.yml` config file for your custom plugin (even though it's mentioned in the documentation). Omitting the config file will mean that cosmiconfig will try and traverse parent directories until it finds a valid config. This will likely be the config at the app's root instead, which will (at least transitively) include the current plugin in its `plugin` property, causing an infinite loop of config resolution.

Let's try and catch when we've resolved the config to the same root version and print a warning to remind people this can have unexpected results. This probably won't catch loops when one plugin installs another within the `node_modules` directory, but at that point it's likely going to be a plugin we own and have audited so should have a config file.

# Checklist:

- [x] My branch has been rebased onto the latest commit on main (don't merge main into your branch)
- [x] My commit messages are [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/), for example: `feat(circleci): add support for nightly workflows`, `fix: set Heroku app name for staging apps too`
