### PR TITLE
Fix lockfile failing to install import-from package

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10018,6 +10018,17 @@
         "node": ">=8"
       }
     },
+    "node_modules/import-cwd/node_modules/import-from": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/import-from/-/import-from-3.0.0.tgz",
+      "integrity": "sha512-CiuXOFFSzkU5x/CR0+z7T91Iht4CXgfCxVOFRhh2Zyhg5wOpWvvDLQUsWl+gcN+QscYBjez8hDCt85O7RLDttQ==",
+      "dependencies": {
+        "resolve-from": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/import-fresh": {
       "version": "3.3.0",
       "license": "MIT",
@@ -27934,6 +27945,16 @@
       "integrity": "sha512-4pnzH16plW+hgvRECbDWpQl3cqtvSofHWh44met7ESfZ8UZOWWddm8hEyDTqREJ9RbYHY8gi8DqmaelApoOGMg==",
       "requires": {
         "import-from": "^3.0.0"
+      },
+      "dependencies": {
+        "import-from": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/import-from/-/import-from-3.0.0.tgz",
+          "integrity": "sha512-CiuXOFFSzkU5x/CR0+z7T91Iht4CXgfCxVOFRhh2Zyhg5wOpWvvDLQUsWl+gcN+QscYBjez8hDCt85O7RLDttQ==",
+          "requires": {
+            "resolve-from": "^5.0.0"
+          }
+        }
       }
     },
     "import-fresh": {


### PR DESCRIPTION
# Description

For some unknown reason, `import-from` was not being installed to a `node_modules` directory, even though it's a dependency of `import-cwd`, which is a dependency of the `@dotcom-tool-kit/create` package. This was affecting clones of this repository, breaking local runs of the `@dotcom-tool-kit/create` package. Just explicitly installing `import-from@3` into `create`, deleting the dependency from the `package.json`, then running `npm install` again seems to have unstuck the lockfile. :shrug:

# Checklist:

- [x] My branch has been rebased onto the latest commit on main (don't merge main into your branch)
- [x] My commit messages are [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/), for example: `feat(circleci): add support for nightly workflows`, `fix: set Heroku app name for staging apps too`
