### PR TITLE
Fix issues with release-please configuration

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -1,5 +1,5 @@
 {
-  "bootstrap-sha": "bc6f822e7a6927b65b63c91021ede10dad73006f",
+  "bootstrap-sha": "47035e3bd4e3ac399319b3421ce86a82f1c1ab21",
   "plugins": ["node-workspace"],
   "changelog-type": "github",
   "prerelease": true,

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -1,7 +1,6 @@
 {
   "bootstrap-sha": "47035e3bd4e3ac399319b3421ce86a82f1c1ab21",
   "plugins": ["node-workspace"],
-  "changelog-type": "github",
   "prerelease": true,
   "bump-minor-pre-major": true,
   "bump-patch-for-minor-pre-major": true,


### PR DESCRIPTION
# Description

These changes should improve the behaviour of release-please so that

1. new components are not incorrectly assigned a tag of `v2.0.0` when initially released
2. changelogs only include changes relevant to each component, an issue we were seeing since we [updated](https://github.com/Financial-Times/dotcom-tool-kit/pull/329) to release-please `v15.0.0`.

Further details can be found in the commit descriptions. I have tested the behaviour by running release-please locally.

# Checklist:

- [x] My branch has been rebased onto the latest commit on main (don't merge main into your branch)
- [x] My commit messages are [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/), for example: `feat(circleci): add support for nightly workflows`, `fix: set Heroku app name for staging apps too`
