### PR TITLE
fix: correct TypeScript casing

### DIFF
--- a/plugins/typescript/.toolkitrc.yml
+++ b/plugins/typescript/.toolkitrc.yml
@@ -1,4 +1,4 @@
 hooks:
-  'build:local': TypescriptBuild
+  'build:local': TypeScriptBuild
   'run:local': TypeScriptWatch
-  'test:local': TypescriptTest
+  'test:local': TypeScriptTest


### PR DESCRIPTION
# Description

This was erroring for me because the casing was incorrect. This should address the issue and stop me having to manually override.

# Checklist:

- [x] My branch has been rebased onto the latest commit on main (don't merge main into your branch)
- [x] My commit messages are [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/), for example: `feat(circleci): add support for nightly workflows`, `fix: set Heroku app name for staging apps too`
