### PR TITLE
fix(upload-assets-to-s3): only upload files

### DIFF
--- a/plugins/upload-assets-to-s3/src/tasks/upload-assets-to-s3.ts
+++ b/plugins/upload-assets-to-s3/src/tasks/upload-assets-to-s3.ts
@@ -81,7 +81,7 @@ export default class UploadAssetsToS3 extends Task<typeof UploadAssetsToS3Schema
     // Wrap extensions in braces if there are multiple
     const extensions = options.extensions.includes(',') ? `{${options.extensions}}` : options.extensions
     const globFile = `**/*${extensions}`
-    const files = glob.sync(globFile, { cwd: options.directory })
+    const files = glob.sync(globFile, { cwd: options.directory, nodir: true })
     const s3 = new aws.S3({
       // fallback to default value for accessKeyId if neither accessKeyIdEnvVar or accessKeyId have been provided as options
       accessKeyId:


### PR DESCRIPTION
the upload-assets-to-s3 plugin works by looping over the files passed to it and uploading each to s3. When the files to upload includes a folder (with files inside) the directory itself is passed to s3 for upload.
s3 throws an error because it can only read files and not directories. This change updates the glob pattern of files to upload to not include directories.
The files within the directory are still uploaded successfully

# Description

**Before:**
list of files to upload includes `v2` which is a directory:
<img width="259" alt="image" src="https://user-images.githubusercontent.com/17846996/207583601-b3d0552c-c8ee-49c9-b22f-048d0300047e.png">

error is thrown (although files are still uploaded successfully):
<img width="471" alt="image" src="https://user-images.githubusercontent.com/17846996/207583983-fe2b4f08-822f-4251-adab-50e43850a62d.png">
<img width="483" alt="image" src="https://user-images.githubusercontent.com/17846996/207583951-0febd65b-2946-428b-9789-173b8292017b.png">

**After:**
list of files to upload doesn't include any directories: 
<img width="255" alt="image" src="https://user-images.githubusercontent.com/17846996/207583648-4847fe43-9311-48b4-ae77-fd3eeb14cfb3.png">

files within the directory are still uploaded successfully:
<img width="911" alt="image" src="https://user-images.githubusercontent.com/17846996/207583862-36fcd430-4b91-4c73-97f6-2ad7e5570c50.png">

top level:
<img width="1086" alt="image" src="https://user-images.githubusercontent.com/17846996/207584297-91c77d2b-defd-4be2-ba50-1de0913d51be.png">

inside `v2` directory:
<img width="1120" alt="image" src="https://user-images.githubusercontent.com/17846996/207584378-b759167a-a634-4229-a11c-804fbf489417.png">


# Checklist:

- [x] My branch has been rebased onto the latest commit on main (don't merge main into your branch)
- [x] My commit messages are [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/), for example: `feat(circleci): add support for nightly workflows`, `fix: set Heroku app name for staging apps too`
