### PR TITLE
fix: prettier plugin respects .prettierignore

### DIFF
--- a/lib/types/src/schema/prettier.ts
+++ b/lib/types/src/schema/prettier.ts
@@ -3,6 +3,7 @@ import { SchemaOutput } from '../schema'
 export const PrettierSchema = {
   files: 'array.string',
   configFile: 'string?',
+  ignoreFile: 'string?',
   configOptions: 'record.unknown?'
 } as const
 export type PrettierOptions = SchemaOutput<typeof PrettierSchema>

--- a/plugins/prettier/src/tasks/prettier.ts
+++ b/plugins/prettier/src/tasks/prettier.ts
@@ -11,6 +11,7 @@ export default class Prettier extends Task<typeof PrettierSchema> {
 
   static defaultOptions: PrettierOptions = {
     files: ['**/*.js'],
+    ignoreFile: '.prettierignore',
     configOptions: {
       singleQuote: true,
       useTabs: true,
@@ -59,6 +60,12 @@ export default class Prettier extends Task<typeof PrettierSchema> {
         }), using ${styles.option('configOptions')} instead`
       )
       prettierConfig = options.configOptions
+    }
+
+    const { ignored } = await prettier.getFileInfo(filepath, { ignorePath: this.options.ignoreFile })
+
+    if (ignored) {
+      return
     }
 
     const unhook = hookConsole(this.logger, 'prettier')

--- a/plugins/prettier/test/tasks/prettier.test.ts
+++ b/plugins/prettier/test/tasks/prettier.test.ts
@@ -36,7 +36,8 @@ describe('prettier', () => {
 
   it('should format the correct file with default configOptions', async () => {
     const task = new Prettier(logger, {
-      files: [path.join(testDirectory, 'unformatted.ts')]
+      files: [path.join(testDirectory, 'unformatted.ts')],
+      ignoreFile: 'nonexistent prettierignore'
     })
     await task.run()
     const prettified = await fsp.readFile(path.join(testDirectory, 'unformatted.ts'), 'utf8')
@@ -47,7 +48,8 @@ describe('prettier', () => {
     // having the configuration file be named .prettierrc-test.json hides it from being found by prettier on other non-test occasions.
     const task = new Prettier(logger, {
       files: [path.join(testDirectory, 'unformatted.ts')],
-      configFile: path.join(__dirname, '../.prettierrc-test.json')
+      configFile: path.join(__dirname, '../.prettierrc-test.json'),
+      ignoreFile: 'nonexistent prettierignore'
     })
     await task.run()
     const prettified = await fsp.readFile(path.join(testDirectory, 'unformatted.ts'), 'utf8')
@@ -58,6 +60,7 @@ describe('prettier', () => {
     const task = new Prettier(logger, {
       files: [path.join(testDirectory, 'unformatted.ts')],
       configFile: '/incorrect/.prettierrc.js',
+      ignoreFile: 'nonexistent prettierignore',
       configOptions: {
         singleQuote: false,
         useTabs: true,
@@ -70,5 +73,18 @@ describe('prettier', () => {
     await task.run()
     const prettified = await fsp.readFile(path.join(testDirectory, 'unformatted.ts'), 'utf8')
     expect(prettified).toEqual(formattedConfigOptionsFixture)
+  })
+
+  it('should use .prettierignore as ignorefile by default', async () => {
+    const task = new Prettier(logger, {
+      files: [path.join(testDirectory, 'unformatted.ts')]
+    })
+
+    await task.run()
+    const prettified = await fsp.readFile(path.join(testDirectory, 'unformatted.ts'), 'utf8')
+
+    // .prettierignore in the dotcom-tool-kit root includes the prettier fixtures,
+    // so using that ignore file we'd expect this file not to get formatted
+    expect(prettified).toEqual(unformattedFixture)
   })
 })


### PR DESCRIPTION
this (and the default value) are implemented in the Prettier CLI, not the API, so we should implement it in the task