### PR TITLE
CPP-1027: add provision job to nightly workflow

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -45,13 +45,13 @@
     },
     "core/cli": {
       "name": "dotcom-tool-kit",
-      "version": "2.3.6",
+      "version": "2.4.0",
       "license": "MIT",
       "dependencies": {
         "@dotcom-tool-kit/error": "^2.0.1",
         "@dotcom-tool-kit/logger": "^2.1.2",
-        "@dotcom-tool-kit/options": "^2.0.9",
-        "@dotcom-tool-kit/types": "^2.6.2",
+        "@dotcom-tool-kit/options": "^2.0.10",
+        "@dotcom-tool-kit/types": "^2.7.0",
         "@dotcom-tool-kit/wait-for-ok": "^2.0.1",
         "cosmiconfig": "^7.0.0",
         "lodash.groupby": "^4.6.0",
@@ -65,17 +65,17 @@
         "dotcom-tool-kit": "bin/run"
       },
       "devDependencies": {
-        "@dotcom-tool-kit/babel": "^2.0.9",
-        "@dotcom-tool-kit/backend-app": "^2.0.12",
-        "@dotcom-tool-kit/circleci": "^2.1.7",
-        "@dotcom-tool-kit/circleci-heroku": "^2.0.12",
-        "@dotcom-tool-kit/eslint": "^2.2.2",
-        "@dotcom-tool-kit/frontend-app": "^2.1.10",
-        "@dotcom-tool-kit/heroku": "^2.1.0",
-        "@dotcom-tool-kit/mocha": "^2.1.6",
-        "@dotcom-tool-kit/n-test": "^2.1.4",
-        "@dotcom-tool-kit/npm": "^2.0.10",
-        "@dotcom-tool-kit/webpack": "^2.1.8",
+        "@dotcom-tool-kit/babel": "^2.0.10",
+        "@dotcom-tool-kit/backend-app": "^2.0.13",
+        "@dotcom-tool-kit/circleci": "^3.0.0",
+        "@dotcom-tool-kit/circleci-heroku": "^2.1.0",
+        "@dotcom-tool-kit/eslint": "^2.2.3",
+        "@dotcom-tool-kit/frontend-app": "^2.1.11",
+        "@dotcom-tool-kit/heroku": "^2.1.1",
+        "@dotcom-tool-kit/mocha": "^2.1.7",
+        "@dotcom-tool-kit/n-test": "^2.1.5",
+        "@dotcom-tool-kit/npm": "^2.0.11",
+        "@dotcom-tool-kit/webpack": "^2.1.9",
         "@jest/globals": "^27.4.6",
         "@types/lodash.groupby": "^4.6.7",
         "@types/lodash.merge": "^4.6.6",
@@ -114,12 +114,12 @@
     },
     "core/create": {
       "name": "@dotcom-tool-kit/create",
-      "version": "2.3.1",
+      "version": "2.3.2",
       "license": "ISC",
       "dependencies": {
         "@dotcom-tool-kit/error": "^2.0.1",
         "@dotcom-tool-kit/logger": "^2.1.2",
-        "@dotcom-tool-kit/types": "^2.6.2",
+        "@dotcom-tool-kit/types": "^2.7.0",
         "@financial-times/package-json": "^3.0.0",
         "@quarterto/parse-makefile-rules": "^1.1.0",
         "import-cwd": "^3.0.0",
@@ -142,7 +142,7 @@
         "@types/pacote": "^11.1.3",
         "@types/prompts": "^2.0.14",
         "cosmiconfig": "^7.0.1",
-        "dotcom-tool-kit": "^2.3.6"
+        "dotcom-tool-kit": "^2.4.0"
       }
     },
     "core/create/node_modules/tslib": {
@@ -155,11 +155,11 @@
       "license": "ISC",
       "devDependencies": {
         "@dotcom-tool-kit/circleci-heroku": "^2.0.0",
-        "@dotcom-tool-kit/circleci-npm": "^2.0.0",
+        "@dotcom-tool-kit/circleci-npm": "^3.0.0",
         "@dotcom-tool-kit/eslint": "^2.0.0",
         "@dotcom-tool-kit/frontend-app": "^2.0.0",
         "@dotcom-tool-kit/jest": "^2.0.0",
-        "@dotcom-tool-kit/lint-staged": "^2.0.0",
+        "@dotcom-tool-kit/lint-staged": "^3.0.0",
         "@dotcom-tool-kit/lint-staged-npm": "^2.0.0",
         "@dotcom-tool-kit/mocha": "^2.0.0",
         "@dotcom-tool-kit/n-test": "^2.0.0",
@@ -211,10 +211,10 @@
     },
     "lib/options": {
       "name": "@dotcom-tool-kit/options",
-      "version": "2.0.9",
+      "version": "2.0.10",
       "license": "ISC",
       "dependencies": {
-        "@dotcom-tool-kit/types": "^2.6.2",
+        "@dotcom-tool-kit/types": "^2.7.0",
         "tslib": "^2.3.1"
       }
     },
@@ -225,7 +225,7 @@
     },
     "lib/package-json-hook": {
       "name": "@dotcom-tool-kit/package-json-hook",
-      "version": "2.1.1",
+      "version": "3.0.0",
       "license": "ISC",
       "dependencies": {
         "@financial-times/package-json": "^3.0.0",
@@ -258,7 +258,7 @@
     },
     "lib/types": {
       "name": "@dotcom-tool-kit/types",
-      "version": "2.6.2",
+      "version": "2.7.0",
       "license": "ISC",
       "dependencies": {
         "@dotcom-tool-kit/error": "^2.0.0",
@@ -280,12 +280,12 @@
     },
     "lib/vault": {
       "name": "@dotcom-tool-kit/vault",
-      "version": "2.0.9",
+      "version": "2.0.10",
       "license": "ISC",
       "dependencies": {
         "@dotcom-tool-kit/error": "^2.0.1",
-        "@dotcom-tool-kit/options": "^2.0.9",
-        "@dotcom-tool-kit/types": "^2.6.2",
+        "@dotcom-tool-kit/options": "^2.0.10",
+        "@dotcom-tool-kit/types": "^2.7.0",
         "@financial-times/n-fetch": "^1.0.0-beta.7",
         "fs": "0.0.1-security",
         "os": "^0.1.2",
@@ -19940,12 +19940,12 @@
     },
     "plugins/babel": {
       "name": "@dotcom-tool-kit/babel",
-      "version": "2.0.9",
+      "version": "2.0.10",
       "license": "MIT",
       "dependencies": {
         "@dotcom-tool-kit/error": "^2.0.1",
         "@dotcom-tool-kit/logger": "^2.1.2",
-        "@dotcom-tool-kit/types": "^2.6.2",
+        "@dotcom-tool-kit/types": "^2.7.0",
         "fast-glob": "^3.2.11",
         "tslib": "^2.3.1"
       },
@@ -19966,12 +19966,12 @@
     },
     "plugins/backend-app": {
       "name": "@dotcom-tool-kit/backend-app",
-      "version": "2.0.12",
+      "version": "2.0.13",
       "license": "ISC",
       "dependencies": {
-        "@dotcom-tool-kit/circleci-heroku": "^2.0.12",
-        "@dotcom-tool-kit/node": "^2.2.2",
-        "@dotcom-tool-kit/npm": "^2.0.10"
+        "@dotcom-tool-kit/circleci-heroku": "^2.1.0",
+        "@dotcom-tool-kit/node": "^2.2.3",
+        "@dotcom-tool-kit/npm": "^2.0.11"
       },
       "peerDependencies": {
         "dotcom-tool-kit": "2.x"
@@ -19979,13 +19979,13 @@
     },
     "plugins/circleci": {
       "name": "@dotcom-tool-kit/circleci",
-      "version": "2.1.7",
+      "version": "3.0.0",
       "license": "ISC",
       "dependencies": {
         "@dotcom-tool-kit/error": "^2.0.0",
         "@dotcom-tool-kit/logger": "^2.1.1",
         "@dotcom-tool-kit/state": "^2.0.0",
-        "@dotcom-tool-kit/types": "^2.6.1",
+        "@dotcom-tool-kit/types": "^2.7.0",
         "lodash": "^4.17.21",
         "tslib": "^2.3.1",
         "yaml": "^2.1.1"
@@ -20003,11 +20003,11 @@
     },
     "plugins/circleci-heroku": {
       "name": "@dotcom-tool-kit/circleci-heroku",
-      "version": "2.0.12",
+      "version": "2.1.0",
       "license": "ISC",
       "dependencies": {
-        "@dotcom-tool-kit/circleci": "^2.1.7",
-        "@dotcom-tool-kit/heroku": "^2.1.0",
+        "@dotcom-tool-kit/circleci": "^3.0.0",
+        "@dotcom-tool-kit/heroku": "^2.1.1",
         "tslib": "^2.3.1"
       },
       "peerDependencies": {
@@ -20021,12 +20021,12 @@
     },
     "plugins/circleci-npm": {
       "name": "@dotcom-tool-kit/circleci-npm",
-      "version": "2.0.10",
+      "version": "3.0.0",
       "license": "ISC",
       "dependencies": {
-        "@dotcom-tool-kit/circleci": "^2.1.7",
-        "@dotcom-tool-kit/npm": "^2.0.10",
-        "@dotcom-tool-kit/types": "^2.6.2",
+        "@dotcom-tool-kit/circleci": "^3.0.0",
+        "@dotcom-tool-kit/npm": "^2.0.11",
+        "@dotcom-tool-kit/types": "^2.7.0",
         "tslib": "^2.3.1"
       },
       "peerDependencies": {
@@ -20053,18 +20053,19 @@
     },
     "plugins/component": {
       "name": "@dotcom-tool-kit/component",
-      "version": "2.0.0",
+      "version": "2.0.1",
       "license": "ISC",
       "dependencies": {
-        "@dotcom-tool-kit/circleci-npm": "^2.0.9",
-        "@dotcom-tool-kit/npm": "^2.0.9"
+        "@dotcom-tool-kit/circleci-npm": "^3.0.0",
+        "@dotcom-tool-kit/npm": "^2.0.11"
       },
       "peerDependencies": {
         "dotcom-tool-kit": "2.x"
       }
     },
     "plugins/cypress": {
-      "version": "0.1.0",
+      "name": "@dotcom-tool-kit/cypress",
+      "version": "2.0.0",
       "license": "ISC",
       "peerDependencies": {
         "dotcom-tool-kit": "2.x"
@@ -20072,12 +20073,12 @@
     },
     "plugins/eslint": {
       "name": "@dotcom-tool-kit/eslint",
-      "version": "2.2.2",
+      "version": "2.2.3",
       "license": "ISC",
       "dependencies": {
         "@dotcom-tool-kit/error": "^2.0.1",
         "@dotcom-tool-kit/logger": "^2.1.2",
-        "@dotcom-tool-kit/types": "^2.6.2",
+        "@dotcom-tool-kit/types": "^2.7.0",
         "tslib": "^2.3.1"
       },
       "devDependencies": {
@@ -20290,11 +20291,11 @@
     },
     "plugins/frontend-app": {
       "name": "@dotcom-tool-kit/frontend-app",
-      "version": "2.1.10",
+      "version": "2.1.11",
       "license": "ISC",
       "dependencies": {
-        "@dotcom-tool-kit/backend-app": "^2.0.12",
-        "@dotcom-tool-kit/webpack": "^2.1.8"
+        "@dotcom-tool-kit/backend-app": "^2.0.13",
+        "@dotcom-tool-kit/webpack": "^2.1.9"
       },
       "peerDependencies": {
         "dotcom-tool-kit": "2.x"
@@ -20302,16 +20303,16 @@
     },
     "plugins/heroku": {
       "name": "@dotcom-tool-kit/heroku",
-      "version": "2.1.0",
+      "version": "2.1.1",
       "license": "ISC",
       "dependencies": {
         "@dotcom-tool-kit/error": "^2.0.1",
         "@dotcom-tool-kit/logger": "^2.1.2",
-        "@dotcom-tool-kit/npm": "^2.0.10",
-        "@dotcom-tool-kit/package-json-hook": "^2.1.1",
+        "@dotcom-tool-kit/npm": "^2.0.11",
+        "@dotcom-tool-kit/package-json-hook": "^3.0.0",
         "@dotcom-tool-kit/state": "^2.0.1",
-        "@dotcom-tool-kit/types": "^2.6.2",
-        "@dotcom-tool-kit/vault": "^2.0.9",
+        "@dotcom-tool-kit/types": "^2.7.0",
+        "@dotcom-tool-kit/vault": "^2.0.10",
         "@dotcom-tool-kit/wait-for-ok": "^2.0.1",
         "@octokit/request": "^5.6.0",
         "@octokit/request-error": "^2.1.0",
@@ -20337,10 +20338,10 @@
     },
     "plugins/husky-npm": {
       "name": "@dotcom-tool-kit/husky-npm",
-      "version": "2.2.1",
+      "version": "3.0.0",
       "license": "ISC",
       "dependencies": {
-        "@dotcom-tool-kit/package-json-hook": "^2.1.1",
+        "@dotcom-tool-kit/package-json-hook": "^3.0.0",
         "tslib": "^2.3.1"
       },
       "peerDependencies": {
@@ -20355,11 +20356,11 @@
     },
     "plugins/jest": {
       "name": "@dotcom-tool-kit/jest",
-      "version": "2.0.9",
+      "version": "2.0.10",
       "license": "ISC",
       "dependencies": {
         "@dotcom-tool-kit/logger": "^2.1.2",
-        "@dotcom-tool-kit/types": "^2.6.2",
+        "@dotcom-tool-kit/types": "^2.7.0",
         "tslib": "^2.3.1"
       },
       "devDependencies": {
@@ -20378,12 +20379,12 @@
     },
     "plugins/lint-staged": {
       "name": "@dotcom-tool-kit/lint-staged",
-      "version": "2.1.9",
+      "version": "3.0.0",
       "license": "ISC",
       "dependencies": {
         "@dotcom-tool-kit/logger": "^2.1.2",
-        "@dotcom-tool-kit/package-json-hook": "^2.1.1",
-        "@dotcom-tool-kit/types": "^2.6.2",
+        "@dotcom-tool-kit/package-json-hook": "^3.0.0",
+        "@dotcom-tool-kit/types": "^2.7.0",
         "lint-staged": "^11.2.3",
         "tslib": "^2.3.1"
       },
@@ -20393,12 +20394,12 @@
     },
     "plugins/lint-staged-npm": {
       "name": "@dotcom-tool-kit/lint-staged-npm",
-      "version": "2.0.10",
+      "version": "2.0.11",
       "license": "ISC",
       "dependencies": {
-        "@dotcom-tool-kit/husky-npm": "^2.2.1",
-        "@dotcom-tool-kit/lint-staged": "^2.1.9",
-        "@dotcom-tool-kit/options": "^2.0.9",
+        "@dotcom-tool-kit/husky-npm": "^3.0.0",
+        "@dotcom-tool-kit/lint-staged": "^3.0.0",
+        "@dotcom-tool-kit/options": "^2.0.10",
         "tslib": "^2.3.1"
       },
       "peerDependencies": {
@@ -20467,12 +20468,12 @@
     },
     "plugins/mocha": {
       "name": "@dotcom-tool-kit/mocha",
-      "version": "2.1.6",
+      "version": "2.1.7",
       "license": "ISC",
       "dependencies": {
         "@dotcom-tool-kit/error": "^2.0.1",
         "@dotcom-tool-kit/logger": "^2.1.2",
-        "@dotcom-tool-kit/types": "^2.6.2",
+        "@dotcom-tool-kit/types": "^2.7.0",
         "fs": "0.0.1-security",
         "glob": "^7.1.7",
         "mocha": "^8.3.2",
@@ -20495,12 +20496,12 @@
     },
     "plugins/n-test": {
       "name": "@dotcom-tool-kit/n-test",
-      "version": "2.1.4",
+      "version": "2.1.5",
       "license": "ISC",
       "dependencies": {
         "@dotcom-tool-kit/logger": "^2.1.2",
         "@dotcom-tool-kit/state": "^2.0.1",
-        "@dotcom-tool-kit/types": "^2.6.2",
+        "@dotcom-tool-kit/types": "^2.7.0",
         "@financial-times/n-test": "^4.0.1",
         "tslib": "^2.3.1"
       },
@@ -20520,14 +20521,14 @@
     },
     "plugins/next-router": {
       "name": "@dotcom-tool-kit/next-router",
-      "version": "2.0.9",
+      "version": "2.0.10",
       "license": "ISC",
       "dependencies": {
         "@dotcom-tool-kit/error": "^2.0.1",
         "@dotcom-tool-kit/logger": "^2.1.2",
         "@dotcom-tool-kit/state": "^2.0.1",
-        "@dotcom-tool-kit/types": "^2.6.2",
-        "@dotcom-tool-kit/vault": "^2.0.9",
+        "@dotcom-tool-kit/types": "^2.7.0",
+        "@dotcom-tool-kit/vault": "^2.0.10",
         "ft-next-router": "^1.0.0",
         "tslib": "^2.3.1"
       },
@@ -20542,13 +20543,13 @@
     },
     "plugins/node": {
       "name": "@dotcom-tool-kit/node",
-      "version": "2.2.2",
+      "version": "2.2.3",
       "license": "ISC",
       "dependencies": {
         "@dotcom-tool-kit/error": "^2.0.1",
         "@dotcom-tool-kit/state": "^2.0.1",
-        "@dotcom-tool-kit/types": "^2.6.2",
-        "@dotcom-tool-kit/vault": "^2.0.9",
+        "@dotcom-tool-kit/types": "^2.7.0",
+        "@dotcom-tool-kit/vault": "^2.0.10",
         "get-port": "^5.1.1",
         "tslib": "^2.3.1",
         "wait-port": "^0.2.9"
@@ -20564,13 +20565,13 @@
     },
     "plugins/nodemon": {
       "name": "@dotcom-tool-kit/nodemon",
-      "version": "2.1.2",
+      "version": "2.1.3",
       "license": "ISC",
       "dependencies": {
         "@dotcom-tool-kit/error": "^2.0.1",
         "@dotcom-tool-kit/state": "^2.0.1",
-        "@dotcom-tool-kit/types": "^2.6.2",
-        "@dotcom-tool-kit/vault": "^2.0.9",
+        "@dotcom-tool-kit/types": "^2.7.0",
+        "@dotcom-tool-kit/vault": "^2.0.10",
         "get-port": "^5.1.1",
         "tslib": "^2.3.1"
       },
@@ -20589,14 +20590,14 @@
     },
     "plugins/npm": {
       "name": "@dotcom-tool-kit/npm",
-      "version": "2.0.10",
+      "version": "2.0.11",
       "license": "ISC",
       "dependencies": {
         "@actions/exec": "^1.1.0",
         "@dotcom-tool-kit/error": "^2.0.1",
-        "@dotcom-tool-kit/package-json-hook": "^2.1.1",
+        "@dotcom-tool-kit/package-json-hook": "^3.0.0",
         "@dotcom-tool-kit/state": "^2.0.1",
-        "@dotcom-tool-kit/types": "^2.6.2",
+        "@dotcom-tool-kit/types": "^2.7.0",
         "libnpmpack": "^3.1.0",
         "libnpmpublish": "^5.0.1",
         "pacote": "^12.0.3",
@@ -20753,10 +20754,10 @@
     },
     "plugins/pa11y": {
       "name": "@dotcom-tool-kit/pa11y",
-      "version": "0.3.6",
+      "version": "0.3.7",
       "license": "ISC",
       "dependencies": {
-        "@dotcom-tool-kit/types": "^2.6.2",
+        "@dotcom-tool-kit/types": "^2.7.0",
         "pa11y-ci": "^3.0.1",
         "tslib": "^2.3.1"
       },
@@ -20774,13 +20775,13 @@
     },
     "plugins/prettier": {
       "name": "@dotcom-tool-kit/prettier",
-      "version": "2.1.0",
+      "version": "2.1.1",
       "license": "ISC",
       "dependencies": {
         "@dotcom-tool-kit/error": "^2.0.1",
         "@dotcom-tool-kit/logger": "^2.1.2",
-        "@dotcom-tool-kit/package-json-hook": "^2.1.1",
-        "@dotcom-tool-kit/types": "^2.6.2",
+        "@dotcom-tool-kit/package-json-hook": "^3.0.0",
+        "@dotcom-tool-kit/types": "^2.7.0",
         "fast-glob": "^3.2.7",
         "hook-std": "^2.0.0",
         "prettier": "^2.2.1",
@@ -20803,11 +20804,11 @@
     },
     "plugins/secret-squirrel": {
       "name": "@dotcom-tool-kit/secret-squirrel",
-      "version": "1.0.8",
+      "version": "1.0.9",
       "license": "ISC",
       "dependencies": {
         "@dotcom-tool-kit/logger": "^2.1.2",
-        "@dotcom-tool-kit/types": "^2.6.2",
+        "@dotcom-tool-kit/types": "^2.7.0",
         "tslib": "^2.3.1"
       },
       "peerDependencies": {
@@ -20822,12 +20823,12 @@
     },
     "plugins/upload-assets-to-s3": {
       "name": "@dotcom-tool-kit/upload-assets-to-s3",
-      "version": "2.0.10",
+      "version": "2.0.11",
       "license": "ISC",
       "dependencies": {
         "@dotcom-tool-kit/error": "^2.0.1",
         "@dotcom-tool-kit/logger": "^2.1.2",
-        "@dotcom-tool-kit/types": "^2.6.2",
+        "@dotcom-tool-kit/types": "^2.7.0",
         "aws-sdk": "^2.901.0",
         "glob": "^7.1.6",
         "mime": "^2.5.2",
@@ -20852,12 +20853,12 @@
     },
     "plugins/webpack": {
       "name": "@dotcom-tool-kit/webpack",
-      "version": "2.1.8",
+      "version": "2.1.9",
       "license": "MIT",
       "dependencies": {
         "@dotcom-tool-kit/error": "^2.0.1",
         "@dotcom-tool-kit/logger": "^2.1.2",
-        "@dotcom-tool-kit/types": "^2.6.2",
+        "@dotcom-tool-kit/types": "^2.7.0",
         "tslib": "^2.3.1",
         "webpack-cli": "^4.6.0"
       },
@@ -22114,7 +22115,7 @@
         "@babel/preset-env": "^7.16.11",
         "@dotcom-tool-kit/error": "^2.0.1",
         "@dotcom-tool-kit/logger": "^2.1.2",
-        "@dotcom-tool-kit/types": "^2.6.2",
+        "@dotcom-tool-kit/types": "^2.7.0",
         "@jest/globals": "^27.4.6",
         "fast-glob": "^3.2.11",
         "tslib": "^2.3.1",
@@ -22131,9 +22132,9 @@
     "@dotcom-tool-kit/backend-app": {
       "version": "file:plugins/backend-app",
       "requires": {
-        "@dotcom-tool-kit/circleci-heroku": "^2.0.12",
-        "@dotcom-tool-kit/node": "^2.2.2",
-        "@dotcom-tool-kit/npm": "^2.0.10"
+        "@dotcom-tool-kit/circleci-heroku": "^2.1.0",
+        "@dotcom-tool-kit/node": "^2.2.3",
+        "@dotcom-tool-kit/npm": "^2.0.11"
       }
     },
     "@dotcom-tool-kit/circleci": {
@@ -22142,7 +22143,7 @@
         "@dotcom-tool-kit/error": "^2.0.0",
         "@dotcom-tool-kit/logger": "^2.1.1",
         "@dotcom-tool-kit/state": "^2.0.0",
-        "@dotcom-tool-kit/types": "^2.6.1",
+        "@dotcom-tool-kit/types": "^2.7.0",
         "@jest/globals": "^27.4.6",
         "@types/jest": "^27.4.0",
         "@types/js-yaml": "^4.0.3",
@@ -22168,8 +22169,8 @@
     "@dotcom-tool-kit/circleci-heroku": {
       "version": "file:plugins/circleci-heroku",
       "requires": {
-        "@dotcom-tool-kit/circleci": "^2.1.7",
-        "@dotcom-tool-kit/heroku": "^2.1.0",
+        "@dotcom-tool-kit/circleci": "^3.0.0",
+        "@dotcom-tool-kit/heroku": "^2.1.1",
         "tslib": "^2.3.1"
       },
       "dependencies": {
@@ -22183,9 +22184,9 @@
     "@dotcom-tool-kit/circleci-npm": {
       "version": "file:plugins/circleci-npm",
       "requires": {
-        "@dotcom-tool-kit/circleci": "^2.1.7",
-        "@dotcom-tool-kit/npm": "^2.0.10",
-        "@dotcom-tool-kit/types": "^2.6.2",
+        "@dotcom-tool-kit/circleci": "^3.0.0",
+        "@dotcom-tool-kit/npm": "^2.0.11",
+        "@dotcom-tool-kit/types": "^2.7.0",
         "tslib": "^2.3.1"
       },
       "dependencies": {
@@ -22199,8 +22200,8 @@
     "@dotcom-tool-kit/component": {
       "version": "file:plugins/component",
       "requires": {
-        "@dotcom-tool-kit/circleci-npm": "^2.0.9",
-        "@dotcom-tool-kit/npm": "^2.0.9"
+        "@dotcom-tool-kit/circleci-npm": "^3.0.0",
+        "@dotcom-tool-kit/npm": "^2.0.11"
       }
     },
     "@dotcom-tool-kit/create": {
@@ -22208,7 +22209,7 @@
       "requires": {
         "@dotcom-tool-kit/error": "^2.0.1",
         "@dotcom-tool-kit/logger": "^2.1.2",
-        "@dotcom-tool-kit/types": "^2.6.2",
+        "@dotcom-tool-kit/types": "^2.7.0",
         "@financial-times/package-json": "^3.0.0",
         "@quarterto/parse-makefile-rules": "^1.1.0",
         "@types/financial-times__package-json": "^1.9.0",
@@ -22218,7 +22219,7 @@
         "@types/pacote": "^11.1.3",
         "@types/prompts": "^2.0.14",
         "cosmiconfig": "^7.0.1",
-        "dotcom-tool-kit": "^2.3.6",
+        "dotcom-tool-kit": "^2.4.0",
         "import-cwd": "^3.0.0",
         "js-yaml": "^4.1.0",
         "komatsu": "^1.3.0",
@@ -22256,7 +22257,7 @@
       "requires": {
         "@dotcom-tool-kit/error": "^2.0.1",
         "@dotcom-tool-kit/logger": "^2.1.2",
-        "@dotcom-tool-kit/types": "^2.6.2",
+        "@dotcom-tool-kit/types": "^2.7.0",
         "@jest/globals": "^27.4.6",
         "@types/eslint": "^7.2.13",
         "eslint": "^8.15.0",
@@ -22402,8 +22403,8 @@
     "@dotcom-tool-kit/frontend-app": {
       "version": "file:plugins/frontend-app",
       "requires": {
-        "@dotcom-tool-kit/backend-app": "^2.0.12",
-        "@dotcom-tool-kit/webpack": "^2.1.8"
+        "@dotcom-tool-kit/backend-app": "^2.0.13",
+        "@dotcom-tool-kit/webpack": "^2.1.9"
       }
     },
     "@dotcom-tool-kit/heroku": {
@@ -22411,11 +22412,11 @@
       "requires": {
         "@dotcom-tool-kit/error": "^2.0.1",
         "@dotcom-tool-kit/logger": "^2.1.2",
-        "@dotcom-tool-kit/npm": "^2.0.10",
-        "@dotcom-tool-kit/package-json-hook": "^2.1.1",
+        "@dotcom-tool-kit/npm": "^2.0.11",
+        "@dotcom-tool-kit/package-json-hook": "^3.0.0",
         "@dotcom-tool-kit/state": "^2.0.1",
-        "@dotcom-tool-kit/types": "^2.6.2",
-        "@dotcom-tool-kit/vault": "^2.0.9",
+        "@dotcom-tool-kit/types": "^2.7.0",
+        "@dotcom-tool-kit/vault": "^2.0.10",
         "@dotcom-tool-kit/wait-for-ok": "^2.0.1",
         "@octokit/request": "^5.6.0",
         "@octokit/request-error": "^2.1.0",
@@ -22439,7 +22440,7 @@
     "@dotcom-tool-kit/husky-npm": {
       "version": "file:plugins/husky-npm",
       "requires": {
-        "@dotcom-tool-kit/package-json-hook": "^2.1.1",
+        "@dotcom-tool-kit/package-json-hook": "^3.0.0",
         "tslib": "^2.3.1"
       },
       "dependencies": {
@@ -22454,7 +22455,7 @@
       "version": "file:plugins/jest",
       "requires": {
         "@dotcom-tool-kit/logger": "^2.1.2",
-        "@dotcom-tool-kit/types": "^2.6.2",
+        "@dotcom-tool-kit/types": "^2.7.0",
         "@jest/globals": "^27.4.6",
         "tslib": "^2.3.1",
         "winston": "^3.5.1"
@@ -22471,8 +22472,8 @@
       "version": "file:plugins/lint-staged",
       "requires": {
         "@dotcom-tool-kit/logger": "^2.1.2",
-        "@dotcom-tool-kit/package-json-hook": "^2.1.1",
-        "@dotcom-tool-kit/types": "^2.6.2",
+        "@dotcom-tool-kit/package-json-hook": "^3.0.0",
+        "@dotcom-tool-kit/types": "^2.7.0",
         "lint-staged": "^11.2.3",
         "tslib": "^2.3.1"
       },
@@ -22518,9 +22519,9 @@
     "@dotcom-tool-kit/lint-staged-npm": {
       "version": "file:plugins/lint-staged-npm",
       "requires": {
-        "@dotcom-tool-kit/husky-npm": "^2.2.1",
-        "@dotcom-tool-kit/lint-staged": "^2.1.9",
-        "@dotcom-tool-kit/options": "^2.0.9",
+        "@dotcom-tool-kit/husky-npm": "^3.0.0",
+        "@dotcom-tool-kit/lint-staged": "^3.0.0",
+        "@dotcom-tool-kit/options": "^2.0.10",
         "tslib": "^2.3.1"
       },
       "dependencies": {
@@ -22556,7 +22557,7 @@
       "requires": {
         "@dotcom-tool-kit/error": "^2.0.1",
         "@dotcom-tool-kit/logger": "^2.1.2",
-        "@dotcom-tool-kit/types": "^2.6.2",
+        "@dotcom-tool-kit/types": "^2.7.0",
         "@jest/globals": "^27.4.6",
         "@types/glob": "^7.1.3",
         "@types/mocha": "^8.2.2",
@@ -22579,7 +22580,7 @@
       "requires": {
         "@dotcom-tool-kit/logger": "^2.1.2",
         "@dotcom-tool-kit/state": "^2.0.1",
-        "@dotcom-tool-kit/types": "^2.6.2",
+        "@dotcom-tool-kit/types": "^2.7.0",
         "@financial-times/n-test": "^4.0.1",
         "@jest/globals": "^27.4.6",
         "@types/jest": "^27.4.0",
@@ -22600,8 +22601,8 @@
         "@dotcom-tool-kit/error": "^2.0.1",
         "@dotcom-tool-kit/logger": "^2.1.2",
         "@dotcom-tool-kit/state": "^2.0.1",
-        "@dotcom-tool-kit/types": "^2.6.2",
-        "@dotcom-tool-kit/vault": "^2.0.9",
+        "@dotcom-tool-kit/types": "^2.7.0",
+        "@dotcom-tool-kit/vault": "^2.0.10",
         "ft-next-router": "^1.0.0",
         "tslib": "^2.3.1"
       },
@@ -22618,8 +22619,8 @@
       "requires": {
         "@dotcom-tool-kit/error": "^2.0.1",
         "@dotcom-tool-kit/state": "^2.0.1",
-        "@dotcom-tool-kit/types": "^2.6.2",
-        "@dotcom-tool-kit/vault": "^2.0.9",
+        "@dotcom-tool-kit/types": "^2.7.0",
+        "@dotcom-tool-kit/vault": "^2.0.10",
         "get-port": "^5.1.1",
         "tslib": "^2.3.1",
         "wait-port": "^0.2.9"
@@ -22637,8 +22638,8 @@
       "requires": {
         "@dotcom-tool-kit/error": "^2.0.1",
         "@dotcom-tool-kit/state": "^2.0.1",
-        "@dotcom-tool-kit/types": "^2.6.2",
-        "@dotcom-tool-kit/vault": "^2.0.9",
+        "@dotcom-tool-kit/types": "^2.7.0",
+        "@dotcom-tool-kit/vault": "^2.0.10",
         "@types/nodemon": "^1.19.1",
         "get-port": "^5.1.1",
         "tslib": "^2.3.1"
@@ -22656,9 +22657,9 @@
       "requires": {
         "@actions/exec": "^1.1.0",
         "@dotcom-tool-kit/error": "^2.0.1",
-        "@dotcom-tool-kit/package-json-hook": "^2.1.1",
+        "@dotcom-tool-kit/package-json-hook": "^3.0.0",
         "@dotcom-tool-kit/state": "^2.0.1",
-        "@dotcom-tool-kit/types": "^2.6.2",
+        "@dotcom-tool-kit/types": "^2.7.0",
         "@types/libnpmpublish": "^4.0.1",
         "@types/pacote": "^11.1.3",
         "@types/tar": "^6.1.1",
@@ -22775,7 +22776,7 @@
     "@dotcom-tool-kit/options": {
       "version": "file:lib/options",
       "requires": {
-        "@dotcom-tool-kit/types": "^2.6.2",
+        "@dotcom-tool-kit/types": "^2.7.0",
         "tslib": "^2.3.1"
       },
       "dependencies": {
@@ -22789,7 +22790,7 @@
     "@dotcom-tool-kit/pa11y": {
       "version": "file:plugins/pa11y",
       "requires": {
-        "@dotcom-tool-kit/types": "^2.6.2",
+        "@dotcom-tool-kit/types": "^2.7.0",
         "@types/pa11y": "^5.3.4",
         "pa11y-ci": "^3.0.1",
         "tslib": "^2.3.1"
@@ -22825,8 +22826,8 @@
       "requires": {
         "@dotcom-tool-kit/error": "^2.0.1",
         "@dotcom-tool-kit/logger": "^2.1.2",
-        "@dotcom-tool-kit/package-json-hook": "^2.1.1",
-        "@dotcom-tool-kit/types": "^2.6.2",
+        "@dotcom-tool-kit/package-json-hook": "^3.0.0",
+        "@dotcom-tool-kit/types": "^2.7.0",
         "@jest/globals": "^27.4.6",
         "fast-glob": "^3.2.7",
         "hook-std": "^2.0.0",
@@ -22848,11 +22849,11 @@
       "version": "file:core/sandbox",
       "requires": {
         "@dotcom-tool-kit/circleci-heroku": "^2.0.0",
-        "@dotcom-tool-kit/circleci-npm": "^2.0.0",
+        "@dotcom-tool-kit/circleci-npm": "^3.0.0",
         "@dotcom-tool-kit/eslint": "^2.0.0",
         "@dotcom-tool-kit/frontend-app": "^2.0.0",
         "@dotcom-tool-kit/jest": "^2.0.0",
-        "@dotcom-tool-kit/lint-staged": "^2.0.0",
+        "@dotcom-tool-kit/lint-staged": "^3.0.0",
         "@dotcom-tool-kit/lint-staged-npm": "^2.0.0",
         "@dotcom-tool-kit/mocha": "^2.0.0",
         "@dotcom-tool-kit/n-test": "^2.0.0",
@@ -22871,7 +22872,7 @@
       "version": "file:plugins/secret-squirrel",
       "requires": {
         "@dotcom-tool-kit/logger": "^2.1.2",
-        "@dotcom-tool-kit/types": "^2.6.2",
+        "@dotcom-tool-kit/types": "^2.7.0",
         "tslib": "^2.3.1"
       },
       "dependencies": {
@@ -22921,7 +22922,7 @@
         "@aws-sdk/types": "^3.13.1",
         "@dotcom-tool-kit/error": "^2.0.1",
         "@dotcom-tool-kit/logger": "^2.1.2",
-        "@dotcom-tool-kit/types": "^2.6.2",
+        "@dotcom-tool-kit/types": "^2.7.0",
         "@jest/globals": "^27.4.6",
         "@types/glob": "^7.1.3",
         "@types/jest": "^27.4.0",
@@ -22944,8 +22945,8 @@
       "version": "file:lib/vault",
       "requires": {
         "@dotcom-tool-kit/error": "^2.0.1",
-        "@dotcom-tool-kit/options": "^2.0.9",
-        "@dotcom-tool-kit/types": "^2.6.2",
+        "@dotcom-tool-kit/options": "^2.0.10",
+        "@dotcom-tool-kit/types": "^2.7.0",
         "@financial-times/n-fetch": "^1.0.0-beta.7",
         "@types/jest": "^27.0.2",
         "fs": "0.0.1-security",
@@ -22998,7 +22999,7 @@
       "requires": {
         "@dotcom-tool-kit/error": "^2.0.1",
         "@dotcom-tool-kit/logger": "^2.1.2",
-        "@dotcom-tool-kit/types": "^2.6.2",
+        "@dotcom-tool-kit/types": "^2.7.0",
         "@jest/globals": "^27.4.6",
         "ts-node": "^10.0.0",
         "tslib": "^2.3.1",
@@ -26614,22 +26615,22 @@
     "dotcom-tool-kit": {
       "version": "file:core/cli",
       "requires": {
-        "@dotcom-tool-kit/babel": "^2.0.9",
-        "@dotcom-tool-kit/backend-app": "^2.0.12",
-        "@dotcom-tool-kit/circleci": "^2.1.7",
-        "@dotcom-tool-kit/circleci-heroku": "^2.0.12",
+        "@dotcom-tool-kit/babel": "^2.0.10",
+        "@dotcom-tool-kit/backend-app": "^2.0.13",
+        "@dotcom-tool-kit/circleci": "^3.0.0",
+        "@dotcom-tool-kit/circleci-heroku": "^2.1.0",
         "@dotcom-tool-kit/error": "^2.0.1",
-        "@dotcom-tool-kit/eslint": "^2.2.2",
-        "@dotcom-tool-kit/frontend-app": "^2.1.10",
-        "@dotcom-tool-kit/heroku": "^2.1.0",
+        "@dotcom-tool-kit/eslint": "^2.2.3",
+        "@dotcom-tool-kit/frontend-app": "^2.1.11",
+        "@dotcom-tool-kit/heroku": "^2.1.1",
         "@dotcom-tool-kit/logger": "^2.1.2",
-        "@dotcom-tool-kit/mocha": "^2.1.6",
-        "@dotcom-tool-kit/n-test": "^2.1.4",
-        "@dotcom-tool-kit/npm": "^2.0.10",
-        "@dotcom-tool-kit/options": "^2.0.9",
-        "@dotcom-tool-kit/types": "^2.6.2",
+        "@dotcom-tool-kit/mocha": "^2.1.7",
+        "@dotcom-tool-kit/n-test": "^2.1.5",
+        "@dotcom-tool-kit/npm": "^2.0.11",
+        "@dotcom-tool-kit/options": "^2.0.10",
+        "@dotcom-tool-kit/types": "^2.7.0",
         "@dotcom-tool-kit/wait-for-ok": "^2.0.1",
-        "@dotcom-tool-kit/webpack": "^2.1.8",
+        "@dotcom-tool-kit/webpack": "^2.1.9",
         "@jest/globals": "^27.4.6",
         "@types/lodash.groupby": "^4.6.7",
         "@types/lodash.merge": "^4.6.6",

--- a/plugins/circleci-heroku/src/index.ts
+++ b/plugins/circleci-heroku/src/index.ts
@@ -9,6 +9,7 @@ export class DeployReview extends CircleCiConfigHook {
     requires: ['tool-kit/setup', 'waiting-for-approval'],
     filters: { branches: { ignore: 'main' } }
   }
+  addToNightly = true
 }
 
 export class DeployStaging extends CircleCiConfigHook {

--- a/plugins/circleci/src/circleci-config.ts
+++ b/plugins/circleci/src/circleci-config.ts
@@ -13,7 +13,7 @@ const majorOrbVersion = '2'
 
 interface CircleCIState {
   jobs: Record<string, JobConfig>
-  nightlyJobs: Record<string, JobConfig>
+  nightlyJobs: Record<string, Omit<JobConfig, 'filters'>>
   runOnVersionTags: boolean
   additionalFields: Record<string, unknown>
 }
@@ -106,7 +106,11 @@ export default abstract class CircleCiConfigHook extends Hook<CircleCIState> {
 
     state.jobs[this.job] = this.jobOptions
     if (this.addToNightly) {
-      state.nightlyJobs[this.job] = this.jobOptions
+      const jobOptionsWithoutFilters = {
+        ...this.jobOptions,
+        filters: undefined
+      }
+      state.nightlyJobs[this.job] = jobOptionsWithoutFilters
     }
     if (this.runOnVersionTags) {
       state.runOnVersionTags = true


### PR DESCRIPTION
# Description

Adding the `tool-kit/heroku-provision` job to the Nightly workflow. Our heroku apps would provision a review app as part of the Nightly scheduled workflow when the CircleCI config was not automated. We are adding the job back for our automated by Tool Kit configs.

This also includes a removing being able to set `filters` job options to Nightly workflow jobs. This is because we configure in CircleCI that our nightly workflows are triggered against the `main` branch only. Therefore if we add a job to be in the Nightly workflow, it shouldn't need to filter which branches it won't/will run against. And in the case for the `tool-kit/heroku-provision` job where it has a filter not to run against the `main` branch for our `tool-kit` workflow, we need to cancel this option for the `nightly` workflow.

# Checklist:

- [x] My branch has been rebased onto the latest commit on main (don't merge main into your branch)
- [x] My commit messages are [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/), for example: `feat(circleci): add support for nightly workflows`, `fix: set Heroku app name for staging apps too`
