### PR TITLE
Readme tidy up

### DIFF
--- a/plugins/circleci-heroku/readme.md
+++ b/plugins/circleci-heroku/readme.md
@@ -2,6 +2,8 @@
 
 A plugin that will add CircleCI jobs that will interact with Heroku to the CircleCI config.
 
+This plugin will be installed as a dependency of the [frontend-app](https://github.com/Financial-Times/dotcom-tool-kit/tree/main/plugins/frontend-app) and [backend-app](https://github.com/Financial-Times/dotcom-tool-kit/tree/main/plugins/backend-app) plugins so you do not need to install it separately if you are using either of those plugins.
+
 ## Installation
 
 Install `@dotcom-tool-kit/circleci-heroku` as a `devDependency` in your app:

--- a/plugins/circleci-npm/readme.md
+++ b/plugins/circleci-npm/readme.md
@@ -4,6 +4,8 @@ This plugin is for managing the `publish:tag` hook that is run from circleci to 
 
 The tool-kit/publish job is triggered in your circleci pipeline once you do a release with a tag matching the semver format. If your tag is a beta version, i.e. `v1.6.0-beta.1`, then the publish job will tag your build as a prerelease version. If your tag is a release version, i.e. `v1.6.0`, then the publish job will tag your build as the latest version.
 
+This plugin will be installed as a dependency of the [component](https://github.com/Financial-Times/dotcom-tool-kit/tree/main/plugins/component) plugin so you do not need to install it separately if you are using either of those plugins.
+
 ## Installation
 
 Install `@dotcom-tool-kit/circleci-npm` as a `devDependency` in your app:

--- a/plugins/circleci/readme.md
+++ b/plugins/circleci/readme.md
@@ -1,4 +1,4 @@
-# `circleci` Tool Kit plugin
+# @dotcom-tool-kit/circleci
 
 This plugin exposes state from the CircleCI environment for other plugins to consume generically. It also manages Tool Kit hooks that are run from CircleCI workflows.
 

--- a/plugins/circleci/readme.md
+++ b/plugins/circleci/readme.md
@@ -2,7 +2,7 @@
 
 This plugin exposes state from the CircleCI environment for other plugins to consume generically. It also manages Tool Kit hooks that are run from CircleCI workflows.
 
-This plugin will be installed as a dependency of the [frontend-app](https://github.com/Financial-Times/dotcom-tool-kit/tree/main/plugins/frontend-app), [backend-app](https://github.com/Financial-Times/dotcom-tool-kit/tree/main/plugins/backend-app), [circleci-heroku](https://github.com/Financial-Times/dotcom-tool-kit/tree/main/plugins/circleci-heroku), and [circleci-npm](https://github.com/Financial-Times/dotcom-tool-kit/tree/main/plugins/circleci-npm) plugins so you do not need to install it separately if you are using any of those plugins.
+This plugin will be installed as a dependency of the [frontend-app](https://github.com/Financial-Times/dotcom-tool-kit/tree/main/plugins/frontend-app), [backend-app](https://github.com/Financial-Times/dotcom-tool-kit/tree/main/plugins/backend-app), [component](https://github.com/Financial-Times/dotcom-tool-kit/tree/main/plugins/component), [circleci-heroku](https://github.com/Financial-Times/dotcom-tool-kit/tree/main/plugins/circleci-heroku), and [circleci-npm](https://github.com/Financial-Times/dotcom-tool-kit/tree/main/plugins/circleci-npm) plugins so you do not need to install it separately if you are using any of those plugins.
 
 ## Installation
 

--- a/plugins/heroku/readme.md
+++ b/plugins/heroku/readme.md
@@ -16,7 +16,7 @@ Add the plugin to your [Tool Kit configuration](https://github.com/financial-tim
 
 ```yaml
 plugins:
-	- '@dotcom-tool-kit/heroku'
+  - '@dotcom-tool-kit/heroku'
 ```
 
 And install this plugin's hooks:
@@ -27,9 +27,27 @@ npx dotcom-tool-kit --install
 
 This plugin cannot currently automatically install itself to heroku configuration, so it will exit, and explain what you need to include in the config.
 
-## Deployment workflow
+## Options
 
-TODO
+| Key | Description | Default value |
+|-|-|-|
+| `pipeline` | (required) the pipeline name for your application as it's defined in Heroku | none |
+| `systemCode` | (required) system code for your application as it's defined in Biz Ops | none |
+| `scaling` | (required) configuration for dyno scaling with a quantity and size for each production app | none |
+
+Here's what your configuration might look like passing in the above options:
+
+```yml
+options:
+  '@dotcom-tool-kit/heroku':
+    pipeline: 'ft-next-static'
+    systemCode: 'next-static'
+    scaling:
+      ft-next-static-eu:
+        web:
+          size: standard-1x
+          quantity: 1
+```
 
 ## Hooks
 
@@ -37,3 +55,12 @@ TODO
 |-|-|-|
 | `build:remote` | Compile any assets or code required for your app to run. | `heroku-postbuild` script in `package.json` |
 | `release:remote` | Run any post-release tasks for an app that require a tool-kit task, e.g. upload assets to s3 | `heroku-postbuild` script in `package.json` |
+
+## Tasks
+
+| Task | Description | Preconfigured hooks |
+|-|-|-|
+| `HerokuProduction` | deploy production app to Heroku via CircleCi | `deploy:production` |
+| `HerokuStaging` | deploy to staging | `deploy:staging` |
+| `HerokuReview` | create and test Heroku review app | `deploy:review` |
+| `HerokuTeardown` | scale down staging once smoke tests have been run | `teardown:staging` |

--- a/plugins/heroku/readme.md
+++ b/plugins/heroku/readme.md
@@ -1,4 +1,4 @@
-# `heroku` Tool Kit plugin
+# @dotcom-tool-kit/heroku
 
 This plugin handles deploying apps to Heroku. It also manages Tool Kit hooks that are run during Heroku builds.
 

--- a/plugins/heroku/readme.md
+++ b/plugins/heroku/readme.md
@@ -2,6 +2,8 @@
 
 This plugin handles deploying apps to Heroku. It also manages Tool Kit hooks that are run during Heroku builds.
 
+This plugin will be installed as a dependency of the [frontend-app](https://github.com/Financial-Times/dotcom-tool-kit/tree/main/plugins/frontend-app) and [backend-app](https://github.com/Financial-Times/dotcom-tool-kit/tree/main/plugins/backend-app) plugins so you do not need to install it separately if you are using either of those plugins.
+
 ## Installation
 
 Install `@dotcom-tool-kit/heroku` as a `devDependency` in your app:

--- a/plugins/husky-npm/README.md
+++ b/plugins/husky-npm/README.md
@@ -2,6 +2,8 @@
 
 A plugin to add git hooks to your project via [husky](https://typicode.github.io/husky/#/). These hooks can be configured with different tasks as your project requires.
 
+This plugin will be installed as a dependency of the [frontend-app](https://github.com/Financial-Times/dotcom-tool-kit/tree/main/plugins/frontend-app), [backend-app](https://github.com/Financial-Times/dotcom-tool-kit/tree/main/plugins/backend-app), and [component](https://github.com/Financial-Times/dotcom-tool-kit/tree/main/plugins/component) plugins so you do not need to install it separately if you are using either of those plugins.
+
 ## Installation
 
 With Tool Kit [already set up](https://github.com/financial-times/dotcom-tool-kit#installing-and-using-tool-kit), install this plugin as a dev dependency:

--- a/plugins/npm/readme.md
+++ b/plugins/npm/readme.md
@@ -1,4 +1,4 @@
-# `npm` Tool Kit plugin
+# @dotcom-tool-kit/npm
 
 This plugin is for managing Tool Kit hooks that are run from npm scripts (such as `npm run test`).
 

--- a/plugins/npm/readme.md
+++ b/plugins/npm/readme.md
@@ -2,6 +2,8 @@
 
 This plugin is for managing Tool Kit hooks that are run from npm scripts (such as `npm run test`).
 
+This plugin will be installed as a dependency of the [frontend-app](https://github.com/Financial-Times/dotcom-tool-kit/tree/main/plugins/frontend-app), [backend-app](https://github.com/Financial-Times/dotcom-tool-kit/tree/main/plugins/backend-app), and [component](https://github.com/Financial-Times/dotcom-tool-kit/tree/main/plugins/component) plugins so you do not need to install it separately if you are using either of those plugins.
+
 ## Installation
 
 Install `@dotcom-tool-kit/npm` as a `devDependency` in your app:

--- a/plugins/prettier/readme.md
+++ b/plugins/prettier/readme.md
@@ -1,4 +1,4 @@
-# `prettier` Tool Kit plugin
+# @dotcom-tool-kit/prettier
 
 This plugin is for adding prettier onto your apps.
 

--- a/plugins/secret-squirrel/readme.md
+++ b/plugins/secret-squirrel/readme.md
@@ -2,6 +2,8 @@
 
 Tool Kit plugin to run [Secret Squirrel](https://github.com/financial-times/secret-squirrel)
 
+This plugin will be installed as a dependency of the [frontend-app](https://github.com/Financial-Times/dotcom-tool-kit/tree/main/plugins/frontend-app), [backend-app](https://github.com/Financial-Times/dotcom-tool-kit/tree/main/plugins/backend-app), and [component](https://github.com/Financial-Times/dotcom-tool-kit/tree/main/plugins/component) plugins so you do not need to install it separately if you are using either of those plugins.
+
 ## Installation & Usage
 
 With Tool Kit [already set up](https://github.com/financial-times/dotcom-tool-kit#installing-and-using-tool-kit), install this plugin as a dev dependency:


### PR DESCRIPTION
A quick tidy up on the readme's we've done so far (each point has its own commit):
- standardise title
- add paragraph to those that are installed as part of the bootstrap plugins
- added some missing content

- [x] My branch has been rebased onto the latest commit on main (don't merge main into your branch)
- [x] My commit messages are [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/), for example: `feat(circleci): add support for nightly workflows`, `fix: set Heroku app name for staging apps too`
