### PR TITLE
CPP-1012: docs: add more clarity on installing a plugin

### DIFF
--- a/docs/faq.md
+++ b/docs/faq.md
@@ -53,10 +53,10 @@ Funny you should ask! We have just the thing:
 |                     |                         | `Eslint`             |
 |                     |                         | `SecretSquirrel`     |
 |                     |                         | `CypressLocal`       |
-|                     |                         | `TypescriptTest`     |
+|                     |                         | `TypeScriptTest`     |
 | `build:local`       | npm                     | `BabelDevelopment`   |
 |                     |                         | `WebpackDevelopment` |
-|                     |                         | `TypescriptBuild`    |
+|                     |                         | `TypeScriptBuild`    |
 | `build:ci`          | circleci                | `BabelProduction`    |
 |                     |                         | `WebpackProduction`  |
 | `test:ci`           | circleci                | `Eslint`             |


### PR DESCRIPTION
add more clarity on installing a plugin in the case where Tool Kit has already been set up in a project.

The card reads:

Add documentation that explains how to add a plugin (that isn’t setup by the migration) to an existing tool kit project

This document should explain:
- how the configuration has been chosen
- how the plugin installs a hook
- how to select a hook for the plugin’s task to run in
- include using npx dotcom-tool-kit --help to review what has been done

However, I actually think most of that is well explained in the README's for the individual plugins, so I think maybe something on the top level README that introduces installing individual plugins might do.

# Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. 

# Checklist:

- [x] My branch has been rebased onto the latest commit on main (don't merge main into your branch)
- [x] My commit messages are [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/), for example: `feat(circleci): add support for nightly workflows`, `fix: set Heroku app name for staging apps too`
