### PR TITLE
CPP-1028: fix(prettier): remove config for json files

### DIFF
--- a/plugins/prettier/src/tasks/prettier.ts
+++ b/plugins/prettier/src/tasks/prettier.ts
@@ -10,7 +10,7 @@ export default class Prettier extends Task<typeof PrettierSchema> {
   static description = ''
 
   static defaultOptions: PrettierOptions = {
-    files: ['**/*.{js,json,jsx,ts,tsx}'],
+    files: ['**/*.{js,jsx,ts,tsx}'],
     ignoreFile: '.prettierignore',
     configOptions: {
       singleQuote: true,


### PR DESCRIPTION
# Description

`.json` was added to the default list of files to format by Prettier in https://github.com/Financial-Times/dotcom-tool-kit/pull/300, however this has added some unwanted complexity:
`package.json` and `package-lock.json` files are now being formatted which we don't want to happen, and `json` files are being indented with tabs which is not the usual pattern. There are options to override this config just for `json` files* but this adds more complexity and obfuscation inside Tool Kit.

This change therefore removes config for json altogether and then users can add it in their custom config file if they wish.

***options to override this config just for json files**
Updating the file list in the Prettier options to exclude package.json and package-lock.json will exclude them from being formatted: `files: ['**/*.{js,jsx,ts,tsx}', '!package.json', '!package-lock.json']`, but other json files will still be formatted with tabs which we don't want.

The standard way to provide different formatting for a specific file type is with the `overrides` option:
```js
    configOptions: {
      useTabs: true,
      overrides: [
        {
          files: '*.json',
          options: {
            useTabs: false
          }
        }
      ]
    }
```
However the `overrides` option only works when provided as part of a config file as it is requires to be flattened and merged into the main config object with via the [`resolveConfig` method](https://github.com/Financial-Times/dotcom-tool-kit/blob/main/plugins/prettier/src/tasks/prettier.ts#L46), which requires a config file to be passed in. If there is no config file the Prettier task passes the default [config options](https://github.com/Financial-Times/dotcom-tool-kit/blob/main/plugins/prettier/src/tasks/prettier.ts#L12) directly to the use the [Prettier format](https://github.com/Financial-Times/dotcom-tool-kit/blob/main/plugins/prettier/src/tasks/prettier.ts#L75) method but this method doesn't handle the `overrides` option and so we can't use it at this point.





# Checklist:

- [x] My branch has been rebased onto the latest commit on main (don't merge main into your branch)
- [x] My commit messages are [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/), for example: `feat(circleci): add support for nightly workflows`, `fix: set Heroku app name for staging apps too`
