### PR TITLE
chore: add tslib package to individual plugins

### DIFF
--- a/core/cli/package.json
+++ b/core/cli/package.json
@@ -49,7 +49,7 @@
     "lodash.merge": "^4.6.2",
     "minimist": "^1.2.5",
     "resolve-from": "^5.0.0",
-    "tslib": "^1.14.1",
+    "tslib": "^2.3.1",
     "yaml": "^1.10.2"
   },
   "engines": {

--- a/lib/error/package.json
+++ b/lib/error/package.json
@@ -21,5 +21,8 @@
   ],
   "volta": {
     "extends": "../../package.json"
+  },
+  "dependencies": {
+    "tslib": "^2.3.1"
   }
 }

--- a/lib/logger/package.json
+++ b/lib/logger/package.json
@@ -27,6 +27,7 @@
     "ansi-colors": "^4.1.1",
     "ansi-regex": "^5.0.1",
     "triple-beam": "^1.3.0",
+    "tslib": "^2.3.1",
     "winston": "^3.5.1",
     "winston-transport": "^4.4.2"
   },

--- a/lib/options/package.json
+++ b/lib/options/package.json
@@ -10,7 +10,8 @@
   "author": "FT.com Platforms Team <platforms-team.customer-products@ft.com>",
   "license": "ISC",
   "dependencies": {
-    "@dotcom-tool-kit/types": "^2.6.1"
+    "@dotcom-tool-kit/types": "^2.6.1",
+    "tslib": "^2.3.1"
   },
   "repository": {
     "type": "git",

--- a/lib/package-json-hook/package.json
+++ b/lib/package-json-hook/package.json
@@ -10,7 +10,8 @@
   "author": "FT.com Platforms Team <platforms-team.customer-products@ft.com>",
   "license": "ISC",
   "dependencies": {
-    "@financial-times/package-json": "^3.0.0"
+    "@financial-times/package-json": "^3.0.0",
+    "tslib": "^2.3.1"
   },
   "repository": {
     "type": "git",

--- a/lib/state/package.json
+++ b/lib/state/package.json
@@ -22,5 +22,8 @@
   ],
   "volta": {
     "extends": "../../package.json"
+  },
+  "dependencies": {
+    "tslib": "^2.3.1"
   }
 }

--- a/lib/types/package.json
+++ b/lib/types/package.json
@@ -27,7 +27,8 @@
     "@dotcom-tool-kit/logger": "^2.1.1",
     "lodash.isplainobject": "^4.0.6",
     "lodash.mapvalues": "^4.6.0",
-    "semver": "^7.3.7"
+    "semver": "^7.3.7",
+    "tslib": "^2.3.1"
   },
   "devDependencies": {
     "@jest/globals": "^27.4.6",

--- a/lib/vault/package.json
+++ b/lib/vault/package.json
@@ -14,7 +14,8 @@
     "fs": "0.0.1-security",
     "os": "^0.1.2",
     "path": "^0.12.7",
-    "superagent": "^6.1.0"
+    "superagent": "^6.1.0",
+    "tslib": "^2.3.1"
   },
   "keywords": [],
   "author": "FT.com Platforms Team <platforms-team.customer-products@ft.com>",

--- a/lib/wait-for-ok/package.json
+++ b/lib/wait-for-ok/package.json
@@ -10,7 +10,8 @@
   "author": "FT.com Platforms Team <platforms-team.customer-products@ft.com>",
   "license": "ISC",
   "dependencies": {
-    "node-fetch": "^2.6.1"
+    "node-fetch": "^2.6.1",
+    "tslib": "^2.3.1"
   },
   "repository": {
     "type": "git",

--- a/package-lock.json
+++ b/package-lock.json
@@ -57,7 +57,7 @@
         "lodash.merge": "^4.6.2",
         "minimist": "^1.2.5",
         "resolve-from": "^5.0.0",
-        "tslib": "^1.14.1",
+        "tslib": "^2.3.1",
         "yaml": "^1.10.2"
       },
       "bin": {
@@ -104,6 +104,11 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "core/cli/node_modules/tslib": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
+      "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA=="
     },
     "core/create": {
       "name": "@dotcom-tool-kit/create",
@@ -169,7 +174,15 @@
     "lib/error": {
       "name": "@dotcom-tool-kit/error",
       "version": "2.0.0",
-      "license": "ISC"
+      "license": "ISC",
+      "dependencies": {
+        "tslib": "^2.3.1"
+      }
+    },
+    "lib/error/node_modules/tslib": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
+      "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA=="
     },
     "lib/logger": {
       "name": "@dotcom-tool-kit/logger",
@@ -180,6 +193,7 @@
         "ansi-colors": "^4.1.1",
         "ansi-regex": "^5.0.1",
         "triple-beam": "^1.3.0",
+        "tslib": "^2.3.1",
         "winston": "^3.5.1",
         "winston-transport": "^4.4.2"
       },
@@ -187,30 +201,55 @@
         "@types/triple-beam": "^1.3.2"
       }
     },
+    "lib/logger/node_modules/tslib": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
+      "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA=="
+    },
     "lib/options": {
       "name": "@dotcom-tool-kit/options",
       "version": "2.0.8",
       "license": "ISC",
       "dependencies": {
-        "@dotcom-tool-kit/types": "^2.6.1"
+        "@dotcom-tool-kit/types": "^2.6.1",
+        "tslib": "^2.3.1"
       }
+    },
+    "lib/options/node_modules/tslib": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
+      "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA=="
     },
     "lib/package-json-hook": {
       "name": "@dotcom-tool-kit/package-json-hook",
       "version": "2.1.0",
       "license": "ISC",
       "dependencies": {
-        "@financial-times/package-json": "^3.0.0"
+        "@financial-times/package-json": "^3.0.0",
+        "tslib": "^2.3.1"
       },
       "devDependencies": {
         "@jest/globals": "^27.4.6",
         "winston": "^3.5.1"
       }
     },
+    "lib/package-json-hook/node_modules/tslib": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
+      "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA=="
+    },
     "lib/state": {
       "name": "@dotcom-tool-kit/state",
       "version": "2.0.0",
-      "license": "ISC"
+      "license": "ISC",
+      "dependencies": {
+        "tslib": "^2.3.1"
+      }
+    },
+    "lib/state/node_modules/tslib": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
+      "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA=="
     },
     "lib/types": {
       "name": "@dotcom-tool-kit/types",
@@ -221,7 +260,8 @@
         "@dotcom-tool-kit/logger": "^2.1.1",
         "lodash.isplainobject": "^4.0.6",
         "lodash.mapvalues": "^4.6.0",
-        "semver": "^7.3.7"
+        "semver": "^7.3.7",
+        "tslib": "^2.3.1"
       },
       "devDependencies": {
         "@jest/globals": "^27.4.6",
@@ -231,6 +271,11 @@
         "@types/semver": "^7.3.9",
         "winston": "^3.5.1"
       }
+    },
+    "lib/types/node_modules/tslib": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
+      "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA=="
     },
     "lib/vault": {
       "name": "@dotcom-tool-kit/vault",
@@ -244,7 +289,8 @@
         "fs": "0.0.1-security",
         "os": "^0.1.2",
         "path": "^0.12.7",
-        "superagent": "^6.1.0"
+        "superagent": "^6.1.0",
+        "tslib": "^2.3.1"
       },
       "devDependencies": {
         "@types/jest": "^27.0.2",
@@ -269,18 +315,29 @@
         "is-stream": "^1.0.1"
       }
     },
+    "lib/vault/node_modules/tslib": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
+      "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA=="
+    },
     "lib/wait-for-ok": {
       "name": "@dotcom-tool-kit/wait-for-ok",
       "version": "2.0.0",
       "license": "ISC",
       "dependencies": {
-        "node-fetch": "^2.6.1"
+        "node-fetch": "^2.6.1",
+        "tslib": "^2.3.1"
       },
       "devDependencies": {
         "@types/node": "^12.20.24",
         "@types/node-fetch": "^2.5.10",
         "winston": "^3.5.1"
       }
+    },
+    "lib/wait-for-ok/node_modules/tslib": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
+      "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA=="
     },
     "node_modules/@actions/exec": {
       "version": "1.1.1",
@@ -19908,7 +19965,8 @@
         "@dotcom-tool-kit/error": "^2.0.0",
         "@dotcom-tool-kit/logger": "^2.1.1",
         "@dotcom-tool-kit/types": "^2.6.1",
-        "fast-glob": "^3.2.11"
+        "fast-glob": "^3.2.11",
+        "tslib": "^2.3.1"
       },
       "devDependencies": {
         "@babel/preset-env": "^7.16.11",
@@ -19919,6 +19977,11 @@
         "@babel/core": "7.x",
         "dotcom-tool-kit": "2.x"
       }
+    },
+    "plugins/babel/node_modules/tslib": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
+      "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA=="
     },
     "plugins/backend-app": {
       "name": "@dotcom-tool-kit/backend-app",
@@ -19943,7 +20006,8 @@
         "@dotcom-tool-kit/state": "^2.0.0",
         "@dotcom-tool-kit/types": "^2.6.1",
         "js-yaml": "^4.1.0",
-        "lodash.isequal": "^4.5.0"
+        "lodash.isequal": "^4.5.0",
+        "tslib": "^2.3.1"
       },
       "devDependencies": {
         "@jest/globals": "^27.4.6",
@@ -19962,11 +20026,17 @@
       "license": "ISC",
       "dependencies": {
         "@dotcom-tool-kit/circleci": "^2.1.6",
-        "@dotcom-tool-kit/heroku": "^2.0.10"
+        "@dotcom-tool-kit/heroku": "^2.0.10",
+        "tslib": "^2.3.1"
       },
       "peerDependencies": {
         "dotcom-tool-kit": "2.x"
       }
+    },
+    "plugins/circleci-heroku/node_modules/tslib": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
+      "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA=="
     },
     "plugins/circleci-npm": {
       "name": "@dotcom-tool-kit/circleci-npm",
@@ -19975,11 +20045,22 @@
       "dependencies": {
         "@dotcom-tool-kit/circleci": "^2.1.6",
         "@dotcom-tool-kit/npm": "^2.0.9",
-        "@dotcom-tool-kit/types": "^2.6.1"
+        "@dotcom-tool-kit/types": "^2.6.1",
+        "tslib": "^2.3.1"
       },
       "peerDependencies": {
         "dotcom-tool-kit": "2.x"
       }
+    },
+    "plugins/circleci-npm/node_modules/tslib": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
+      "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA=="
+    },
+    "plugins/circleci/node_modules/tslib": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
+      "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA=="
     },
     "plugins/eslint": {
       "name": "@dotcom-tool-kit/eslint",
@@ -19988,7 +20069,8 @@
       "dependencies": {
         "@dotcom-tool-kit/error": "^2.0.0",
         "@dotcom-tool-kit/logger": "^2.1.1",
-        "@dotcom-tool-kit/types": "^2.6.1"
+        "@dotcom-tool-kit/types": "^2.6.1",
+        "tslib": "^2.3.1"
       },
       "devDependencies": {
         "@jest/globals": "^27.4.6",
@@ -20179,6 +20261,11 @@
         "node": ">=8"
       }
     },
+    "plugins/eslint/node_modules/tslib": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
+      "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA=="
+    },
     "plugins/eslint/node_modules/which": {
       "version": "2.0.2",
       "dev": true,
@@ -20223,7 +20310,8 @@
         "heroku-client": "^3.1.0",
         "node-fetch": "^2.6.1",
         "p-retry": "^4.5.0",
-        "superagent": "^6.1.0"
+        "superagent": "^6.1.0",
+        "tslib": "^2.3.1"
       },
       "devDependencies": {
         "@types/financial-times__package-json": "^1.9.0",
@@ -20234,17 +20322,28 @@
         "dotcom-tool-kit": "2.x"
       }
     },
+    "plugins/heroku/node_modules/tslib": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
+      "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA=="
+    },
     "plugins/husky-npm": {
       "name": "@dotcom-tool-kit/husky-npm",
       "version": "2.2.0",
       "license": "ISC",
       "dependencies": {
-        "@dotcom-tool-kit/package-json-hook": "^2.1.0"
+        "@dotcom-tool-kit/package-json-hook": "^2.1.0",
+        "tslib": "^2.3.1"
       },
       "peerDependencies": {
         "dotcom-tool-kit": "2.x",
         "husky": "4.x"
       }
+    },
+    "plugins/husky-npm/node_modules/tslib": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
+      "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA=="
     },
     "plugins/jest": {
       "name": "@dotcom-tool-kit/jest",
@@ -20252,7 +20351,8 @@
       "license": "ISC",
       "dependencies": {
         "@dotcom-tool-kit/logger": "^2.1.1",
-        "@dotcom-tool-kit/types": "^2.6.1"
+        "@dotcom-tool-kit/types": "^2.6.1",
+        "tslib": "^2.3.1"
       },
       "devDependencies": {
         "@jest/globals": "^27.4.6",
@@ -20263,6 +20363,11 @@
         "jest-cli": "27.x"
       }
     },
+    "plugins/jest/node_modules/tslib": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
+      "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA=="
+    },
     "plugins/lint-staged": {
       "name": "@dotcom-tool-kit/lint-staged",
       "version": "2.1.8",
@@ -20271,7 +20376,8 @@
         "@dotcom-tool-kit/logger": "^2.1.1",
         "@dotcom-tool-kit/package-json-hook": "^2.1.0",
         "@dotcom-tool-kit/types": "^2.6.1",
-        "lint-staged": "^11.2.3"
+        "lint-staged": "^11.2.3",
+        "tslib": "^2.3.1"
       },
       "peerDependencies": {
         "dotcom-tool-kit": "2.x"
@@ -20284,11 +20390,17 @@
       "dependencies": {
         "@dotcom-tool-kit/husky-npm": "^2.2.0",
         "@dotcom-tool-kit/lint-staged": "^2.1.8",
-        "@dotcom-tool-kit/options": "^2.0.8"
+        "@dotcom-tool-kit/options": "^2.0.8",
+        "tslib": "^2.3.1"
       },
       "peerDependencies": {
         "dotcom-tool-kit": "2.x"
       }
+    },
+    "plugins/lint-staged-npm/node_modules/tslib": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
+      "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA=="
     },
     "plugins/lint-staged/node_modules/colorette": {
       "version": "1.4.0",
@@ -20340,6 +20452,11 @@
         "url": "https://github.com/chalk/supports-color?sponsor=1"
       }
     },
+    "plugins/lint-staged/node_modules/tslib": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
+      "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA=="
+    },
     "plugins/mocha": {
       "name": "@dotcom-tool-kit/mocha",
       "version": "2.1.5",
@@ -20350,7 +20467,8 @@
         "@dotcom-tool-kit/types": "^2.6.1",
         "fs": "0.0.1-security",
         "glob": "^7.1.7",
-        "mocha": "^8.3.2"
+        "mocha": "^8.3.2",
+        "tslib": "^2.3.1"
       },
       "devDependencies": {
         "@jest/globals": "^27.4.6",
@@ -20362,6 +20480,11 @@
         "dotcom-tool-kit": "2.x"
       }
     },
+    "plugins/mocha/node_modules/tslib": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
+      "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA=="
+    },
     "plugins/n-test": {
       "name": "@dotcom-tool-kit/n-test",
       "version": "2.1.3",
@@ -20370,7 +20493,8 @@
         "@dotcom-tool-kit/logger": "^2.1.1",
         "@dotcom-tool-kit/state": "^2.0.0",
         "@dotcom-tool-kit/types": "^2.6.1",
-        "@financial-times/n-test": "^4.0.1"
+        "@financial-times/n-test": "^4.0.1",
+        "tslib": "^2.3.1"
       },
       "devDependencies": {
         "@jest/globals": "^27.4.6",
@@ -20380,6 +20504,11 @@
       "peerDependencies": {
         "dotcom-tool-kit": "2.x"
       }
+    },
+    "plugins/n-test/node_modules/tslib": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
+      "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA=="
     },
     "plugins/next-router": {
       "name": "@dotcom-tool-kit/next-router",
@@ -20391,11 +20520,17 @@
         "@dotcom-tool-kit/state": "^2.0.0",
         "@dotcom-tool-kit/types": "^2.6.1",
         "@dotcom-tool-kit/vault": "^2.0.8",
-        "ft-next-router": "^1.0.0"
+        "ft-next-router": "^1.0.0",
+        "tslib": "^2.3.1"
       },
       "peerDependencies": {
         "dotcom-tool-kit": "2.x"
       }
+    },
+    "plugins/next-router/node_modules/tslib": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
+      "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA=="
     },
     "plugins/node": {
       "name": "@dotcom-tool-kit/node",
@@ -20407,11 +20542,17 @@
         "@dotcom-tool-kit/types": "^2.6.1",
         "@dotcom-tool-kit/vault": "^2.0.8",
         "get-port": "^5.1.1",
+        "tslib": "^2.3.1",
         "wait-port": "^0.2.9"
       },
       "peerDependencies": {
         "dotcom-tool-kit": "2.x"
       }
+    },
+    "plugins/node/node_modules/tslib": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
+      "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA=="
     },
     "plugins/nodemon": {
       "name": "@dotcom-tool-kit/nodemon",
@@ -20422,7 +20563,8 @@
         "@dotcom-tool-kit/state": "^2.0.0",
         "@dotcom-tool-kit/types": "^2.6.1",
         "@dotcom-tool-kit/vault": "^2.0.8",
-        "get-port": "^5.1.1"
+        "get-port": "^5.1.1",
+        "tslib": "^2.3.1"
       },
       "devDependencies": {
         "@types/nodemon": "^1.19.1"
@@ -20431,6 +20573,11 @@
         "dotcom-tool-kit": "2.x",
         "nodemon": "2.x"
       }
+    },
+    "plugins/nodemon/node_modules/tslib": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
+      "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA=="
     },
     "plugins/npm": {
       "name": "@dotcom-tool-kit/npm",
@@ -20445,7 +20592,8 @@
         "libnpmpack": "^3.1.0",
         "libnpmpublish": "^5.0.1",
         "pacote": "^12.0.3",
-        "tar": "^4.4.16"
+        "tar": "^4.4.16",
+        "tslib": "^2.3.1"
       },
       "devDependencies": {
         "@types/libnpmpublish": "^4.0.1",
@@ -20573,6 +20721,11 @@
         "node": ">= 10"
       }
     },
+    "plugins/npm/node_modules/tslib": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
+      "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA=="
+    },
     "plugins/npm/node_modules/which": {
       "version": "2.0.2",
       "license": "ISC",
@@ -20596,7 +20749,8 @@
       "license": "ISC",
       "dependencies": {
         "@dotcom-tool-kit/types": "^2.6.1",
-        "pa11y-ci": "^3.0.1"
+        "pa11y-ci": "^3.0.1",
+        "tslib": "^2.3.1"
       },
       "devDependencies": {
         "@types/pa11y": "^5.3.4"
@@ -20604,6 +20758,11 @@
       "peerDependencies": {
         "dotcom-tool-kit": "2.x"
       }
+    },
+    "plugins/pa11y/node_modules/tslib": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
+      "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA=="
     },
     "plugins/prettier": {
       "name": "@dotcom-tool-kit/prettier",
@@ -20616,7 +20775,8 @@
         "@dotcom-tool-kit/types": "^2.6.1",
         "fast-glob": "^3.2.7",
         "hook-std": "^2.0.0",
-        "prettier": "^2.2.1"
+        "prettier": "^2.2.1",
+        "tslib": "^2.3.1"
       },
       "devDependencies": {
         "@jest/globals": "^27.4.6",
@@ -20628,18 +20788,29 @@
         "dotcom-tool-kit": "2.x"
       }
     },
+    "plugins/prettier/node_modules/tslib": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
+      "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA=="
+    },
     "plugins/secret-squirrel": {
       "name": "@dotcom-tool-kit/secret-squirrel",
       "version": "1.0.7",
       "license": "ISC",
       "dependencies": {
         "@dotcom-tool-kit/logger": "^2.1.1",
-        "@dotcom-tool-kit/types": "^2.6.1"
+        "@dotcom-tool-kit/types": "^2.6.1",
+        "tslib": "^2.3.1"
       },
       "peerDependencies": {
         "@financial-times/secret-squirrel": "2.x",
         "dotcom-tool-kit": "2.x"
       }
+    },
+    "plugins/secret-squirrel/node_modules/tslib": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
+      "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA=="
     },
     "plugins/upload-assets-to-s3": {
       "name": "@dotcom-tool-kit/upload-assets-to-s3",
@@ -20651,7 +20822,8 @@
         "@dotcom-tool-kit/types": "^2.6.1",
         "aws-sdk": "^2.901.0",
         "glob": "^7.1.6",
-        "mime": "^2.5.2"
+        "mime": "^2.5.2",
+        "tslib": "^2.3.1"
       },
       "devDependencies": {
         "@aws-sdk/types": "^3.13.1",
@@ -20665,6 +20837,11 @@
         "dotcom-tool-kit": "2.x"
       }
     },
+    "plugins/upload-assets-to-s3/node_modules/tslib": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
+      "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA=="
+    },
     "plugins/webpack": {
       "name": "@dotcom-tool-kit/webpack",
       "version": "2.1.7",
@@ -20673,6 +20850,7 @@
         "@dotcom-tool-kit/error": "^2.0.0",
         "@dotcom-tool-kit/logger": "^2.1.1",
         "@dotcom-tool-kit/types": "^2.6.1",
+        "tslib": "^2.3.1",
         "webpack-cli": "^4.6.0"
       },
       "devDependencies": {
@@ -20754,6 +20932,11 @@
           "optional": true
         }
       }
+    },
+    "plugins/webpack/node_modules/tslib": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
+      "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA=="
     },
     "types/financial-times__package-json": {
       "name": "@types/financial-times__package-json",
@@ -21926,7 +22109,15 @@
         "@dotcom-tool-kit/types": "^2.6.1",
         "@jest/globals": "^27.4.6",
         "fast-glob": "^3.2.11",
+        "tslib": "^2.3.1",
         "winston": "^3.5.1"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.4.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
+          "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA=="
+        }
       }
     },
     "@dotcom-tool-kit/backend-app": {
@@ -21950,14 +22141,30 @@
         "@types/lodash.isequal": "^4.5.5",
         "js-yaml": "^4.1.0",
         "lodash.isequal": "^4.5.0",
+        "tslib": "^2.3.1",
         "winston": "^3.5.1"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.4.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
+          "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA=="
+        }
       }
     },
     "@dotcom-tool-kit/circleci-heroku": {
       "version": "file:plugins/circleci-heroku",
       "requires": {
         "@dotcom-tool-kit/circleci": "^2.1.6",
-        "@dotcom-tool-kit/heroku": "^2.0.10"
+        "@dotcom-tool-kit/heroku": "^2.0.10",
+        "tslib": "^2.3.1"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.4.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
+          "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA=="
+        }
       }
     },
     "@dotcom-tool-kit/circleci-npm": {
@@ -21965,7 +22172,15 @@
       "requires": {
         "@dotcom-tool-kit/circleci": "^2.1.6",
         "@dotcom-tool-kit/npm": "^2.0.9",
-        "@dotcom-tool-kit/types": "^2.6.1"
+        "@dotcom-tool-kit/types": "^2.6.1",
+        "tslib": "^2.3.1"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.4.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
+          "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA=="
+        }
       }
     },
     "@dotcom-tool-kit/create": {
@@ -21999,7 +22214,17 @@
       }
     },
     "@dotcom-tool-kit/error": {
-      "version": "file:lib/error"
+      "version": "file:lib/error",
+      "requires": {
+        "tslib": "^2.3.1"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.4.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
+          "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA=="
+        }
+      }
     },
     "@dotcom-tool-kit/eslint": {
       "version": "file:plugins/eslint",
@@ -22010,6 +22235,7 @@
         "@jest/globals": "^27.4.6",
         "@types/eslint": "^7.2.13",
         "eslint": "^8.15.0",
+        "tslib": "^2.3.1",
         "winston": "^3.5.1"
       },
       "dependencies": {
@@ -22134,6 +22360,11 @@
           "version": "3.0.0",
           "dev": true
         },
+        "tslib": {
+          "version": "2.4.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
+          "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA=="
+        },
         "which": {
           "version": "2.0.2",
           "dev": true,
@@ -22169,13 +22400,29 @@
         "node-fetch": "^2.6.1",
         "p-retry": "^4.5.0",
         "superagent": "^6.1.0",
+        "tslib": "^2.3.1",
         "winston": "^3.5.1"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.4.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
+          "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA=="
+        }
       }
     },
     "@dotcom-tool-kit/husky-npm": {
       "version": "file:plugins/husky-npm",
       "requires": {
-        "@dotcom-tool-kit/package-json-hook": "^2.1.0"
+        "@dotcom-tool-kit/package-json-hook": "^2.1.0",
+        "tslib": "^2.3.1"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.4.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
+          "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA=="
+        }
       }
     },
     "@dotcom-tool-kit/jest": {
@@ -22184,7 +22431,15 @@
         "@dotcom-tool-kit/logger": "^2.1.1",
         "@dotcom-tool-kit/types": "^2.6.1",
         "@jest/globals": "^27.4.6",
+        "tslib": "^2.3.1",
         "winston": "^3.5.1"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.4.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
+          "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA=="
+        }
       }
     },
     "@dotcom-tool-kit/lint-staged": {
@@ -22193,7 +22448,8 @@
         "@dotcom-tool-kit/logger": "^2.1.1",
         "@dotcom-tool-kit/package-json-hook": "^2.1.0",
         "@dotcom-tool-kit/types": "^2.6.1",
-        "lint-staged": "^11.2.3"
+        "lint-staged": "^11.2.3",
+        "tslib": "^2.3.1"
       },
       "dependencies": {
         "colorette": {
@@ -22226,6 +22482,11 @@
           "requires": {
             "has-flag": "^4.0.0"
           }
+        },
+        "tslib": {
+          "version": "2.4.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
+          "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA=="
         }
       }
     },
@@ -22234,7 +22495,15 @@
       "requires": {
         "@dotcom-tool-kit/husky-npm": "^2.2.0",
         "@dotcom-tool-kit/lint-staged": "^2.1.8",
-        "@dotcom-tool-kit/options": "^2.0.8"
+        "@dotcom-tool-kit/options": "^2.0.8",
+        "tslib": "^2.3.1"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.4.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
+          "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA=="
+        }
       }
     },
     "@dotcom-tool-kit/logger": {
@@ -22245,8 +22514,16 @@
         "ansi-colors": "^4.1.1",
         "ansi-regex": "^5.0.1",
         "triple-beam": "^1.3.0",
+        "tslib": "^2.3.1",
         "winston": "^3.5.1",
         "winston-transport": "^4.4.2"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.4.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
+          "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA=="
+        }
       }
     },
     "@dotcom-tool-kit/mocha": {
@@ -22261,7 +22538,15 @@
         "fs": "0.0.1-security",
         "glob": "^7.1.7",
         "mocha": "^8.3.2",
+        "tslib": "^2.3.1",
         "winston": "^3.5.1"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.4.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
+          "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA=="
+        }
       }
     },
     "@dotcom-tool-kit/n-test": {
@@ -22273,7 +22558,15 @@
         "@financial-times/n-test": "^4.0.1",
         "@jest/globals": "^27.4.6",
         "@types/jest": "^27.4.0",
+        "tslib": "^2.3.1",
         "winston": "^3.5.1"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.4.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
+          "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA=="
+        }
       }
     },
     "@dotcom-tool-kit/next-router": {
@@ -22284,7 +22577,15 @@
         "@dotcom-tool-kit/state": "^2.0.0",
         "@dotcom-tool-kit/types": "^2.6.1",
         "@dotcom-tool-kit/vault": "^2.0.8",
-        "ft-next-router": "^1.0.0"
+        "ft-next-router": "^1.0.0",
+        "tslib": "^2.3.1"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.4.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
+          "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA=="
+        }
       }
     },
     "@dotcom-tool-kit/node": {
@@ -22295,7 +22596,15 @@
         "@dotcom-tool-kit/types": "^2.6.1",
         "@dotcom-tool-kit/vault": "^2.0.8",
         "get-port": "^5.1.1",
+        "tslib": "^2.3.1",
         "wait-port": "^0.2.9"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.4.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
+          "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA=="
+        }
       }
     },
     "@dotcom-tool-kit/nodemon": {
@@ -22306,7 +22615,15 @@
         "@dotcom-tool-kit/types": "^2.6.1",
         "@dotcom-tool-kit/vault": "^2.0.8",
         "@types/nodemon": "^1.19.1",
-        "get-port": "^5.1.1"
+        "get-port": "^5.1.1",
+        "tslib": "^2.3.1"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.4.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
+          "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA=="
+        }
       }
     },
     "@dotcom-tool-kit/npm": {
@@ -22324,6 +22641,7 @@
         "libnpmpublish": "^5.0.1",
         "pacote": "^12.0.3",
         "tar": "^4.4.16",
+        "tslib": "^2.3.1",
         "winston": "^3.5.1"
       },
       "dependencies": {
@@ -22413,6 +22731,11 @@
             }
           }
         },
+        "tslib": {
+          "version": "2.4.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
+          "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA=="
+        },
         "which": {
           "version": "2.0.2",
           "requires": {
@@ -22427,7 +22750,15 @@
     "@dotcom-tool-kit/options": {
       "version": "file:lib/options",
       "requires": {
-        "@dotcom-tool-kit/types": "^2.6.1"
+        "@dotcom-tool-kit/types": "^2.6.1",
+        "tslib": "^2.3.1"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.4.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
+          "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA=="
+        }
       }
     },
     "@dotcom-tool-kit/pa11y": {
@@ -22435,7 +22766,15 @@
       "requires": {
         "@dotcom-tool-kit/types": "^2.6.1",
         "@types/pa11y": "^5.3.4",
-        "pa11y-ci": "^3.0.1"
+        "pa11y-ci": "^3.0.1",
+        "tslib": "^2.3.1"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.4.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
+          "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA=="
+        }
       }
     },
     "@dotcom-tool-kit/package-json-hook": {
@@ -22443,7 +22782,15 @@
       "requires": {
         "@financial-times/package-json": "^3.0.0",
         "@jest/globals": "^27.4.6",
+        "tslib": "^2.3.1",
         "winston": "^3.5.1"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.4.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
+          "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA=="
+        }
       }
     },
     "@dotcom-tool-kit/prettier": {
@@ -22459,7 +22806,15 @@
         "jest": "^27.4.7",
         "prettier": "^2.2.1",
         "ts-jest": "^27.1.3",
+        "tslib": "^2.3.1",
         "winston": "^3.5.1"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.4.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
+          "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA=="
+        }
       }
     },
     "@dotcom-tool-kit/sandbox": {
@@ -22489,11 +22844,29 @@
       "version": "file:plugins/secret-squirrel",
       "requires": {
         "@dotcom-tool-kit/logger": "^2.1.1",
-        "@dotcom-tool-kit/types": "^2.6.1"
+        "@dotcom-tool-kit/types": "^2.6.1",
+        "tslib": "^2.3.1"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.4.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
+          "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA=="
+        }
       }
     },
     "@dotcom-tool-kit/state": {
-      "version": "file:lib/state"
+      "version": "file:lib/state",
+      "requires": {
+        "tslib": "^2.3.1"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.4.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
+          "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA=="
+        }
+      }
     },
     "@dotcom-tool-kit/types": {
       "version": "file:lib/types",
@@ -22508,7 +22881,15 @@
         "lodash.isplainobject": "^4.0.6",
         "lodash.mapvalues": "^4.6.0",
         "semver": "^7.3.7",
+        "tslib": "^2.3.1",
         "winston": "^3.5.1"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.4.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
+          "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA=="
+        }
       }
     },
     "@dotcom-tool-kit/upload-assets-to-s3": {
@@ -22525,7 +22906,15 @@
         "aws-sdk": "^2.901.0",
         "glob": "^7.1.6",
         "mime": "^2.5.2",
+        "tslib": "^2.3.1",
         "winston": "^3.5.1"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.4.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
+          "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA=="
+        }
       }
     },
     "@dotcom-tool-kit/vault": {
@@ -22541,6 +22930,7 @@
         "os": "^0.1.2",
         "path": "^0.12.7",
         "superagent": "^6.1.0",
+        "tslib": "^2.3.1",
         "winston": "^3.5.1"
       },
       "dependencies": {
@@ -22555,6 +22945,11 @@
             "encoding": "^0.1.11",
             "is-stream": "^1.0.1"
           }
+        },
+        "tslib": {
+          "version": "2.4.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
+          "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA=="
         }
       }
     },
@@ -22564,7 +22959,15 @@
         "@types/node": "^12.20.24",
         "@types/node-fetch": "^2.5.10",
         "node-fetch": "^2.6.1",
+        "tslib": "^2.3.1",
         "winston": "^3.5.1"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.4.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
+          "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA=="
+        }
       }
     },
     "@dotcom-tool-kit/webpack": {
@@ -22575,6 +22978,7 @@
         "@dotcom-tool-kit/types": "^2.6.1",
         "@jest/globals": "^27.4.6",
         "ts-node": "^10.0.0",
+        "tslib": "^2.3.1",
         "webpack": "^4.42.1",
         "webpack-cli": "^4.6.0",
         "winston": "^3.5.1"
@@ -22610,6 +23014,11 @@
             "v8-compile-cache-lib": "^3.0.0",
             "yn": "3.1.1"
           }
+        },
+        "tslib": {
+          "version": "2.4.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
+          "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA=="
         }
       }
     },
@@ -26223,7 +26632,7 @@
         "minimist": "^1.2.5",
         "resolve-from": "^5.0.0",
         "ts-node": "^8.10.2",
-        "tslib": "^1.14.1",
+        "tslib": "^2.3.1",
         "winston": "^3.5.1",
         "yaml": "^1.10.2"
       },
@@ -26241,6 +26650,11 @@
             "merge2": "^1.2.3",
             "slash": "^3.0.0"
           }
+        },
+        "tslib": {
+          "version": "2.4.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
+          "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA=="
         }
       }
     },

--- a/plugins/babel/package.json
+++ b/plugins/babel/package.json
@@ -20,7 +20,8 @@
     "@dotcom-tool-kit/error": "^2.0.0",
     "@dotcom-tool-kit/logger": "^2.1.1",
     "@dotcom-tool-kit/types": "^2.6.1",
-    "fast-glob": "^3.2.11"
+    "fast-glob": "^3.2.11",
+    "tslib": "^2.3.1"
   },
   "files": [
     "/lib",

--- a/plugins/circleci-heroku/package.json
+++ b/plugins/circleci-heroku/package.json
@@ -11,7 +11,8 @@
   "license": "ISC",
   "dependencies": {
     "@dotcom-tool-kit/circleci": "^2.1.6",
-    "@dotcom-tool-kit/heroku": "^2.0.10"
+    "@dotcom-tool-kit/heroku": "^2.0.10",
+    "tslib": "^2.3.1"
   },
   "repository": {
     "type": "git",

--- a/plugins/circleci-npm/package.json
+++ b/plugins/circleci-npm/package.json
@@ -12,7 +12,8 @@
   "dependencies": {
     "@dotcom-tool-kit/types": "^2.6.1",
     "@dotcom-tool-kit/circleci": "^2.1.6",
-    "@dotcom-tool-kit/npm": "^2.0.9"
+    "@dotcom-tool-kit/npm": "^2.0.9",
+    "tslib": "^2.3.1"
   },
   "repository": {
     "type": "git",

--- a/plugins/circleci/package.json
+++ b/plugins/circleci/package.json
@@ -12,7 +12,8 @@
     "@dotcom-tool-kit/state": "^2.0.0",
     "@dotcom-tool-kit/types": "^2.6.1",
     "js-yaml": "^4.1.0",
-    "lodash.isequal": "^4.5.0"
+    "lodash.isequal": "^4.5.0",
+    "tslib": "^2.3.1"
   },
   "keywords": [],
   "author": "FT.com Platforms Team <platforms-team.customer-products@ft.com>",

--- a/plugins/eslint/package.json
+++ b/plugins/eslint/package.json
@@ -12,7 +12,8 @@
   "dependencies": {
     "@dotcom-tool-kit/error": "^2.0.0",
     "@dotcom-tool-kit/logger": "^2.1.1",
-    "@dotcom-tool-kit/types": "^2.6.1"
+    "@dotcom-tool-kit/types": "^2.6.1",
+    "tslib": "^2.3.1"
   },
   "repository": {
     "type": "git",

--- a/plugins/heroku/package.json
+++ b/plugins/heroku/package.json
@@ -23,7 +23,8 @@
     "heroku-client": "^3.1.0",
     "node-fetch": "^2.6.1",
     "p-retry": "^4.5.0",
-    "superagent": "^6.1.0"
+    "superagent": "^6.1.0",
+    "tslib": "^2.3.1"
   },
   "repository": {
     "type": "git",

--- a/plugins/husky-npm/package.json
+++ b/plugins/husky-npm/package.json
@@ -10,7 +10,8 @@
   "author": "FT.com Platforms Team <platforms-team.customer-products@ft.com>",
   "license": "ISC",
   "dependencies": {
-    "@dotcom-tool-kit/package-json-hook": "^2.1.0"
+    "@dotcom-tool-kit/package-json-hook": "^2.1.0",
+    "tslib": "^2.3.1"
   },
   "peerDependencies": {
     "husky": "4.x",

--- a/plugins/jest/package.json
+++ b/plugins/jest/package.json
@@ -11,7 +11,8 @@
   "license": "ISC",
   "dependencies": {
     "@dotcom-tool-kit/logger": "^2.1.1",
-    "@dotcom-tool-kit/types": "^2.6.1"
+    "@dotcom-tool-kit/types": "^2.6.1",
+    "tslib": "^2.3.1"
   },
   "peerDependencies": {
     "jest-cli": "27.x",

--- a/plugins/lint-staged-npm/package.json
+++ b/plugins/lint-staged-npm/package.json
@@ -12,7 +12,8 @@
   "dependencies": {
     "@dotcom-tool-kit/husky-npm": "^2.2.0",
     "@dotcom-tool-kit/lint-staged": "^2.1.8",
-    "@dotcom-tool-kit/options": "^2.0.8"
+    "@dotcom-tool-kit/options": "^2.0.8",
+    "tslib": "^2.3.1"
   },
   "repository": {
     "type": "git",

--- a/plugins/lint-staged/package.json
+++ b/plugins/lint-staged/package.json
@@ -13,7 +13,8 @@
     "@dotcom-tool-kit/package-json-hook": "^2.1.0",
     "@dotcom-tool-kit/logger": "^2.1.1",
     "@dotcom-tool-kit/types": "^2.6.1",
-    "lint-staged": "^11.2.3"
+    "lint-staged": "^11.2.3",
+    "tslib": "^2.3.1"
   },
   "repository": {
     "type": "git",

--- a/plugins/mocha/package.json
+++ b/plugins/mocha/package.json
@@ -15,7 +15,8 @@
     "@dotcom-tool-kit/types": "^2.6.1",
     "fs": "0.0.1-security",
     "glob": "^7.1.7",
-    "mocha": "^8.3.2"
+    "mocha": "^8.3.2",
+    "tslib": "^2.3.1"
   },
   "repository": {
     "type": "git",

--- a/plugins/n-test/package.json
+++ b/plugins/n-test/package.json
@@ -13,7 +13,8 @@
     "@dotcom-tool-kit/logger": "^2.1.1",
     "@dotcom-tool-kit/state": "^2.0.0",
     "@dotcom-tool-kit/types": "^2.6.1",
-    "@financial-times/n-test": "^4.0.1"
+    "@financial-times/n-test": "^4.0.1",
+    "tslib": "^2.3.1"
   },
   "repository": {
     "type": "git",

--- a/plugins/next-router/package.json
+++ b/plugins/next-router/package.json
@@ -15,7 +15,8 @@
     "@dotcom-tool-kit/logger": "^2.1.1",
     "@dotcom-tool-kit/types": "^2.6.1",
     "@dotcom-tool-kit/vault": "^2.0.8",
-    "ft-next-router": "^1.0.0"
+    "ft-next-router": "^1.0.0",
+    "tslib": "^2.3.1"
   },
   "repository": {
     "type": "git",

--- a/plugins/node/package.json
+++ b/plugins/node/package.json
@@ -15,6 +15,7 @@
     "@dotcom-tool-kit/types": "^2.6.1",
     "@dotcom-tool-kit/vault": "^2.0.8",
     "get-port": "^5.1.1",
+    "tslib": "^2.3.1",
     "wait-port": "^0.2.9"
   },
   "repository": {

--- a/plugins/nodemon/package.json
+++ b/plugins/nodemon/package.json
@@ -14,7 +14,8 @@
     "@dotcom-tool-kit/state": "^2.0.0",
     "@dotcom-tool-kit/types": "^2.6.1",
     "@dotcom-tool-kit/vault": "^2.0.8",
-    "get-port": "^5.1.1"
+    "get-port": "^5.1.1",
+    "tslib": "^2.3.1"
   },
   "peerDependencies": {
     "nodemon": "2.x",

--- a/plugins/npm/package.json
+++ b/plugins/npm/package.json
@@ -18,7 +18,8 @@
     "libnpmpack": "^3.1.0",
     "libnpmpublish": "^5.0.1",
     "pacote": "^12.0.3",
-    "tar": "^4.4.16"
+    "tar": "^4.4.16",
+    "tslib": "^2.3.1"
   },
   "repository": {
     "type": "git",

--- a/plugins/pa11y/package.json
+++ b/plugins/pa11y/package.json
@@ -13,7 +13,8 @@
   "license": "ISC",
   "dependencies": {
     "@dotcom-tool-kit/types": "^2.6.1",
-    "pa11y-ci": "^3.0.1"
+    "pa11y-ci": "^3.0.1",
+    "tslib": "^2.3.1"
   },
   "repository": {
     "type": "git",

--- a/plugins/prettier/package.json
+++ b/plugins/prettier/package.json
@@ -16,7 +16,8 @@
     "@dotcom-tool-kit/types": "^2.6.1",
     "fast-glob": "^3.2.7",
     "hook-std": "^2.0.0",
-    "prettier": "^2.2.1"
+    "prettier": "^2.2.1",
+    "tslib": "^2.3.1"
   },
   "repository": {
     "type": "git",

--- a/plugins/secret-squirrel/package.json
+++ b/plugins/secret-squirrel/package.json
@@ -26,6 +26,7 @@
   },
   "dependencies": {
     "@dotcom-tool-kit/logger": "^2.1.1",
-    "@dotcom-tool-kit/types": "^2.6.1"
+    "@dotcom-tool-kit/types": "^2.6.1",
+    "tslib": "^2.3.1"
   }
 }

--- a/plugins/upload-assets-to-s3/package.json
+++ b/plugins/upload-assets-to-s3/package.json
@@ -15,7 +15,8 @@
     "@dotcom-tool-kit/types": "^2.6.1",
     "aws-sdk": "^2.901.0",
     "glob": "^7.1.6",
-    "mime": "^2.5.2"
+    "mime": "^2.5.2",
+    "tslib": "^2.3.1"
   },
   "repository": {
     "type": "git",

--- a/plugins/webpack/package.json
+++ b/plugins/webpack/package.json
@@ -20,7 +20,8 @@
     "@dotcom-tool-kit/error": "^2.0.0",
     "@dotcom-tool-kit/logger": "^2.1.1",
     "@dotcom-tool-kit/types": "^2.6.1",
-    "webpack-cli": "^4.6.0"
+    "webpack-cli": "^4.6.0",
+    "tslib": "^2.3.1"
   },
   "peerDependencies": {
     "webpack": "4.x.x || 5.x.x",


### PR DESCRIPTION
Add tslib to individual plugins package.json files

So that packages don't need to rely on `tslib` being available from installation on another plugin. This avoids the error `Cannot find module 'tslib'` when running the migration tool.
