### PR TITLE
CPP-1022 Update Tool Kit orb to use change-api's 1.0 orb release

### DIFF
--- a/orb/src/@orb.yml
+++ b/orb/src/@orb.yml
@@ -12,4 +12,4 @@ display:
 # If your orb requires other orbs, you can import them like this. Otherwise remove the "orbs" stanza.
 orbs:
   node: circleci/node@5.0.2
-  change-api: financial-times/change-api@0.25.1
+  change-api: financial-times/change-api@1.0.1

--- a/orb/src/jobs/heroku-promote.yml
+++ b/orb/src/jobs/heroku-promote.yml
@@ -20,6 +20,6 @@ steps:
   - run:
       name: Deploy to production
       command: npx dotcom-tool-kit deploy:production
-  - change-api/generate:
+  - change-api/change-log:
       environment: production
-      systemCode: <<parameters.systemCode>>
+      system-code: <<parameters.systemCode>>

--- a/orb/src/jobs/setup.yml
+++ b/orb/src/jobs/setup.yml
@@ -11,7 +11,6 @@ executor: << parameters.executor >>
 steps:
   - attach-workspace
   - run: sudo npm install -g npm@<<parameters.npm-version>>
-  - change-api/install-jq
   - node/install-packages
   - persist-workspace:
       path: .


### PR DESCRIPTION
# Description

The Edge Delivery & Observability team updated the change-api orb to be a bit more streamlined and [released a new major version](https://github.com/Financial-Times/change-api-orb/releases/tag/v1.0.0). The main interesting change for us the removal of the dependency on `jq`, which means we don't have to run a command in our `tool-kit/setup` job to install `jq`, which was redundant if you weren't calling the Change API in a given workflow. Updating to the latest version also means we can get future feature releases automatically.

# Checklist:

- [x] My branch has been rebased onto the latest commit on main (don't merge main into your branch)
- [x] My commit messages are [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/), for example: `feat(circleci): add support for nightly workflows`, `fix: set Heroku app name for staging apps too`
