### PR TITLE
CPP-1017: Readme intro update

### DIFF
--- a/docs/faq.md
+++ b/docs/faq.md
@@ -5,7 +5,7 @@ Below are responses to some general questions about Tool Kit that have been aske
 
 ## How do I add package specific configuration (for e.g. ESLint) to the Tool Kit plugin (e.g. @dotcom-tool-kit/eslint))?
 
-As much as possible Tool Kit doesn't handle configuration for third party packages. The purpose of Tool Kit’s plugin for packages is to get them working in the FT development workflow with the minimum possible configuration. Tool Kit plugins will leave package configuration to a specific configuration file for that package (e.g. `.eslintrc` for the ESLint package).
+As much as possible Tool Kit doesn't handle configuration for third party packages. The purpose of Tool Kit’s plugins for packages is to get them working in the FT development workflow with the minimum possible configuration. Tool Kit plugins will leave package configuration to a specific configuration file for that package (e.g. `.eslintrc` for the ESLint package).
 
 ## How can I use custom commands for my tooling that are not accommodated for by Tool Kit's config?
 

--- a/readme.md
+++ b/readme.md
@@ -6,6 +6,10 @@
 
 Tool Kit is modern developer tooling for FT.com repositories. It's fully modular, allowing repos that need different tooling to install separate plugins that work consistently together.
 
+Tool Kit has been created to enable the FT.com development workflow and only handles common tooling use cases that are required for most apps to work. Tool Kit sets up the minimal configuration for third party packages to run.
+
+Your application does not need to use Tool Kit for all of its tooling and tooling not supported by Tool Kit can be configured directly in your application.
+
 ## Installing and using Tool Kit
 
 For general questions about using Tool Kit please see the [Tool Kit FAQs](./docs/faq.md).


### PR DESCRIPTION
# Description

There have been support requests that suggest that people may think that Tool Kit is setup to handle all scripts and packages. This PR is to update the intro to the Tool Kit readme to highlight that Tool Kit is to enable packages in the FT.com workflow and not to control all aspects of the package.

# Checklist:

- [x] My branch has been rebased onto the latest commit on main (don't merge main into your branch)
- [x] My commit messages are [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/), for example: `feat(circleci): add support for nightly workflows`, `fix: set Heroku app name for staging apps too`
