### PR TITLE
CPP-1037 Reduce noise created by metadata prefixes

### DIFF
--- a/lib/logger/src/format.ts
+++ b/lib/logger/src/format.ts
@@ -1,6 +1,12 @@
 import winston from 'winston'
 import { styles } from './styles'
 
+// This global variable is used to prevent the same label being printed
+// multiple times in a row. Some processes (e.g., Jest) are prone to frequent
+// stream flushing, causing their logs to be repeatedly interspersed with the
+// labels, greatly hindering readability.
+let lastLabel: string | undefined
+
 export const format = winston.format.printf((info) => {
   let { message } = info
 
@@ -17,16 +23,23 @@ export const format = winston.format.printf((info) => {
     }
 
     if (info.level === 'error') {
-      message = styles.error(message)
       labels = styles.errorHighlight(labels)
     } else if (info.level === 'warn') {
-      message = styles.warning(message)
       labels = styles.warningHighlight(labels)
     }
 
-    if (labels) {
-      message = `${labels} ${message}`
+    if (labels && labels !== lastLabel) {
+      if (info.level === 'error') {
+        message = styles.error(message)
+      } else if (info.level === 'warn') {
+        message = styles.warning(message)
+      }
+      // Put hooked messages on a new line so we don't break fancy layouts from
+      // subprocesses, e.g., tables, with our metadata
+      const delimiter = info.process ? '\n' : ' '
+      message = `${labels}${delimiter}${message}`
     }
+    lastLabel = labels
   }
 
   return message

--- a/lib/logger/src/helpers.ts
+++ b/lib/logger/src/helpers.ts
@@ -55,7 +55,7 @@ export function hookConsole(logger: Logger, processName: string): () => void {
         return true
       }
     }
-    
+
     return originalWrite
   }
 
@@ -95,9 +95,7 @@ export function hookFork(
           decodeStrings: false,
           readableObjectMode: true,
           transform: (data, _enc, callback) => {
-            // Put messages on a new line so we don't break fancy layouts, e.g.,
-            // tables, with our metadata
-            callback(null, { level, message: '\n' + (data.endsWith('\n') ? data.slice(0, -1) : data) })
+            callback(null, { level, message: data.endsWith('\n') ? data.slice(0, -1) : data })
           }
         })
       )


### PR DESCRIPTION
# Description

The Tool Kit logger prefixes each log message with labels to give context about where the message is coming from, e.g., which Tool Kit task or subprocess it's from. Some subprocesses (e.g., Jest) are prone to frequent stream flushing, causing their logs to be repeatedly interspersed with these labels greatly hindering readability. Let's work around this with a global variable that stores the last label we printed and only print another prefix if the label has changed, i.e., when the context for the message has changed.

# Checklist:

- [x] My branch has been rebased onto the latest commit on main (don't merge main into your branch)
- [x] My commit messages are [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/), for example: `feat(circleci): add support for nightly workflows`, `fix: set Heroku app name for staging apps too`
