### PR TITLE
CPP-979: Add component option to migration script

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -15,6 +15,7 @@
   "plugins/circleci": "2.1.7",
   "plugins/circleci-heroku": "2.0.12",
   "plugins/circleci-npm": "2.0.10",
+  "plugins/component": "0.1.0",
   "plugins/eslint": "2.2.2",
   "plugins/frontend-app": "2.1.10",
   "plugins/heroku": "2.1.0",

--- a/core/create/src/index.ts
+++ b/core/create/src/index.ts
@@ -107,7 +107,8 @@ async function mainPrompt() {
         message: `What kind of app is ${styles.app(packageJson.getField('name'))}?`,
         choices: [
           { title: 'A user-facing (frontend) app', value: 'frontend-app' },
-          { title: 'A service (backend) app', value: 'backend-app' }
+          { title: 'A service (backend) app', value: 'backend-app' },
+          { title: 'An npm component', value: 'component' }
         ]
       },
       {

--- a/package-lock.json
+++ b/package-lock.json
@@ -45,14 +45,14 @@
     },
     "core/cli": {
       "name": "dotcom-tool-kit",
-      "version": "2.3.5",
+      "version": "2.3.6",
       "license": "MIT",
       "dependencies": {
-        "@dotcom-tool-kit/error": "^2.0.0",
-        "@dotcom-tool-kit/logger": "^2.1.1",
-        "@dotcom-tool-kit/options": "^2.0.8",
-        "@dotcom-tool-kit/types": "^2.6.1",
-        "@dotcom-tool-kit/wait-for-ok": "^2.0.0",
+        "@dotcom-tool-kit/error": "^2.0.1",
+        "@dotcom-tool-kit/logger": "^2.1.2",
+        "@dotcom-tool-kit/options": "^2.0.9",
+        "@dotcom-tool-kit/types": "^2.6.2",
+        "@dotcom-tool-kit/wait-for-ok": "^2.0.1",
         "cosmiconfig": "^7.0.0",
         "lodash.merge": "^4.6.2",
         "minimist": "^1.2.5",
@@ -64,17 +64,17 @@
         "dotcom-tool-kit": "bin/run"
       },
       "devDependencies": {
-        "@dotcom-tool-kit/babel": "^2.0.8",
-        "@dotcom-tool-kit/backend-app": "^2.0.11",
-        "@dotcom-tool-kit/circleci": "^2.1.6",
-        "@dotcom-tool-kit/circleci-heroku": "^2.0.11",
-        "@dotcom-tool-kit/eslint": "^2.2.1",
-        "@dotcom-tool-kit/frontend-app": "^2.1.9",
-        "@dotcom-tool-kit/heroku": "^2.0.10",
-        "@dotcom-tool-kit/mocha": "^2.1.5",
-        "@dotcom-tool-kit/n-test": "^2.1.3",
-        "@dotcom-tool-kit/npm": "^2.0.9",
-        "@dotcom-tool-kit/webpack": "^2.1.7",
+        "@dotcom-tool-kit/babel": "^2.0.9",
+        "@dotcom-tool-kit/backend-app": "^2.0.12",
+        "@dotcom-tool-kit/circleci": "^2.1.7",
+        "@dotcom-tool-kit/circleci-heroku": "^2.0.12",
+        "@dotcom-tool-kit/eslint": "^2.2.2",
+        "@dotcom-tool-kit/frontend-app": "^2.1.10",
+        "@dotcom-tool-kit/heroku": "^2.1.0",
+        "@dotcom-tool-kit/mocha": "^2.1.6",
+        "@dotcom-tool-kit/n-test": "^2.1.4",
+        "@dotcom-tool-kit/npm": "^2.0.10",
+        "@dotcom-tool-kit/webpack": "^2.1.8",
         "@jest/globals": "^27.4.6",
         "@types/lodash.merge": "^4.6.6",
         "@types/node": "^12.20.24",
@@ -112,15 +112,15 @@
     },
     "core/create": {
       "name": "@dotcom-tool-kit/create",
-      "version": "2.1.5",
+      "version": "2.2.0",
       "license": "ISC",
       "dependencies": {
-        "@dotcom-tool-kit/error": "^2.0.0",
-        "@dotcom-tool-kit/logger": "^2.1.1",
-        "@dotcom-tool-kit/types": "^2.6.1",
+        "@dotcom-tool-kit/error": "^2.0.1",
+        "@dotcom-tool-kit/logger": "^2.1.2",
+        "@dotcom-tool-kit/types": "^2.6.2",
         "@financial-times/package-json": "^3.0.0",
         "@quarterto/parse-makefile-rules": "^1.1.0",
-        "dotcom-tool-kit": "^2.3.5",
+        "dotcom-tool-kit": "^2.3.6",
         "import-cwd": "^3.0.0",
         "js-yaml": "^4.1.0",
         "komatsu": "^1.3.0",
@@ -173,7 +173,7 @@
     },
     "lib/error": {
       "name": "@dotcom-tool-kit/error",
-      "version": "2.0.0",
+      "version": "2.0.1",
       "license": "ISC",
       "dependencies": {
         "tslib": "^2.3.1"
@@ -186,10 +186,10 @@
     },
     "lib/logger": {
       "name": "@dotcom-tool-kit/logger",
-      "version": "2.1.1",
+      "version": "2.1.2",
       "license": "ISC",
       "dependencies": {
-        "@dotcom-tool-kit/error": "^2.0.0",
+        "@dotcom-tool-kit/error": "^2.0.1",
         "ansi-colors": "^4.1.1",
         "ansi-regex": "^5.0.1",
         "triple-beam": "^1.3.0",
@@ -208,10 +208,10 @@
     },
     "lib/options": {
       "name": "@dotcom-tool-kit/options",
-      "version": "2.0.8",
+      "version": "2.0.9",
       "license": "ISC",
       "dependencies": {
-        "@dotcom-tool-kit/types": "^2.6.1",
+        "@dotcom-tool-kit/types": "^2.6.2",
         "tslib": "^2.3.1"
       }
     },
@@ -222,7 +222,7 @@
     },
     "lib/package-json-hook": {
       "name": "@dotcom-tool-kit/package-json-hook",
-      "version": "2.1.0",
+      "version": "2.1.1",
       "license": "ISC",
       "dependencies": {
         "@financial-times/package-json": "^3.0.0",
@@ -240,7 +240,7 @@
     },
     "lib/state": {
       "name": "@dotcom-tool-kit/state",
-      "version": "2.0.0",
+      "version": "2.0.1",
       "license": "ISC",
       "dependencies": {
         "tslib": "^2.3.1"
@@ -253,11 +253,11 @@
     },
     "lib/types": {
       "name": "@dotcom-tool-kit/types",
-      "version": "2.6.1",
+      "version": "2.6.2",
       "license": "ISC",
       "dependencies": {
-        "@dotcom-tool-kit/error": "^2.0.0",
-        "@dotcom-tool-kit/logger": "^2.1.1",
+        "@dotcom-tool-kit/error": "^2.0.1",
+        "@dotcom-tool-kit/logger": "^2.1.2",
         "lodash.isplainobject": "^4.0.6",
         "lodash.mapvalues": "^4.6.0",
         "semver": "^7.3.7",
@@ -279,12 +279,12 @@
     },
     "lib/vault": {
       "name": "@dotcom-tool-kit/vault",
-      "version": "2.0.8",
+      "version": "2.0.9",
       "license": "ISC",
       "dependencies": {
-        "@dotcom-tool-kit/error": "^2.0.0",
-        "@dotcom-tool-kit/options": "^2.0.8",
-        "@dotcom-tool-kit/types": "^2.6.1",
+        "@dotcom-tool-kit/error": "^2.0.1",
+        "@dotcom-tool-kit/options": "^2.0.9",
+        "@dotcom-tool-kit/types": "^2.6.2",
         "@financial-times/n-fetch": "^1.0.0-beta.7",
         "fs": "0.0.1-security",
         "os": "^0.1.2",
@@ -322,7 +322,7 @@
     },
     "lib/wait-for-ok": {
       "name": "@dotcom-tool-kit/wait-for-ok",
-      "version": "2.0.0",
+      "version": "2.0.1",
       "license": "ISC",
       "dependencies": {
         "node-fetch": "^2.6.1",
@@ -19959,12 +19959,12 @@
     },
     "plugins/babel": {
       "name": "@dotcom-tool-kit/babel",
-      "version": "2.0.8",
+      "version": "2.0.9",
       "license": "MIT",
       "dependencies": {
-        "@dotcom-tool-kit/error": "^2.0.0",
-        "@dotcom-tool-kit/logger": "^2.1.1",
-        "@dotcom-tool-kit/types": "^2.6.1",
+        "@dotcom-tool-kit/error": "^2.0.1",
+        "@dotcom-tool-kit/logger": "^2.1.2",
+        "@dotcom-tool-kit/types": "^2.6.2",
         "fast-glob": "^3.2.11",
         "tslib": "^2.3.1"
       },
@@ -19985,12 +19985,12 @@
     },
     "plugins/backend-app": {
       "name": "@dotcom-tool-kit/backend-app",
-      "version": "2.0.11",
+      "version": "2.0.12",
       "license": "ISC",
       "dependencies": {
-        "@dotcom-tool-kit/circleci-heroku": "^2.0.11",
-        "@dotcom-tool-kit/node": "^2.2.1",
-        "@dotcom-tool-kit/npm": "^2.0.9"
+        "@dotcom-tool-kit/circleci-heroku": "^2.0.12",
+        "@dotcom-tool-kit/node": "^2.2.2",
+        "@dotcom-tool-kit/npm": "^2.0.10"
       },
       "peerDependencies": {
         "dotcom-tool-kit": "2.x"
@@ -19998,13 +19998,13 @@
     },
     "plugins/circleci": {
       "name": "@dotcom-tool-kit/circleci",
-      "version": "2.1.6",
+      "version": "2.1.7",
       "license": "ISC",
       "dependencies": {
-        "@dotcom-tool-kit/error": "^2.0.0",
-        "@dotcom-tool-kit/logger": "^2.1.1",
-        "@dotcom-tool-kit/state": "^2.0.0",
-        "@dotcom-tool-kit/types": "^2.6.1",
+        "@dotcom-tool-kit/error": "^2.0.1",
+        "@dotcom-tool-kit/logger": "^2.1.2",
+        "@dotcom-tool-kit/state": "^2.0.1",
+        "@dotcom-tool-kit/types": "^2.6.2",
         "js-yaml": "^4.1.0",
         "lodash.isequal": "^4.5.0",
         "tslib": "^2.3.1"
@@ -20022,11 +20022,11 @@
     },
     "plugins/circleci-heroku": {
       "name": "@dotcom-tool-kit/circleci-heroku",
-      "version": "2.0.11",
+      "version": "2.0.12",
       "license": "ISC",
       "dependencies": {
-        "@dotcom-tool-kit/circleci": "^2.1.6",
-        "@dotcom-tool-kit/heroku": "^2.0.10",
+        "@dotcom-tool-kit/circleci": "^2.1.7",
+        "@dotcom-tool-kit/heroku": "^2.1.0",
         "tslib": "^2.3.1"
       },
       "peerDependencies": {
@@ -20040,12 +20040,12 @@
     },
     "plugins/circleci-npm": {
       "name": "@dotcom-tool-kit/circleci-npm",
-      "version": "2.0.9",
+      "version": "2.0.10",
       "license": "ISC",
       "dependencies": {
-        "@dotcom-tool-kit/circleci": "^2.1.6",
-        "@dotcom-tool-kit/npm": "^2.0.9",
-        "@dotcom-tool-kit/types": "^2.6.1",
+        "@dotcom-tool-kit/circleci": "^2.1.7",
+        "@dotcom-tool-kit/npm": "^2.0.10",
+        "@dotcom-tool-kit/types": "^2.6.2",
         "tslib": "^2.3.1"
       },
       "peerDependencies": {
@@ -20064,12 +20064,12 @@
     },
     "plugins/eslint": {
       "name": "@dotcom-tool-kit/eslint",
-      "version": "2.2.1",
+      "version": "2.2.2",
       "license": "ISC",
       "dependencies": {
-        "@dotcom-tool-kit/error": "^2.0.0",
-        "@dotcom-tool-kit/logger": "^2.1.1",
-        "@dotcom-tool-kit/types": "^2.6.1",
+        "@dotcom-tool-kit/error": "^2.0.1",
+        "@dotcom-tool-kit/logger": "^2.1.2",
+        "@dotcom-tool-kit/types": "^2.6.2",
         "tslib": "^2.3.1"
       },
       "devDependencies": {
@@ -20282,11 +20282,11 @@
     },
     "plugins/frontend-app": {
       "name": "@dotcom-tool-kit/frontend-app",
-      "version": "2.1.9",
+      "version": "2.1.10",
       "license": "ISC",
       "dependencies": {
-        "@dotcom-tool-kit/backend-app": "^2.0.11",
-        "@dotcom-tool-kit/webpack": "^2.1.7"
+        "@dotcom-tool-kit/backend-app": "^2.0.12",
+        "@dotcom-tool-kit/webpack": "^2.1.8"
       },
       "peerDependencies": {
         "dotcom-tool-kit": "2.x"
@@ -20294,17 +20294,17 @@
     },
     "plugins/heroku": {
       "name": "@dotcom-tool-kit/heroku",
-      "version": "2.0.10",
+      "version": "2.1.0",
       "license": "ISC",
       "dependencies": {
-        "@dotcom-tool-kit/error": "^2.0.0",
-        "@dotcom-tool-kit/logger": "^2.1.1",
-        "@dotcom-tool-kit/npm": "^2.0.9",
-        "@dotcom-tool-kit/package-json-hook": "^2.1.0",
-        "@dotcom-tool-kit/state": "^2.0.0",
-        "@dotcom-tool-kit/types": "^2.6.1",
-        "@dotcom-tool-kit/vault": "^2.0.8",
-        "@dotcom-tool-kit/wait-for-ok": "^2.0.0",
+        "@dotcom-tool-kit/error": "^2.0.1",
+        "@dotcom-tool-kit/logger": "^2.1.2",
+        "@dotcom-tool-kit/npm": "^2.0.10",
+        "@dotcom-tool-kit/package-json-hook": "^2.1.1",
+        "@dotcom-tool-kit/state": "^2.0.1",
+        "@dotcom-tool-kit/types": "^2.6.2",
+        "@dotcom-tool-kit/vault": "^2.0.9",
+        "@dotcom-tool-kit/wait-for-ok": "^2.0.1",
         "@octokit/request": "^5.6.0",
         "@octokit/request-error": "^2.1.0",
         "heroku-client": "^3.1.0",
@@ -20329,10 +20329,10 @@
     },
     "plugins/husky-npm": {
       "name": "@dotcom-tool-kit/husky-npm",
-      "version": "2.2.0",
+      "version": "2.2.1",
       "license": "ISC",
       "dependencies": {
-        "@dotcom-tool-kit/package-json-hook": "^2.1.0",
+        "@dotcom-tool-kit/package-json-hook": "^2.1.1",
         "tslib": "^2.3.1"
       },
       "peerDependencies": {
@@ -20347,11 +20347,11 @@
     },
     "plugins/jest": {
       "name": "@dotcom-tool-kit/jest",
-      "version": "2.0.8",
+      "version": "2.0.9",
       "license": "ISC",
       "dependencies": {
-        "@dotcom-tool-kit/logger": "^2.1.1",
-        "@dotcom-tool-kit/types": "^2.6.1",
+        "@dotcom-tool-kit/logger": "^2.1.2",
+        "@dotcom-tool-kit/types": "^2.6.2",
         "tslib": "^2.3.1"
       },
       "devDependencies": {
@@ -20370,12 +20370,12 @@
     },
     "plugins/lint-staged": {
       "name": "@dotcom-tool-kit/lint-staged",
-      "version": "2.1.8",
+      "version": "2.1.9",
       "license": "ISC",
       "dependencies": {
-        "@dotcom-tool-kit/logger": "^2.1.1",
-        "@dotcom-tool-kit/package-json-hook": "^2.1.0",
-        "@dotcom-tool-kit/types": "^2.6.1",
+        "@dotcom-tool-kit/logger": "^2.1.2",
+        "@dotcom-tool-kit/package-json-hook": "^2.1.1",
+        "@dotcom-tool-kit/types": "^2.6.2",
         "lint-staged": "^11.2.3",
         "tslib": "^2.3.1"
       },
@@ -20385,12 +20385,12 @@
     },
     "plugins/lint-staged-npm": {
       "name": "@dotcom-tool-kit/lint-staged-npm",
-      "version": "2.0.9",
+      "version": "2.0.10",
       "license": "ISC",
       "dependencies": {
-        "@dotcom-tool-kit/husky-npm": "^2.2.0",
-        "@dotcom-tool-kit/lint-staged": "^2.1.8",
-        "@dotcom-tool-kit/options": "^2.0.8",
+        "@dotcom-tool-kit/husky-npm": "^2.2.1",
+        "@dotcom-tool-kit/lint-staged": "^2.1.9",
+        "@dotcom-tool-kit/options": "^2.0.9",
         "tslib": "^2.3.1"
       },
       "peerDependencies": {
@@ -20459,12 +20459,12 @@
     },
     "plugins/mocha": {
       "name": "@dotcom-tool-kit/mocha",
-      "version": "2.1.5",
+      "version": "2.1.6",
       "license": "ISC",
       "dependencies": {
-        "@dotcom-tool-kit/error": "^2.0.0",
-        "@dotcom-tool-kit/logger": "^2.1.1",
-        "@dotcom-tool-kit/types": "^2.6.1",
+        "@dotcom-tool-kit/error": "^2.0.1",
+        "@dotcom-tool-kit/logger": "^2.1.2",
+        "@dotcom-tool-kit/types": "^2.6.2",
         "fs": "0.0.1-security",
         "glob": "^7.1.7",
         "mocha": "^8.3.2",
@@ -20487,12 +20487,12 @@
     },
     "plugins/n-test": {
       "name": "@dotcom-tool-kit/n-test",
-      "version": "2.1.3",
+      "version": "2.1.4",
       "license": "ISC",
       "dependencies": {
-        "@dotcom-tool-kit/logger": "^2.1.1",
-        "@dotcom-tool-kit/state": "^2.0.0",
-        "@dotcom-tool-kit/types": "^2.6.1",
+        "@dotcom-tool-kit/logger": "^2.1.2",
+        "@dotcom-tool-kit/state": "^2.0.1",
+        "@dotcom-tool-kit/types": "^2.6.2",
         "@financial-times/n-test": "^4.0.1",
         "tslib": "^2.3.1"
       },
@@ -20512,14 +20512,14 @@
     },
     "plugins/next-router": {
       "name": "@dotcom-tool-kit/next-router",
-      "version": "2.0.8",
+      "version": "2.0.9",
       "license": "ISC",
       "dependencies": {
-        "@dotcom-tool-kit/error": "^2.0.0",
-        "@dotcom-tool-kit/logger": "^2.1.1",
-        "@dotcom-tool-kit/state": "^2.0.0",
-        "@dotcom-tool-kit/types": "^2.6.1",
-        "@dotcom-tool-kit/vault": "^2.0.8",
+        "@dotcom-tool-kit/error": "^2.0.1",
+        "@dotcom-tool-kit/logger": "^2.1.2",
+        "@dotcom-tool-kit/state": "^2.0.1",
+        "@dotcom-tool-kit/types": "^2.6.2",
+        "@dotcom-tool-kit/vault": "^2.0.9",
         "ft-next-router": "^1.0.0",
         "tslib": "^2.3.1"
       },
@@ -20534,13 +20534,13 @@
     },
     "plugins/node": {
       "name": "@dotcom-tool-kit/node",
-      "version": "2.2.1",
+      "version": "2.2.2",
       "license": "ISC",
       "dependencies": {
-        "@dotcom-tool-kit/error": "^2.0.0",
-        "@dotcom-tool-kit/state": "^2.0.0",
-        "@dotcom-tool-kit/types": "^2.6.1",
-        "@dotcom-tool-kit/vault": "^2.0.8",
+        "@dotcom-tool-kit/error": "^2.0.1",
+        "@dotcom-tool-kit/state": "^2.0.1",
+        "@dotcom-tool-kit/types": "^2.6.2",
+        "@dotcom-tool-kit/vault": "^2.0.9",
         "get-port": "^5.1.1",
         "tslib": "^2.3.1",
         "wait-port": "^0.2.9"
@@ -20556,13 +20556,13 @@
     },
     "plugins/nodemon": {
       "name": "@dotcom-tool-kit/nodemon",
-      "version": "2.1.1",
+      "version": "2.1.2",
       "license": "ISC",
       "dependencies": {
-        "@dotcom-tool-kit/error": "^2.0.0",
-        "@dotcom-tool-kit/state": "^2.0.0",
-        "@dotcom-tool-kit/types": "^2.6.1",
-        "@dotcom-tool-kit/vault": "^2.0.8",
+        "@dotcom-tool-kit/error": "^2.0.1",
+        "@dotcom-tool-kit/state": "^2.0.1",
+        "@dotcom-tool-kit/types": "^2.6.2",
+        "@dotcom-tool-kit/vault": "^2.0.9",
         "get-port": "^5.1.1",
         "tslib": "^2.3.1"
       },
@@ -20581,14 +20581,14 @@
     },
     "plugins/npm": {
       "name": "@dotcom-tool-kit/npm",
-      "version": "2.0.9",
+      "version": "2.0.10",
       "license": "ISC",
       "dependencies": {
         "@actions/exec": "^1.1.0",
-        "@dotcom-tool-kit/error": "^2.0.0",
-        "@dotcom-tool-kit/package-json-hook": "^2.1.0",
-        "@dotcom-tool-kit/state": "^2.0.0",
-        "@dotcom-tool-kit/types": "^2.6.1",
+        "@dotcom-tool-kit/error": "^2.0.1",
+        "@dotcom-tool-kit/package-json-hook": "^2.1.1",
+        "@dotcom-tool-kit/state": "^2.0.1",
+        "@dotcom-tool-kit/types": "^2.6.2",
         "libnpmpack": "^3.1.0",
         "libnpmpublish": "^5.0.1",
         "pacote": "^12.0.3",
@@ -20745,10 +20745,10 @@
     },
     "plugins/pa11y": {
       "name": "@dotcom-tool-kit/pa11y",
-      "version": "0.3.5",
+      "version": "0.3.6",
       "license": "ISC",
       "dependencies": {
-        "@dotcom-tool-kit/types": "^2.6.1",
+        "@dotcom-tool-kit/types": "^2.6.2",
         "pa11y-ci": "^3.0.1",
         "tslib": "^2.3.1"
       },
@@ -20766,13 +20766,13 @@
     },
     "plugins/prettier": {
       "name": "@dotcom-tool-kit/prettier",
-      "version": "2.0.9",
+      "version": "2.1.0",
       "license": "ISC",
       "dependencies": {
-        "@dotcom-tool-kit/error": "^2.0.0",
-        "@dotcom-tool-kit/logger": "^2.1.1",
-        "@dotcom-tool-kit/package-json-hook": "^2.1.0",
-        "@dotcom-tool-kit/types": "^2.6.1",
+        "@dotcom-tool-kit/error": "^2.0.1",
+        "@dotcom-tool-kit/logger": "^2.1.2",
+        "@dotcom-tool-kit/package-json-hook": "^2.1.1",
+        "@dotcom-tool-kit/types": "^2.6.2",
         "fast-glob": "^3.2.7",
         "hook-std": "^2.0.0",
         "prettier": "^2.2.1",
@@ -20795,11 +20795,11 @@
     },
     "plugins/secret-squirrel": {
       "name": "@dotcom-tool-kit/secret-squirrel",
-      "version": "1.0.7",
+      "version": "1.0.8",
       "license": "ISC",
       "dependencies": {
-        "@dotcom-tool-kit/logger": "^2.1.1",
-        "@dotcom-tool-kit/types": "^2.6.1",
+        "@dotcom-tool-kit/logger": "^2.1.2",
+        "@dotcom-tool-kit/types": "^2.6.2",
         "tslib": "^2.3.1"
       },
       "peerDependencies": {
@@ -20814,12 +20814,12 @@
     },
     "plugins/upload-assets-to-s3": {
       "name": "@dotcom-tool-kit/upload-assets-to-s3",
-      "version": "2.0.9",
+      "version": "2.0.10",
       "license": "ISC",
       "dependencies": {
-        "@dotcom-tool-kit/error": "^2.0.0",
-        "@dotcom-tool-kit/logger": "^2.1.1",
-        "@dotcom-tool-kit/types": "^2.6.1",
+        "@dotcom-tool-kit/error": "^2.0.1",
+        "@dotcom-tool-kit/logger": "^2.1.2",
+        "@dotcom-tool-kit/types": "^2.6.2",
         "aws-sdk": "^2.901.0",
         "glob": "^7.1.6",
         "mime": "^2.5.2",
@@ -20844,12 +20844,12 @@
     },
     "plugins/webpack": {
       "name": "@dotcom-tool-kit/webpack",
-      "version": "2.1.7",
+      "version": "2.1.8",
       "license": "MIT",
       "dependencies": {
-        "@dotcom-tool-kit/error": "^2.0.0",
-        "@dotcom-tool-kit/logger": "^2.1.1",
-        "@dotcom-tool-kit/types": "^2.6.1",
+        "@dotcom-tool-kit/error": "^2.0.1",
+        "@dotcom-tool-kit/logger": "^2.1.2",
+        "@dotcom-tool-kit/types": "^2.6.2",
         "tslib": "^2.3.1",
         "webpack-cli": "^4.6.0"
       },
@@ -22104,9 +22104,9 @@
       "version": "file:plugins/babel",
       "requires": {
         "@babel/preset-env": "^7.16.11",
-        "@dotcom-tool-kit/error": "^2.0.0",
-        "@dotcom-tool-kit/logger": "^2.1.1",
-        "@dotcom-tool-kit/types": "^2.6.1",
+        "@dotcom-tool-kit/error": "^2.0.1",
+        "@dotcom-tool-kit/logger": "^2.1.2",
+        "@dotcom-tool-kit/types": "^2.6.2",
         "@jest/globals": "^27.4.6",
         "fast-glob": "^3.2.11",
         "tslib": "^2.3.1",
@@ -22123,18 +22123,18 @@
     "@dotcom-tool-kit/backend-app": {
       "version": "file:plugins/backend-app",
       "requires": {
-        "@dotcom-tool-kit/circleci-heroku": "^2.0.11",
-        "@dotcom-tool-kit/node": "^2.2.1",
-        "@dotcom-tool-kit/npm": "^2.0.9"
+        "@dotcom-tool-kit/circleci-heroku": "^2.0.12",
+        "@dotcom-tool-kit/node": "^2.2.2",
+        "@dotcom-tool-kit/npm": "^2.0.10"
       }
     },
     "@dotcom-tool-kit/circleci": {
       "version": "file:plugins/circleci",
       "requires": {
-        "@dotcom-tool-kit/error": "^2.0.0",
-        "@dotcom-tool-kit/logger": "^2.1.1",
-        "@dotcom-tool-kit/state": "^2.0.0",
-        "@dotcom-tool-kit/types": "^2.6.1",
+        "@dotcom-tool-kit/error": "^2.0.1",
+        "@dotcom-tool-kit/logger": "^2.1.2",
+        "@dotcom-tool-kit/state": "^2.0.1",
+        "@dotcom-tool-kit/types": "^2.6.2",
         "@jest/globals": "^27.4.6",
         "@types/jest": "^27.4.0",
         "@types/js-yaml": "^4.0.3",
@@ -22155,8 +22155,8 @@
     "@dotcom-tool-kit/circleci-heroku": {
       "version": "file:plugins/circleci-heroku",
       "requires": {
-        "@dotcom-tool-kit/circleci": "^2.1.6",
-        "@dotcom-tool-kit/heroku": "^2.0.10",
+        "@dotcom-tool-kit/circleci": "^2.1.7",
+        "@dotcom-tool-kit/heroku": "^2.1.0",
         "tslib": "^2.3.1"
       },
       "dependencies": {
@@ -22170,9 +22170,9 @@
     "@dotcom-tool-kit/circleci-npm": {
       "version": "file:plugins/circleci-npm",
       "requires": {
-        "@dotcom-tool-kit/circleci": "^2.1.6",
-        "@dotcom-tool-kit/npm": "^2.0.9",
-        "@dotcom-tool-kit/types": "^2.6.1",
+        "@dotcom-tool-kit/circleci": "^2.1.7",
+        "@dotcom-tool-kit/npm": "^2.0.10",
+        "@dotcom-tool-kit/types": "^2.6.2",
         "tslib": "^2.3.1"
       },
       "dependencies": {
@@ -22186,9 +22186,9 @@
     "@dotcom-tool-kit/create": {
       "version": "file:core/create",
       "requires": {
-        "@dotcom-tool-kit/error": "^2.0.0",
-        "@dotcom-tool-kit/logger": "^2.1.1",
-        "@dotcom-tool-kit/types": "^2.6.1",
+        "@dotcom-tool-kit/error": "^2.0.1",
+        "@dotcom-tool-kit/logger": "^2.1.2",
+        "@dotcom-tool-kit/types": "^2.6.2",
         "@financial-times/package-json": "^3.0.0",
         "@quarterto/parse-makefile-rules": "^1.1.0",
         "@types/financial-times__package-json": "^1.9.0",
@@ -22197,7 +22197,7 @@
         "@types/node": "^12.20.24",
         "@types/pacote": "^11.1.3",
         "@types/prompts": "^2.0.14",
-        "dotcom-tool-kit": "^2.3.5",
+        "dotcom-tool-kit": "^2.3.6",
         "import-cwd": "^3.0.0",
         "js-yaml": "^4.1.0",
         "komatsu": "^1.3.0",
@@ -22229,9 +22229,9 @@
     "@dotcom-tool-kit/eslint": {
       "version": "file:plugins/eslint",
       "requires": {
-        "@dotcom-tool-kit/error": "^2.0.0",
-        "@dotcom-tool-kit/logger": "^2.1.1",
-        "@dotcom-tool-kit/types": "^2.6.1",
+        "@dotcom-tool-kit/error": "^2.0.1",
+        "@dotcom-tool-kit/logger": "^2.1.2",
+        "@dotcom-tool-kit/types": "^2.6.2",
         "@jest/globals": "^27.4.6",
         "@types/eslint": "^7.2.13",
         "eslint": "^8.15.0",
@@ -22377,21 +22377,21 @@
     "@dotcom-tool-kit/frontend-app": {
       "version": "file:plugins/frontend-app",
       "requires": {
-        "@dotcom-tool-kit/backend-app": "^2.0.11",
-        "@dotcom-tool-kit/webpack": "^2.1.7"
+        "@dotcom-tool-kit/backend-app": "^2.0.12",
+        "@dotcom-tool-kit/webpack": "^2.1.8"
       }
     },
     "@dotcom-tool-kit/heroku": {
       "version": "file:plugins/heroku",
       "requires": {
-        "@dotcom-tool-kit/error": "^2.0.0",
-        "@dotcom-tool-kit/logger": "^2.1.1",
-        "@dotcom-tool-kit/npm": "^2.0.9",
-        "@dotcom-tool-kit/package-json-hook": "^2.1.0",
-        "@dotcom-tool-kit/state": "^2.0.0",
-        "@dotcom-tool-kit/types": "^2.6.1",
-        "@dotcom-tool-kit/vault": "^2.0.8",
-        "@dotcom-tool-kit/wait-for-ok": "^2.0.0",
+        "@dotcom-tool-kit/error": "^2.0.1",
+        "@dotcom-tool-kit/logger": "^2.1.2",
+        "@dotcom-tool-kit/npm": "^2.0.10",
+        "@dotcom-tool-kit/package-json-hook": "^2.1.1",
+        "@dotcom-tool-kit/state": "^2.0.1",
+        "@dotcom-tool-kit/types": "^2.6.2",
+        "@dotcom-tool-kit/vault": "^2.0.9",
+        "@dotcom-tool-kit/wait-for-ok": "^2.0.1",
         "@octokit/request": "^5.6.0",
         "@octokit/request-error": "^2.1.0",
         "@types/financial-times__package-json": "^1.9.0",
@@ -22414,7 +22414,7 @@
     "@dotcom-tool-kit/husky-npm": {
       "version": "file:plugins/husky-npm",
       "requires": {
-        "@dotcom-tool-kit/package-json-hook": "^2.1.0",
+        "@dotcom-tool-kit/package-json-hook": "^2.1.1",
         "tslib": "^2.3.1"
       },
       "dependencies": {
@@ -22428,8 +22428,8 @@
     "@dotcom-tool-kit/jest": {
       "version": "file:plugins/jest",
       "requires": {
-        "@dotcom-tool-kit/logger": "^2.1.1",
-        "@dotcom-tool-kit/types": "^2.6.1",
+        "@dotcom-tool-kit/logger": "^2.1.2",
+        "@dotcom-tool-kit/types": "^2.6.2",
         "@jest/globals": "^27.4.6",
         "tslib": "^2.3.1",
         "winston": "^3.5.1"
@@ -22445,9 +22445,9 @@
     "@dotcom-tool-kit/lint-staged": {
       "version": "file:plugins/lint-staged",
       "requires": {
-        "@dotcom-tool-kit/logger": "^2.1.1",
-        "@dotcom-tool-kit/package-json-hook": "^2.1.0",
-        "@dotcom-tool-kit/types": "^2.6.1",
+        "@dotcom-tool-kit/logger": "^2.1.2",
+        "@dotcom-tool-kit/package-json-hook": "^2.1.1",
+        "@dotcom-tool-kit/types": "^2.6.2",
         "lint-staged": "^11.2.3",
         "tslib": "^2.3.1"
       },
@@ -22493,9 +22493,9 @@
     "@dotcom-tool-kit/lint-staged-npm": {
       "version": "file:plugins/lint-staged-npm",
       "requires": {
-        "@dotcom-tool-kit/husky-npm": "^2.2.0",
-        "@dotcom-tool-kit/lint-staged": "^2.1.8",
-        "@dotcom-tool-kit/options": "^2.0.8",
+        "@dotcom-tool-kit/husky-npm": "^2.2.1",
+        "@dotcom-tool-kit/lint-staged": "^2.1.9",
+        "@dotcom-tool-kit/options": "^2.0.9",
         "tslib": "^2.3.1"
       },
       "dependencies": {
@@ -22509,7 +22509,7 @@
     "@dotcom-tool-kit/logger": {
       "version": "file:lib/logger",
       "requires": {
-        "@dotcom-tool-kit/error": "^2.0.0",
+        "@dotcom-tool-kit/error": "^2.0.1",
         "@types/triple-beam": "^1.3.2",
         "ansi-colors": "^4.1.1",
         "ansi-regex": "^5.0.1",
@@ -22529,9 +22529,9 @@
     "@dotcom-tool-kit/mocha": {
       "version": "file:plugins/mocha",
       "requires": {
-        "@dotcom-tool-kit/error": "^2.0.0",
-        "@dotcom-tool-kit/logger": "^2.1.1",
-        "@dotcom-tool-kit/types": "^2.6.1",
+        "@dotcom-tool-kit/error": "^2.0.1",
+        "@dotcom-tool-kit/logger": "^2.1.2",
+        "@dotcom-tool-kit/types": "^2.6.2",
         "@jest/globals": "^27.4.6",
         "@types/glob": "^7.1.3",
         "@types/mocha": "^8.2.2",
@@ -22552,9 +22552,9 @@
     "@dotcom-tool-kit/n-test": {
       "version": "file:plugins/n-test",
       "requires": {
-        "@dotcom-tool-kit/logger": "^2.1.1",
-        "@dotcom-tool-kit/state": "^2.0.0",
-        "@dotcom-tool-kit/types": "^2.6.1",
+        "@dotcom-tool-kit/logger": "^2.1.2",
+        "@dotcom-tool-kit/state": "^2.0.1",
+        "@dotcom-tool-kit/types": "^2.6.2",
         "@financial-times/n-test": "^4.0.1",
         "@jest/globals": "^27.4.6",
         "@types/jest": "^27.4.0",
@@ -22572,11 +22572,11 @@
     "@dotcom-tool-kit/next-router": {
       "version": "file:plugins/next-router",
       "requires": {
-        "@dotcom-tool-kit/error": "^2.0.0",
-        "@dotcom-tool-kit/logger": "^2.1.1",
-        "@dotcom-tool-kit/state": "^2.0.0",
-        "@dotcom-tool-kit/types": "^2.6.1",
-        "@dotcom-tool-kit/vault": "^2.0.8",
+        "@dotcom-tool-kit/error": "^2.0.1",
+        "@dotcom-tool-kit/logger": "^2.1.2",
+        "@dotcom-tool-kit/state": "^2.0.1",
+        "@dotcom-tool-kit/types": "^2.6.2",
+        "@dotcom-tool-kit/vault": "^2.0.9",
         "ft-next-router": "^1.0.0",
         "tslib": "^2.3.1"
       },
@@ -22591,10 +22591,10 @@
     "@dotcom-tool-kit/node": {
       "version": "file:plugins/node",
       "requires": {
-        "@dotcom-tool-kit/error": "^2.0.0",
-        "@dotcom-tool-kit/state": "^2.0.0",
-        "@dotcom-tool-kit/types": "^2.6.1",
-        "@dotcom-tool-kit/vault": "^2.0.8",
+        "@dotcom-tool-kit/error": "^2.0.1",
+        "@dotcom-tool-kit/state": "^2.0.1",
+        "@dotcom-tool-kit/types": "^2.6.2",
+        "@dotcom-tool-kit/vault": "^2.0.9",
         "get-port": "^5.1.1",
         "tslib": "^2.3.1",
         "wait-port": "^0.2.9"
@@ -22610,10 +22610,10 @@
     "@dotcom-tool-kit/nodemon": {
       "version": "file:plugins/nodemon",
       "requires": {
-        "@dotcom-tool-kit/error": "^2.0.0",
-        "@dotcom-tool-kit/state": "^2.0.0",
-        "@dotcom-tool-kit/types": "^2.6.1",
-        "@dotcom-tool-kit/vault": "^2.0.8",
+        "@dotcom-tool-kit/error": "^2.0.1",
+        "@dotcom-tool-kit/state": "^2.0.1",
+        "@dotcom-tool-kit/types": "^2.6.2",
+        "@dotcom-tool-kit/vault": "^2.0.9",
         "@types/nodemon": "^1.19.1",
         "get-port": "^5.1.1",
         "tslib": "^2.3.1"
@@ -22630,10 +22630,10 @@
       "version": "file:plugins/npm",
       "requires": {
         "@actions/exec": "^1.1.0",
-        "@dotcom-tool-kit/error": "^2.0.0",
-        "@dotcom-tool-kit/package-json-hook": "^2.1.0",
-        "@dotcom-tool-kit/state": "^2.0.0",
-        "@dotcom-tool-kit/types": "^2.6.1",
+        "@dotcom-tool-kit/error": "^2.0.1",
+        "@dotcom-tool-kit/package-json-hook": "^2.1.1",
+        "@dotcom-tool-kit/state": "^2.0.1",
+        "@dotcom-tool-kit/types": "^2.6.2",
         "@types/libnpmpublish": "^4.0.1",
         "@types/pacote": "^11.1.3",
         "@types/tar": "^6.1.1",
@@ -22750,7 +22750,7 @@
     "@dotcom-tool-kit/options": {
       "version": "file:lib/options",
       "requires": {
-        "@dotcom-tool-kit/types": "^2.6.1",
+        "@dotcom-tool-kit/types": "^2.6.2",
         "tslib": "^2.3.1"
       },
       "dependencies": {
@@ -22764,7 +22764,7 @@
     "@dotcom-tool-kit/pa11y": {
       "version": "file:plugins/pa11y",
       "requires": {
-        "@dotcom-tool-kit/types": "^2.6.1",
+        "@dotcom-tool-kit/types": "^2.6.2",
         "@types/pa11y": "^5.3.4",
         "pa11y-ci": "^3.0.1",
         "tslib": "^2.3.1"
@@ -22796,10 +22796,10 @@
     "@dotcom-tool-kit/prettier": {
       "version": "file:plugins/prettier",
       "requires": {
-        "@dotcom-tool-kit/error": "^2.0.0",
-        "@dotcom-tool-kit/logger": "^2.1.1",
-        "@dotcom-tool-kit/package-json-hook": "^2.1.0",
-        "@dotcom-tool-kit/types": "^2.6.1",
+        "@dotcom-tool-kit/error": "^2.0.1",
+        "@dotcom-tool-kit/logger": "^2.1.2",
+        "@dotcom-tool-kit/package-json-hook": "^2.1.1",
+        "@dotcom-tool-kit/types": "^2.6.2",
         "@jest/globals": "^27.4.6",
         "fast-glob": "^3.2.7",
         "hook-std": "^2.0.0",
@@ -22843,8 +22843,8 @@
     "@dotcom-tool-kit/secret-squirrel": {
       "version": "file:plugins/secret-squirrel",
       "requires": {
-        "@dotcom-tool-kit/logger": "^2.1.1",
-        "@dotcom-tool-kit/types": "^2.6.1",
+        "@dotcom-tool-kit/logger": "^2.1.2",
+        "@dotcom-tool-kit/types": "^2.6.2",
         "tslib": "^2.3.1"
       },
       "dependencies": {
@@ -22871,8 +22871,8 @@
     "@dotcom-tool-kit/types": {
       "version": "file:lib/types",
       "requires": {
-        "@dotcom-tool-kit/error": "^2.0.0",
-        "@dotcom-tool-kit/logger": "^2.1.1",
+        "@dotcom-tool-kit/error": "^2.0.1",
+        "@dotcom-tool-kit/logger": "^2.1.2",
         "@jest/globals": "^27.4.6",
         "@types/lodash.isplainobject": "^4.0.6",
         "@types/lodash.mapvalues": "^4.6.6",
@@ -22896,9 +22896,9 @@
       "version": "file:plugins/upload-assets-to-s3",
       "requires": {
         "@aws-sdk/types": "^3.13.1",
-        "@dotcom-tool-kit/error": "^2.0.0",
-        "@dotcom-tool-kit/logger": "^2.1.1",
-        "@dotcom-tool-kit/types": "^2.6.1",
+        "@dotcom-tool-kit/error": "^2.0.1",
+        "@dotcom-tool-kit/logger": "^2.1.2",
+        "@dotcom-tool-kit/types": "^2.6.2",
         "@jest/globals": "^27.4.6",
         "@types/glob": "^7.1.3",
         "@types/jest": "^27.4.0",
@@ -22920,9 +22920,9 @@
     "@dotcom-tool-kit/vault": {
       "version": "file:lib/vault",
       "requires": {
-        "@dotcom-tool-kit/error": "^2.0.0",
-        "@dotcom-tool-kit/options": "^2.0.8",
-        "@dotcom-tool-kit/types": "^2.6.1",
+        "@dotcom-tool-kit/error": "^2.0.1",
+        "@dotcom-tool-kit/options": "^2.0.9",
+        "@dotcom-tool-kit/types": "^2.6.2",
         "@financial-times/n-fetch": "^1.0.0-beta.7",
         "@types/jest": "^27.0.2",
         "fs": "0.0.1-security",
@@ -22973,9 +22973,9 @@
     "@dotcom-tool-kit/webpack": {
       "version": "file:plugins/webpack",
       "requires": {
-        "@dotcom-tool-kit/error": "^2.0.0",
-        "@dotcom-tool-kit/logger": "^2.1.1",
-        "@dotcom-tool-kit/types": "^2.6.1",
+        "@dotcom-tool-kit/error": "^2.0.1",
+        "@dotcom-tool-kit/logger": "^2.1.2",
+        "@dotcom-tool-kit/types": "^2.6.2",
         "@jest/globals": "^27.4.6",
         "ts-node": "^10.0.0",
         "tslib": "^2.3.1",
@@ -26606,22 +26606,22 @@
     "dotcom-tool-kit": {
       "version": "file:core/cli",
       "requires": {
-        "@dotcom-tool-kit/babel": "^2.0.8",
-        "@dotcom-tool-kit/backend-app": "^2.0.11",
-        "@dotcom-tool-kit/circleci": "^2.1.6",
-        "@dotcom-tool-kit/circleci-heroku": "^2.0.11",
-        "@dotcom-tool-kit/error": "^2.0.0",
-        "@dotcom-tool-kit/eslint": "^2.2.1",
-        "@dotcom-tool-kit/frontend-app": "^2.1.9",
-        "@dotcom-tool-kit/heroku": "^2.0.10",
-        "@dotcom-tool-kit/logger": "^2.1.1",
-        "@dotcom-tool-kit/mocha": "^2.1.5",
-        "@dotcom-tool-kit/n-test": "^2.1.3",
-        "@dotcom-tool-kit/npm": "^2.0.9",
-        "@dotcom-tool-kit/options": "^2.0.8",
-        "@dotcom-tool-kit/types": "^2.6.1",
-        "@dotcom-tool-kit/wait-for-ok": "^2.0.0",
-        "@dotcom-tool-kit/webpack": "^2.1.7",
+        "@dotcom-tool-kit/babel": "^2.0.9",
+        "@dotcom-tool-kit/backend-app": "^2.0.12",
+        "@dotcom-tool-kit/circleci": "^2.1.7",
+        "@dotcom-tool-kit/circleci-heroku": "^2.0.12",
+        "@dotcom-tool-kit/error": "^2.0.1",
+        "@dotcom-tool-kit/eslint": "^2.2.2",
+        "@dotcom-tool-kit/frontend-app": "^2.1.10",
+        "@dotcom-tool-kit/heroku": "^2.1.0",
+        "@dotcom-tool-kit/logger": "^2.1.2",
+        "@dotcom-tool-kit/mocha": "^2.1.6",
+        "@dotcom-tool-kit/n-test": "^2.1.4",
+        "@dotcom-tool-kit/npm": "^2.0.10",
+        "@dotcom-tool-kit/options": "^2.0.9",
+        "@dotcom-tool-kit/types": "^2.6.2",
+        "@dotcom-tool-kit/wait-for-ok": "^2.0.1",
+        "@dotcom-tool-kit/webpack": "^2.1.8",
         "@jest/globals": "^27.4.6",
         "@types/lodash.merge": "^4.6.6",
         "@types/node": "^12.20.24",

--- a/package-lock.json
+++ b/package-lock.json
@@ -2239,6 +2239,10 @@
       "resolved": "plugins/circleci-npm",
       "link": true
     },
+    "node_modules/@dotcom-tool-kit/component": {
+      "resolved": "plugins/component",
+      "link": true
+    },
     "node_modules/@dotcom-tool-kit/create": {
       "resolved": "core/create",
       "link": true
@@ -20062,6 +20066,18 @@
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
       "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA=="
     },
+    "plugins/component": {
+      "name": "@dotcom-tool-kit/component",
+      "version": "0.1.0",
+      "license": "ISC",
+      "dependencies": {
+        "@dotcom-tool-kit/circleci-npm": "^2.0.9",
+        "@dotcom-tool-kit/npm": "^2.0.9"
+      },
+      "peerDependencies": {
+        "dotcom-tool-kit": "2.x"
+      }
+    },
     "plugins/eslint": {
       "name": "@dotcom-tool-kit/eslint",
       "version": "2.2.2",
@@ -22181,6 +22197,13 @@
           "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
           "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA=="
         }
+      }
+    },
+    "@dotcom-tool-kit/component": {
+      "version": "file:plugins/component",
+      "requires": {
+        "@dotcom-tool-kit/circleci-npm": "^2.0.9",
+        "@dotcom-tool-kit/npm": "^2.0.9"
       }
     },
     "@dotcom-tool-kit/create": {

--- a/plugins/component/.toolkitrc.yml
+++ b/plugins/component/.toolkitrc.yml
@@ -1,0 +1,3 @@
+plugins:
+  - '@dotcom-tool-kit/npm'
+  - '@dotcom-tool-kit/circleci-npm'

--- a/plugins/component/index.js
+++ b/plugins/component/index.js
@@ -1,0 +1,1 @@
+exports.tasks = []

--- a/plugins/component/package.json
+++ b/plugins/component/package.json
@@ -1,0 +1,26 @@
+{
+  "name": "@dotcom-tool-kit/component",
+  "version": "0.1.0",
+  "description": "",
+  "main": "index.js",
+  "keywords": [],
+  "author": "FT.com Platforms Team <platforms-team.customer-products@ft.com>",
+  "license": "ISC",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/financial-times/dotcom-tool-kit.git",
+    "directory": "plugins/component"
+  },
+  "bugs": "https://github.com/financial-times/dotcom-tool-kit/issues",
+  "homepage": "https://github.com/financial-times/dotcom-tool-kit/tree/main/plugins/component",
+  "files": [
+    ".toolkitrc.yml"
+  ],
+  "peerDependencies": {
+    "dotcom-tool-kit": "2.x"
+  },
+  "dependencies": {
+    "@dotcom-tool-kit/circleci-npm": "^2.0.9",
+    "@dotcom-tool-kit/npm": "^2.0.9"
+  }
+}

--- a/plugins/component/tsconfig.json
+++ b/plugins/component/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "extends": "../../tsconfig.settings.json",
+  "compilerOptions": {
+    "outDir": "lib",
+    "rootDir": "src"
+  },
+  "references": [
+    {
+      "path": "../../lib/types"
+    }
+  ],
+  "include": ["src/**/*"]
+}

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -25,6 +25,7 @@
     "plugins/circleci": {},
     "plugins/circleci-heroku": {},
     "plugins/circleci-npm": {},
+    "plugins/component": {},
     "plugins/eslint": {},
     "plugins/frontend-app": {},
     "plugins/heroku": {},

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -99,6 +99,9 @@
     },
     {
       "path": "plugins/pa11y"
+    },
+    {
+      "path": "plugins/component"
     }
   ]
 }


### PR DESCRIPTION
# Description

Adding a component plugin that has the required Tool Kit plugins for our `n-*` components. Along with this, we have added a component option to the migration script so we can easily migrate our components to use Tool Kit.

Here is a video demo of this script working (with a small tweak to get it working locally):

[Screen sharing - 2022-11-09 7_23_05 PM.webm](https://user-images.githubusercontent.com/893208/201050818-d1bff232-47b7-4edb-8c54-07b7e0cb3058.webm)

# Checklist:

- [x] My branch has been rebased onto the latest commit on main (don't merge main into your branch)
- [x] My commit messages are [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/), for example: `feat(circleci): add support for nightly workflows`, `fix: set Heroku app name for staging apps too`
