### PR TITLE
Add bootstrap plugin readmes

### DIFF
--- a/plugins/backend-app/readme.md
+++ b/plugins/backend-app/readme.md
@@ -1,0 +1,26 @@
+# @dotcom-tool-kit/backend-app
+
+A bootstrap plugin that provides the minimum required Tool Kit plugins for a "backend" (aka an [API](https://github.com/Financial-Times/next/wiki/Naming-Conventions#apis)). The plugins are:
+
+- [`@dotcom-tool-kit/npm`](https://github.com/Financial-Times/dotcom-tool-kit/tree/main/plugins/npm)
+- [`@dotcom-tool-kit/circleci-heroku`](https://github.com/Financial-Times/dotcom-tool-kit/tree/main/plugins/circleci-heroku)
+- [`@dotcom-tool-kit/node`](https://github.com/Financial-Times/dotcom-tool-kit/tree/main/plugins/node)
+- [`@dotcom-tool-kit/husky-npm`](https://github.com/Financial-Times/dotcom-tool-kit/tree/main/plugins/husky-npm)
+- [`@dotcom-tool-kit/secret-squirrel`](https://github.com/Financial-Times/dotcom-tool-kit/tree/main/plugins/secret-squirrel)
+
+This bootstrap plugin is also preconfigured to run the `Node` task on the hook `run:local`.
+
+## Installation
+
+With Tool Kit [already set up](https://github.com/financial-times/dotcom-tool-kit#installing-and-using-tool-kit), install this plugin as a dev dependency:
+
+```sh
+npm install --save-dev @dotcom-tool-kit/backend-app
+```
+
+And add it to your repo's `.toolkitrc.yml`:
+
+```yaml
+plugins:
+    - '@dotcom-tool-kit/backend-app'
+```

--- a/plugins/component/readme.md
+++ b/plugins/component/readme.md
@@ -1,0 +1,23 @@
+# @dotcom-tool-kit/component
+
+A bootstrap plugin that provides the minimum required Tool Kit plugins for a "component" (aka an [npm module](https://github.com/Financial-Times/next/wiki/Naming-Conventions#npm-modules)). The plugins are:
+
+- [`@dotcom-tool-kit/npm`](https://github.com/Financial-Times/dotcom-tool-kit/tree/main/plugins/npm)
+- [`@dotcom-tool-kit/circleci-npm`](https://github.com/Financial-Times/dotcom-tool-kit/tree/main/plugins/circleci-npm)
+- [`@dotcom-tool-kit/husky-npm`](https://github.com/Financial-Times/dotcom-tool-kit/tree/main/plugins/husky-npm)
+- [`@dotcom-tool-kit/secret-squirrel`](https://github.com/Financial-Times/dotcom-tool-kit/tree/main/plugins/secret-squirrel)
+
+## Installation
+
+With Tool Kit [already set up](https://github.com/financial-times/dotcom-tool-kit#installing-and-using-tool-kit), install this plugin as a dev dependency:
+
+```sh
+npm install --save-dev @dotcom-tool-kit/component
+```
+
+And add it to your repo's `.toolkitrc.yml`:
+
+```yaml
+plugins:
+    - '@dotcom-tool-kit/component'
+```

--- a/plugins/frontend-app/readme.md
+++ b/plugins/frontend-app/readme.md
@@ -1,0 +1,23 @@
+# @dotcom-tool-kit/frontend-app
+
+A bootstrap plugin that provides the minimum required Tool Kit plugins for a "frontend" (aka an [App or Page](https://github.com/Financial-Times/next/wiki/Naming-Conventions#apps)). The plugins are:
+
+- [`@dotcom-tool-kit/webpack`](https://github.com/Financial-Times/dotcom-tool-kit/tree/main/plugins/webpack)
+- [`@dotcom-tool-kit/backend-app`](https://github.com/Financial-Times/dotcom-tool-kit/tree/main/plugins/backend-app)
+
+This bootstrap plugin is also preconfigured to run the `Node`, `WebpackDevelopment`, and `WebpackWatch` tasks on the hook `run:local`.
+
+## Installation
+
+With Tool Kit [already set up](https://github.com/financial-times/dotcom-tool-kit#installing-and-using-tool-kit), install this plugin as a dev dependency:
+
+```sh
+npm install --save-dev @dotcom-tool-kit/frontend-app
+```
+
+And add it to your repo's `.toolkitrc.yml`:
+
+```yaml
+plugins:
+    - '@dotcom-tool-kit/frontend-app'
+```


### PR DESCRIPTION
# Description

Add readmes for the bootstrap plugins; `backend-app`, `frontend-app`, and `component`.

https://financialtimes.atlassian.net/browse/CPP-876
https://financialtimes.atlassian.net/browse/CPP-877
https://financialtimes.atlassian.net/browse/CPP-1040

# Checklist:

- [x] My branch has been rebased onto the latest commit on main (don't merge main into your branch)
- [x] My commit messages are [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/), for example: `feat(circleci): add support for nightly workflows`, `fix: set Heroku app name for staging apps too`
