### PR TITLE
fix(babel): making destination folders for transpiled code

### DIFF
--- a/plugins/babel/src/run-babel.ts
+++ b/plugins/babel/src/run-babel.ts
@@ -21,7 +21,6 @@ export async function runBabel(
   const { base } = fg.generateTasks(fileGlob)[0]
 
   const outputPath = options.outputPath ?? 'lib'
-  await fs.mkdir(outputPath, { recursive: true })
 
   if (options.configFile) {
     const { configFile } = options
@@ -38,7 +37,10 @@ export async function runBabel(
         error.details = `the problematic file was ${file}`
         throw error
       }
-      await fs.writeFile(path.join(outputPath, path.relative(base, file)), transformed.code)
+      // Create parent directories if they don't exist before creating child file of transpiled code.
+      const filePath = path.join(outputPath, path.relative(base, file))
+      await fs.mkdir(path.dirname(filePath), { recursive: true })
+      await fs.writeFile(filePath, transformed.code)
     })
   )
   unhook()


### PR DESCRIPTION
# Description

This PR fixes an issue for the Babel plugin identified when using it to transpile code in a Serverless app: https://github.com/Financial-Times/cp-metrics-catcher.

The file directory for the app is:

```
.
└── src
	├── clients
	│	└── cloudwatch.js
	└── functions
		└── heroku-token-rate-limit
			├── index.js
			└── lib
				└── get-remaining-requests.js
```

Running `dotcom-tool-kit build:local` with `'@dotcom-tool-kit/babel` set as a plugin in `.toolkitrc.yml` currently errors with:

```
ENOENT: no such file or directory, open 'lib/clients/cloudwatch.js'
```

This is because the root directory of the output path (which defaults to `lib`) is created via the below line of code, which only creates the `lib` directories (and no sub-directories as it does not yet have knowledge of any).

```js
await fs.mkdir(outputPath, { recursive: true })
```

When the following line of code runs, the first argument of `fs.writeFile()` is `lib/clients/cloudwatch.js`, resulting in the above-mentioned error because the `writeFile()` command can only create a file (which it then writes to) but not the file's parent directories.

```js
await fs.writeFile(path.join(outputPath, path.relative(base, file)), transformed.code)
```

The fix is not to create the root directory of the output path in isolation and instead for each file use the `mkdir` command to create the necessary parent directories for each file (the command does not overwrite existing directories).

# Checklist:

- [x] My branch has been rebased onto the latest commit on main (don't merge main into your branch)
- [x] My commit messages are [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/), for example: `feat(circleci): add support for nightly workflows`, `fix: set Heroku app name for staging apps too`
