### PR TITLE
CPP-1018: add secret squirrel to bootstrap plugins

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -20059,7 +20059,9 @@
       "license": "ISC",
       "dependencies": {
         "@dotcom-tool-kit/circleci-npm": "^3.0.0",
-        "@dotcom-tool-kit/npm": "^2.0.11"
+        "@dotcom-tool-kit/husky-npm": "^3.0.0",
+        "@dotcom-tool-kit/npm": "^2.0.11",
+        "@dotcom-tool-kit/secret-squirrel": "^1.0.9"
       },
       "peerDependencies": {
         "dotcom-tool-kit": "2.x"
@@ -22205,7 +22207,9 @@
       "version": "file:plugins/component",
       "requires": {
         "@dotcom-tool-kit/circleci-npm": "^3.0.0",
-        "@dotcom-tool-kit/npm": "^2.0.11"
+        "@dotcom-tool-kit/husky-npm": "^3.0.0",
+        "@dotcom-tool-kit/npm": "^2.0.11",
+        "@dotcom-tool-kit/secret-squirrel": "^1.0.9"
       }
     },
     "@dotcom-tool-kit/create": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -19970,8 +19970,10 @@
       "license": "ISC",
       "dependencies": {
         "@dotcom-tool-kit/circleci-heroku": "^2.1.0",
+        "@dotcom-tool-kit/husky-npm": "^3.0.0",
         "@dotcom-tool-kit/node": "^2.2.3",
-        "@dotcom-tool-kit/npm": "^2.0.11"
+        "@dotcom-tool-kit/npm": "^2.0.11",
+        "@dotcom-tool-kit/secret-squirrel": "^1.0.9"
       },
       "peerDependencies": {
         "dotcom-tool-kit": "2.x"
@@ -22133,8 +22135,10 @@
       "version": "file:plugins/backend-app",
       "requires": {
         "@dotcom-tool-kit/circleci-heroku": "^2.1.0",
+        "@dotcom-tool-kit/husky-npm": "^3.0.0",
         "@dotcom-tool-kit/node": "^2.2.3",
-        "@dotcom-tool-kit/npm": "^2.0.11"
+        "@dotcom-tool-kit/npm": "^2.0.11",
+        "@dotcom-tool-kit/secret-squirrel": "^1.0.9"
       }
     },
     "@dotcom-tool-kit/circleci": {

--- a/plugins/backend-app/.toolkitrc.yml
+++ b/plugins/backend-app/.toolkitrc.yml
@@ -2,6 +2,8 @@ plugins:
   - '@dotcom-tool-kit/npm'
   - '@dotcom-tool-kit/circleci-heroku'
   - '@dotcom-tool-kit/node'
+  - '@dotcom-tool-kit/husky-npm'
+  - '@dotcom-tool-kit/secret-squirrel'
 
 hooks:
   'run:local':

--- a/plugins/backend-app/package.json
+++ b/plugins/backend-app/package.json
@@ -8,8 +8,10 @@
   "license": "ISC",
   "dependencies": {
     "@dotcom-tool-kit/circleci-heroku": "^2.1.0",
+    "@dotcom-tool-kit/husky-npm": "^3.0.0",
+    "@dotcom-tool-kit/node": "^2.2.3",
     "@dotcom-tool-kit/npm": "^2.0.11",
-    "@dotcom-tool-kit/node": "^2.2.3"
+    "@dotcom-tool-kit/secret-squirrel": "^1.0.9"
   },
   "repository": {
     "type": "git",

--- a/plugins/component/.toolkitrc.yml
+++ b/plugins/component/.toolkitrc.yml
@@ -1,3 +1,5 @@
 plugins:
   - '@dotcom-tool-kit/npm'
   - '@dotcom-tool-kit/circleci-npm'
+  - '@dotcom-tool-kit/husky-npm'
+  - '@dotcom-tool-kit/secret-squirrel'

--- a/plugins/component/package.json
+++ b/plugins/component/package.json
@@ -21,6 +21,8 @@
   },
   "dependencies": {
     "@dotcom-tool-kit/circleci-npm": "^3.0.0",
-    "@dotcom-tool-kit/npm": "^2.0.11"
+    "@dotcom-tool-kit/husky-npm": "^3.0.0",
+    "@dotcom-tool-kit/npm": "^2.0.11",
+    "@dotcom-tool-kit/secret-squirrel": "^1.0.9"
   }
 }


### PR DESCRIPTION
# Description

Add `@dotcom-tool-kit/secret-squirrel` as a dependency to our bootstrap plugins, `@dotcom-tool-kit/component` and `@dotcom-tool-kit/backend-app`. Adding the plugin as part of the migration (then into the template apps) should bring Tool Kit more align to feature parity to `n-gage`. We want `secret-squirrel` to be installed by default but, like n-gage, it is possible to remove it from an application.

# Checklist:

- [x] My branch has been rebased onto the latest commit on main (don't merge main into your branch)
- [x] My commit messages are [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/), for example: `feat(circleci): add support for nightly workflows`, `fix: set Heroku app name for staging apps too`
