### PR TITLE
fix(sandbox): resolve hook conflict

### DIFF
--- a/core/sandbox/.toolkitrc.yml
+++ b/core/sandbox/.toolkitrc.yml
@@ -10,6 +10,9 @@ plugins:
   - '@dotcom-tool-kit/pa11y'
 
 hooks:
+  run:local:
+    - Nodemon
+    - NextRouter
   git:precommit:
     - SecretSquirrel
     - LintStaged


### PR DESCRIPTION
# Description
On running `npx dotcom-tool-kit --install` in the sandbox the install fails because there are hook conflicts on run:local. This PR configures run:local in the sandbox .toolkit.rc file to get past this error.

<img width="930" alt="image" src="https://user-images.githubusercontent.com/17846996/201663651-c49d165b-4293-408b-a1f6-e68721b06b94.png">

# Checklist:

- [x] My branch has been rebased onto the latest commit on main (don't merge main into your branch)
- [x] My commit messages are [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/), for example: `feat(circleci): add support for nightly workflows`, `fix: set Heroku app name for staging apps too`
