### PR TITLE
CPP-1026 Document how to integrate code coverage reports with mocha

### DIFF
--- a/plugins/mocha/readme.md
+++ b/plugins/mocha/readme.md
@@ -32,6 +32,8 @@ plugins:
 
 ## Tips
 
+### Resolving test hook conflicts
+
 A common use case is to configure `test:local` and `test:ci` in your `.toolkitrc.yml` to run the `Eslint` task then the relevant Mocha task: 
 
 ```yaml
@@ -42,4 +44,23 @@ hooks:
   test:ci:
     - Eslint
     - Mocha
+```
+
+### Reporting code coverage
+
+If you want to test the coverage of your code (i.e., how many lines of your code are executed by your unit tests) you can use the [Istanbul](https://istanbul.js.org) tool that integrates with Mocha. To use Istanbul, install the command line interface, [nyc](https://github.com/istanbuljs/nyc), by running
+
+```sh
+npm install --save-dev nyc
+```
+
+and then adding a new script to your `package.json` that just runs the Tool Kit `test:local` hook (which should in turn run your Mocha tests) with the `nyc` command prepended to it:
+
+```json
+{
+  "scripts": {
+    "test": "dotcom-tool-kit test:local",
+    "coverage": "nyc npm run test"
+  }
+}
 ```


### PR DESCRIPTION
# Description

Some projects in Customer Products make use of code coverage reports to check that their unit tests are sufficiently thorough. I've add some documentation on how to get code coverage working with mocha, which requires the [nyc](https://github.com/istanbuljs/nyc) tool.

Seeing as Jest has [built-in support](https://jestjs.io/docs/configuration#collectcoverage-boolean) for code coverage reports I didn't add documentation in its own plugin as it felt redundant when users could just refer to Jest's own docs/configuration.

# Checklist:

- [x] My branch has been rebased onto the latest commit on main (don't merge main into your branch)
- [x] My commit messages are [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/), for example: `feat(circleci): add support for nightly workflows`, `fix: set Heroku app name for staging apps too`
