### PR TITLE
Add jsx,json,tsx and ts file types to prettier defaults

### DIFF
--- a/plugins/prettier/src/tasks/prettier.ts
+++ b/plugins/prettier/src/tasks/prettier.ts
@@ -10,7 +10,7 @@ export default class Prettier extends Task<typeof PrettierSchema> {
   static description = ''
 
   static defaultOptions: PrettierOptions = {
-    files: ['**/*.js'],
+    files: ['**/*.{js,json,jsx,ts,tsx}'],
     ignoreFile: '.prettierignore',
     configOptions: {
       singleQuote: true,


### PR DESCRIPTION
# Description

Out of the box the prettier plugin should format the common file types used within customer products

# Checklist:

- [x] My branch has been rebased onto the latest commit on main (don't merge main into your branch)
- [x] My commit messages are [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/), for example: `feat(circleci): add support for nightly workflows`, `fix: set Heroku app name for staging apps too`
