### PR TITLE
Use Zod for declaring option schemas

### DIFF
--- a/core/cli/package.json
+++ b/core/cli/package.json
@@ -20,20 +20,20 @@
     "test": "cd ../../ ; npx jest --silent --projects core/cli"
   },
   "devDependencies": {
+    "@dotcom-tool-kit/babel": "^2.0.12",
+    "@dotcom-tool-kit/backend-heroku-app": "^1.0.0",
+    "@dotcom-tool-kit/circleci": "^3.0.2",
+    "@dotcom-tool-kit/circleci-deploy": "^1.0.0",
+    "@dotcom-tool-kit/eslint": "^2.2.5",
+    "@dotcom-tool-kit/frontend-app": "^2.2.0",
+    "@dotcom-tool-kit/heroku": "^2.1.3",
+    "@dotcom-tool-kit/mocha": "^2.2.1",
+    "@dotcom-tool-kit/n-test": "^2.1.7",
+    "@dotcom-tool-kit/npm": "^2.0.13",
+    "@dotcom-tool-kit/webpack": "^2.1.11",
     "@jest/globals": "^27.4.6",
     "@types/lodash": "^4.14.185",
     "@types/node": "^12.20.24",
-    "@dotcom-tool-kit/backend-heroku-app": "^1.0.0",
-    "@dotcom-tool-kit/heroku": "^2.1.3",
-    "@dotcom-tool-kit/webpack": "^2.1.11",
-    "@dotcom-tool-kit/babel": "^2.0.12",
-    "@dotcom-tool-kit/circleci": "^3.0.2",
-    "@dotcom-tool-kit/npm": "^2.0.13",
-    "@dotcom-tool-kit/circleci-deploy": "^1.0.0",
-    "@dotcom-tool-kit/frontend-app": "^2.2.0",
-    "@dotcom-tool-kit/eslint": "^2.2.5",
-    "@dotcom-tool-kit/mocha": "^2.2.1",
-    "@dotcom-tool-kit/n-test": "^2.1.7",
     "chai": "^4.3.4",
     "globby": "^10.0.2",
     "ts-node": "^8.10.2",
@@ -50,7 +50,8 @@
     "minimist": "^1.2.5",
     "resolve-from": "^5.0.0",
     "tslib": "^2.3.1",
-    "yaml": "^1.10.2"
+    "yaml": "^1.10.2",
+    "zod-validation-error": "^0.3.0"
   },
   "engines": {
     "node": ">=8.0.0"

--- a/core/cli/src/messages.ts
+++ b/core/cli/src/messages.ts
@@ -3,6 +3,7 @@ import type { Conflict } from './conflict'
 import type { HookTask } from './hook'
 import { styles as s, styles } from '@dotcom-tool-kit/logger'
 import type { Plugin, Hook, TaskClass } from '@dotcom-tool-kit/types'
+import type { z } from 'zod'
 
 const formatTaskConflict = (conflict: Conflict<TaskClass>): string =>
   `- ${s.task(conflict.conflicting[0].id || 'unknown task')} ${s.dim(
@@ -89,6 +90,18 @@ ${
     : `There are no hooks defined by this app's plugins. You probably need to install some plugins to define hooks.`
 }.
 `
+
+export type InvalidOption = [string, z.ZodError]
+
+export const formatInvalidOptions = (
+  invalidOptions: InvalidOption[]
+): string => `Options are defined in your Tool Kit configuration that are the wrong types:
+
+${invalidOptions.map(
+  ([plugin, error]) => `- ${s.plugin(plugin)} has the issue(s): ${error}
+
+Please update the options so that they are the expected types.`
+)}`
 
 export const formatUnusedOptions = (
   unusedOptions: string[],

--- a/core/cli/src/messages.ts
+++ b/core/cli/src/messages.ts
@@ -4,6 +4,7 @@ import type { HookTask } from './hook'
 import { styles as s, styles } from '@dotcom-tool-kit/logger'
 import type { Plugin, Hook, TaskClass } from '@dotcom-tool-kit/types'
 import type { z } from 'zod'
+import { fromZodError } from 'zod-validation-error'
 
 const formatTaskConflict = (conflict: Conflict<TaskClass>): string =>
   `- ${s.task(conflict.conflicting[0].id || 'unknown task')} ${s.dim(
@@ -97,11 +98,11 @@ export const formatInvalidOptions = (
   invalidOptions: InvalidOption[]
 ): string => `Options are defined in your Tool Kit configuration that are the wrong types:
 
-${invalidOptions.map(
-  ([plugin, error]) => `- ${s.plugin(plugin)} has the issue(s): ${error}
+${invalidOptions
+  .map(([plugin, error]) => fromZodError(error, { prefix: `- ${s.plugin(plugin)} has the issue(s)` }).message)
+  .join('\n')}
 
-Please update the options so that they are the expected types.`
-)}`
+Please update the options so that they are the expected types. You can refer to the README for the plugin for examples and descriptions of the options used.`
 
 export const formatUnusedOptions = (
   unusedOptions: string[],

--- a/core/cli/test/index.test.ts
+++ b/core/cli/test/index.test.ts
@@ -41,7 +41,7 @@ describe('cli', () => {
 
     resolvePlugin((plugin as Valid<Plugin>).value, validPluginConfig, logger)
 
-    expect(() => validateConfig(validPluginConfig)).toThrow(ToolKitError)
+    expect(() => validateConfig(validPluginConfig, logger)).toThrow(ToolKitError)
     expect(validPluginConfig).toHaveProperty('hookTasks.build:ci.conflicting')
     expect(validPluginConfig).toHaveProperty('hookTasks.build:remote.conflicting')
     expect(validPluginConfig).toHaveProperty('hookTasks.build:local.conflicting')
@@ -62,7 +62,7 @@ describe('cli', () => {
 
     resolvePlugin((plugin as Valid<Plugin>).value, validPluginConfig, logger)
 
-    expect(() => validateConfig(validPluginConfig)).toThrow(ToolKitError)
+    expect(() => validateConfig(validPluginConfig, logger)).toThrow(ToolKitError)
     expect(config).toHaveProperty('hookTasks.build:ci.conflicting')
     expect(config).toHaveProperty('hookTasks.build:remote.conflicting')
     expect(config).toHaveProperty('hookTasks.build:local.conflicting')
@@ -84,7 +84,9 @@ describe('cli', () => {
     resolvePlugin((plugin as Valid<Plugin>).value, validPluginConfig, logger)
 
     try {
-      validateConfig(validPluginConfig)
+      const validConfig = validateConfig(validPluginConfig, logger)
+      expect(validConfig).not.toHaveProperty('hooks.build:local.conflicting')
+      expect(validConfig.hooks['build:local'].plugin?.id).toEqual('@dotcom-tool-kit/npm')
     } catch (e) {
       if (e instanceof ToolKitError) {
         e.message += '\n' + e.details
@@ -92,9 +94,6 @@ describe('cli', () => {
 
       throw e
     }
-
-    expect(validPluginConfig).not.toHaveProperty('hooks.build:local.conflicting')
-    expect(validPluginConfig.hooks['build:local'].plugin?.id).toEqual('@dotcom-tool-kit/npm')
   })
 
   it('should succeed when conflicts are resolved', async () => {
@@ -113,7 +112,10 @@ describe('cli', () => {
     resolvePlugin((plugin as Valid<Plugin>).value, validPluginConfig, logger)
 
     try {
-      validateConfig(validPluginConfig)
+      const validConfig = validateConfig(validPluginConfig, logger)
+
+      expect(validConfig).not.toHaveProperty('hookTasks.build:local.conflicting')
+      expect(validConfig.hookTasks['build:local'].tasks).toEqual(['WebpackDevelopment', 'BabelDevelopment'])
     } catch (e) {
       if (e instanceof ToolKitError) {
         e.message += '\n' + e.details
@@ -121,11 +123,5 @@ describe('cli', () => {
 
       throw e
     }
-
-    expect(validPluginConfig).not.toHaveProperty('hookTasks.build:local.conflicting')
-    expect(validPluginConfig.hookTasks['build:local'].tasks).toEqual([
-      'WebpackDevelopment',
-      'BabelDevelopment'
-    ])
   })
 })

--- a/core/create/src/prompts/options.ts
+++ b/core/create/src/prompts/options.ts
@@ -141,6 +141,9 @@ async function optionsPromptForPlugin(
           toolKitConfig.options[plugin][optionName] = option
         }
         break
+      default:
+        winstonLogger.verbose(`skipping prompting for unrecognised option type ${typeName} for ${optionName}`)
+        break
     }
 
     if (pluginCancelled) {

--- a/core/create/src/prompts/options.ts
+++ b/core/create/src/prompts/options.ts
@@ -30,7 +30,14 @@ async function optionsPromptForPlugin(
       ? ` (leave blank to use default value ${styles.code(JSON.stringify(optionDefault))})`
       : ''
 
-    switch (optionType._def.typeName as z.ZodFirstPartyTypeKind) {
+    // the Def type returned by ._def is different for each different Zod
+    // schema, but all of the schemas we're checking for here will have a
+    // .typeName field on their Def that gives a string representation of
+    // their type. this is preferred to using instanceof to check for the
+    // type as this method should work when different versions of zod are
+    // installed.
+    const typeName = optionType._def.typeName as z.ZodFirstPartyTypeKind
+    switch (typeName) {
       case 'ZodString':
         const { stringOption } = await prompt(
           {

--- a/lib/options/src/index.ts
+++ b/lib/options/src/index.ts
@@ -1,6 +1,6 @@
 import type { Options } from '@dotcom-tool-kit/types/src/schema'
 
-const options: Options = {}
+const options: Partial<Options> = {}
 
 export type OptionKey = keyof Options
 

--- a/lib/types/package.json
+++ b/lib/types/package.json
@@ -26,7 +26,8 @@
     "@dotcom-tool-kit/error": "^2.0.0",
     "@dotcom-tool-kit/logger": "^2.2.0",
     "semver": "^7.3.7",
-    "tslib": "^2.3.1"
+    "tslib": "^2.3.1",
+    "zod": "^3.20.2"
   },
   "devDependencies": {
     "@jest/globals": "^27.4.6",

--- a/lib/types/src/index.ts
+++ b/lib/types/src/index.ts
@@ -3,7 +3,7 @@ import fs from 'fs'
 import path from 'path'
 import semver from 'semver'
 import type { Logger } from 'winston'
-import { Schema, SchemaOutput } from './schema'
+import { z } from 'zod'
 
 const packageJsonPath = path.resolve(__dirname, '../package.json')
 const packageJson = JSON.parse(fs.readFileSync(packageJsonPath, 'utf8'))
@@ -135,7 +135,7 @@ abstract class Base {
   }
 }
 
-export abstract class Task<O extends Schema = Record<string, never>> extends Base {
+export abstract class Task<O extends z.ZodTypeAny = z.ZodTypeAny> extends Base {
   static description: string
   static plugin?: Plugin
   static id?: string
@@ -149,14 +149,14 @@ export abstract class Task<O extends Schema = Record<string, never>> extends Bas
   }
 
   static defaultOptions: Record<string, unknown> = {}
-  options: SchemaOutput<O>
+  options: z.infer<O>
   logger: Logger
 
-  constructor(logger: Logger, options: Partial<SchemaOutput<O>> = {}) {
+  constructor(logger: Logger, options: Partial<z.infer<O>> = {}) {
     super()
 
     const staticThis = this.constructor as typeof Task
-    this.options = Object.assign({}, staticThis.defaultOptions as SchemaOutput<O>, options)
+    this.options = Object.assign({}, staticThis.defaultOptions as z.infer<O>, options)
     this.logger = logger.child({ task: staticThis.id })
   }
 
@@ -164,7 +164,7 @@ export abstract class Task<O extends Schema = Record<string, never>> extends Bas
 }
 
 export type TaskClass = {
-  new <O extends Schema>(logger: Logger, options: Partial<SchemaOutput<O>>): Task<O>
+  new <O extends z.ZodTypeAny>(logger: Logger, options: Partial<z.infer<O>>): Task<O>
 } & typeof Task
 
 export abstract class Hook<State = void> extends Base {

--- a/lib/types/src/index.ts
+++ b/lib/types/src/index.ts
@@ -148,15 +148,14 @@ export abstract class Task<O extends z.ZodTypeAny = z.ZodTypeAny> extends Base {
     return taskSymbol
   }
 
-  static defaultOptions: Record<string, unknown> = {}
-  options: z.infer<O>
+  options: z.output<O>
   logger: Logger
 
-  constructor(logger: Logger, options: Partial<z.infer<O>> = {}) {
+  constructor(logger: Logger, options: z.output<O>) {
     super()
 
     const staticThis = this.constructor as typeof Task
-    this.options = Object.assign({}, staticThis.defaultOptions as z.infer<O>, options)
+    this.options = options
     this.logger = logger.child({ task: staticThis.id })
   }
 

--- a/lib/types/src/schema.ts
+++ b/lib/types/src/schema.ts
@@ -15,38 +15,44 @@ export type PromptGenerators<T> = T extends z.ZodObject<infer Shape>
     }
   : never
 
-import type { ESLintOptions } from './schema/eslint'
-import type { HerokuOptions } from './schema/heroku'
-import type { MochaOptions } from './schema/mocha'
-import type { SmokeTestOptions } from './schema/n-test'
-import type { UploadAssetsToS3Options } from './schema/upload-assets-to-s3'
-import type { VaultOptions } from './schema/vault'
-import type { WebpackOptions } from './schema/webpack'
-import type { NodeOptions } from './schema/node'
-import type { NodemonOptions } from './schema/nodemon'
-import type { NextRouterOptions } from './schema/next-router'
-import type { PrettierOptions } from './schema/prettier'
-import type { LintStagedNpmOptions } from './schema/lint-staged-npm'
-import type { BabelOptions } from './schema/babel'
-import type { CircleCIOptions } from './schema/circleci'
-import type { CypressOptions } from './schema/cypress'
-import type { TypeScriptOptions } from './schema/typescript'
+import { ESLintSchema } from './schema/eslint'
+import { HerokuSchema } from './schema/heroku'
+import { MochaSchema } from './schema/mocha'
+import { SmokeTestSchema } from './schema/n-test'
+import { UploadAssetsToS3Schema } from './schema/upload-assets-to-s3'
+import { VaultSchema } from './schema/vault'
+import { WebpackSchema } from './schema/webpack'
+import { NodeSchema } from './schema/node'
+import { NodemonSchema } from './schema/nodemon'
+import { NextRouterSchema } from './schema/next-router'
+import { PrettierSchema } from './schema/prettier'
+import { LintStagedNpmSchema } from './schema/lint-staged-npm'
+import { BabelSchema } from './schema/babel'
+import { CircleCISchema } from './schema/circleci'
+import { CypressSchema } from './schema/cypress'
+import { TypeScriptSchema } from './schema/typescript'
+
+export const Schemas = {
+  '@dotcom-tool-kit/eslint': ESLintSchema,
+  '@dotcom-tool-kit/heroku': HerokuSchema,
+  '@dotcom-tool-kit/mocha': MochaSchema,
+  '@dotcom-tool-kit/n-test': SmokeTestSchema,
+  '@dotcom-tool-kit/upload-assets-to-s3': UploadAssetsToS3Schema,
+  '@dotcom-tool-kit/vault': VaultSchema,
+  '@dotcom-tool-kit/webpack': WebpackSchema,
+  '@dotcom-tool-kit/node': NodeSchema,
+  '@dotcom-tool-kit/nodemon': NodemonSchema,
+  '@dotcom-tool-kit/next-router': NextRouterSchema,
+  '@dotcom-tool-kit/prettier': PrettierSchema,
+  '@dotcom-tool-kit/lint-staged-npm': LintStagedNpmSchema,
+  '@dotcom-tool-kit/babel': BabelSchema,
+  '@dotcom-tool-kit/circleci': CircleCISchema,
+  '@dotcom-tool-kit/cypress': CypressSchema,
+  '@dotcom-tool-kit/typescript': TypeScriptSchema
+}
 
 export type Options = {
-  '@dotcom-tool-kit/eslint'?: ESLintOptions
-  '@dotcom-tool-kit/heroku'?: HerokuOptions
-  '@dotcom-tool-kit/mocha'?: MochaOptions
-  '@dotcom-tool-kit/n-test'?: SmokeTestOptions
-  '@dotcom-tool-kit/upload-assets-to-s3'?: UploadAssetsToS3Options
-  '@dotcom-tool-kit/vault'?: VaultOptions
-  '@dotcom-tool-kit/webpack'?: WebpackOptions
-  '@dotcom-tool-kit/node'?: NodeOptions
-  '@dotcom-tool-kit/nodemon'?: NodemonOptions
-  '@dotcom-tool-kit/next-router'?: NextRouterOptions
-  '@dotcom-tool-kit/prettier'?: PrettierOptions
-  '@dotcom-tool-kit/lint-staged-npm'?: LintStagedNpmOptions
-  '@dotcom-tool-kit/babel'?: BabelOptions
-  '@dotcom-tool-kit/circleci'?: CircleCIOptions
-  '@dotcom-tool-kit/cypress'?: CypressOptions
-  '@dotcom-tool-kit/typescript'?: TypeScriptOptions
+  [plugin in keyof typeof Schemas]?: typeof Schemas[plugin] extends z.ZodTypeAny
+    ? z.infer<typeof Schemas[plugin]>
+    : never
 }

--- a/lib/types/src/schema.ts
+++ b/lib/types/src/schema.ts
@@ -56,7 +56,7 @@ export const Schemas = {
 }
 
 export type Options = {
-  [plugin in keyof typeof Schemas]?: typeof Schemas[plugin] extends z.ZodTypeAny
+  [plugin in keyof typeof Schemas]: typeof Schemas[plugin] extends z.ZodTypeAny
     ? z.infer<typeof Schemas[plugin]>
     : never
 }

--- a/lib/types/src/schema.ts
+++ b/lib/types/src/schema.ts
@@ -15,40 +15,44 @@ export type PromptGenerators<T> = T extends z.ZodObject<infer Shape>
     }
   : never
 
-import { ESLintSchema } from './schema/eslint'
-import { HerokuSchema } from './schema/heroku'
-import { MochaSchema } from './schema/mocha'
-import { SmokeTestSchema } from './schema/n-test'
-import { UploadAssetsToS3Schema } from './schema/upload-assets-to-s3'
-import { VaultSchema } from './schema/vault'
-import { WebpackSchema } from './schema/webpack'
-import { NodeSchema } from './schema/node'
-import { NodemonSchema } from './schema/nodemon'
-import { NextRouterSchema } from './schema/next-router'
-import { PrettierSchema } from './schema/prettier'
-import { LintStagedNpmSchema } from './schema/lint-staged-npm'
 import { BabelSchema } from './schema/babel'
 import { CircleCISchema } from './schema/circleci'
 import { CypressSchema } from './schema/cypress'
+import { ESLintSchema } from './schema/eslint'
+import { HerokuSchema } from './schema/heroku'
+import { LintStagedNpmSchema } from './schema/lint-staged-npm'
+import { JestSchema } from './schema/jest'
+import { MochaSchema } from './schema/mocha'
+import { SmokeTestSchema } from './schema/n-test'
+import { NextRouterSchema } from './schema/next-router'
+import { NodeSchema } from './schema/node'
+import { NodemonSchema } from './schema/nodemon'
+import { Pa11ySchema } from './schema/pa11y'
+import { PrettierSchema } from './schema/prettier'
 import { TypeScriptSchema } from './schema/typescript'
+import { UploadAssetsToS3Schema } from './schema/upload-assets-to-s3'
+import { VaultSchema } from './schema/vault'
+import { WebpackSchema } from './schema/webpack'
 
 export const Schemas = {
-  '@dotcom-tool-kit/eslint': ESLintSchema,
-  '@dotcom-tool-kit/heroku': HerokuSchema,
-  '@dotcom-tool-kit/mocha': MochaSchema,
-  '@dotcom-tool-kit/n-test': SmokeTestSchema,
-  '@dotcom-tool-kit/upload-assets-to-s3': UploadAssetsToS3Schema,
-  '@dotcom-tool-kit/vault': VaultSchema,
-  '@dotcom-tool-kit/webpack': WebpackSchema,
-  '@dotcom-tool-kit/node': NodeSchema,
-  '@dotcom-tool-kit/nodemon': NodemonSchema,
-  '@dotcom-tool-kit/next-router': NextRouterSchema,
-  '@dotcom-tool-kit/prettier': PrettierSchema,
-  '@dotcom-tool-kit/lint-staged-npm': LintStagedNpmSchema,
   '@dotcom-tool-kit/babel': BabelSchema,
   '@dotcom-tool-kit/circleci': CircleCISchema,
   '@dotcom-tool-kit/cypress': CypressSchema,
-  '@dotcom-tool-kit/typescript': TypeScriptSchema
+  '@dotcom-tool-kit/eslint': ESLintSchema,
+  '@dotcom-tool-kit/heroku': HerokuSchema,
+  '@dotcom-tool-kit/lint-staged-npm': LintStagedNpmSchema,
+  '@dotcom-tool-kit/jest': JestSchema,
+  '@dotcom-tool-kit/mocha': MochaSchema,
+  '@dotcom-tool-kit/n-test': SmokeTestSchema,
+  '@dotcom-tool-kit/next-router': NextRouterSchema,
+  '@dotcom-tool-kit/node': NodeSchema,
+  '@dotcom-tool-kit/nodemon': NodemonSchema,
+  '@dotcom-tool-kit/pa11y': Pa11ySchema,
+  '@dotcom-tool-kit/prettier': PrettierSchema,
+  '@dotcom-tool-kit/typescript': TypeScriptSchema,
+  '@dotcom-tool-kit/upload-assets-to-s3': UploadAssetsToS3Schema,
+  '@dotcom-tool-kit/vault': VaultSchema,
+  '@dotcom-tool-kit/webpack': WebpackSchema
 }
 
 export type Options = {

--- a/lib/types/src/schema.ts
+++ b/lib/types/src/schema.ts
@@ -11,7 +11,7 @@ export type PromptGenerators<T> = T extends z.ZodObject<infer Shape>
   ? {
       [option in keyof Shape as Shape[option] extends z.ZodType
         ? option
-        : never]?: Shape[option] extends z.ZodType ? SchemaPromptGenerator<z.infer<Shape[option]>> : never
+        : never]?: Shape[option] extends z.ZodType ? SchemaPromptGenerator<z.output<Shape[option]>> : never
     }
   : never
 

--- a/lib/types/src/schema.ts
+++ b/lib/types/src/schema.ts
@@ -2,11 +2,21 @@ import type prompts from 'prompts'
 import type { Logger } from 'winston'
 import { z } from 'zod'
 
+/**
+ * A function that should use the `prompt` parameter passed to build a more
+ * complex option structure, like a nested object, from user input
+ * @param onCancel - pass this to `prompt`'s options so that a user
+ *   interrupting the prompt can be handled properly
+ */
 export type SchemaPromptGenerator<T> = (
   logger: Logger,
   prompt: typeof prompts,
   onCancel: () => void
 ) => Promise<T>
+// This type defines an interface you can use to export prompt generators. The
+// `T` type parameter should be the type of your `Schema` object, and it will
+// be mapped into a partial object of `SchemaPromptGenerator` functions with
+// all their return types set to the output type of each option schema.
 export type PromptGenerators<T> = T extends z.ZodObject<infer Shape>
   ? {
       [option in keyof Shape as Shape[option] extends z.ZodType
@@ -55,6 +65,7 @@ export const Schemas = {
   '@dotcom-tool-kit/webpack': WebpackSchema
 }
 
+// Gives the TypeScript type represented by each Schema
 export type Options = {
   [plugin in keyof typeof Schemas]: typeof Schemas[plugin] extends z.ZodTypeAny
     ? z.infer<typeof Schemas[plugin]>

--- a/lib/types/src/schema/babel.ts
+++ b/lib/types/src/schema/babel.ts
@@ -1,10 +1,10 @@
-import { SchemaOutput } from '../schema'
+import { z } from 'zod'
 
-export const BabelSchema = {
-  files: 'string?',
-  outputPath: 'string?',
-  configFile: 'string?'
-} as const
-export type BabelOptions = SchemaOutput<typeof BabelSchema>
+export const BabelSchema = z.object({
+  files: z.string().optional(),
+  outputPath: z.string().optional(),
+  configFile: z.string().optional()
+})
+export type BabelOptions = z.infer<typeof BabelSchema>
 
 export const Schema = BabelSchema

--- a/lib/types/src/schema/circleci.ts
+++ b/lib/types/src/schema/circleci.ts
@@ -1,9 +1,9 @@
-import { SchemaOutput } from '../schema'
+import { z } from 'zod'
 
-export const CircleCISchema = {
-  nodeVersion: 'string?',
-  cypressImage: 'string?'
-} as const
-export type CircleCIOptions = SchemaOutput<typeof CircleCISchema>
+export const CircleCISchema = z.object({
+  nodeVersion: z.string().optional(),
+  cypressImage: z.string().optional()
+})
+export type CircleCIOptions = z.infer<typeof CircleCISchema>
 
 export const Schema = CircleCISchema

--- a/lib/types/src/schema/cypress.ts
+++ b/lib/types/src/schema/cypress.ts
@@ -1,8 +1,8 @@
-import { SchemaOutput } from '../schema'
+import { z } from 'zod'
 
-export const CypressSchema = {
-  localUrl: 'string?'
-} as const
-export type CypressOptions = SchemaOutput<typeof CypressSchema>
+export const CypressSchema = z.object({
+  localUrl: z.string().optional()
+})
+export type CypressOptions = z.infer<typeof CypressSchema>
 
 export const Schema = CypressSchema

--- a/lib/types/src/schema/eslint.ts
+++ b/lib/types/src/schema/eslint.ts
@@ -1,7 +1,7 @@
 import { z } from 'zod'
 
 export const ESLintSchema = z.object({
-  files: z.string().array(),
+  files: z.string().array().default(['**/*.js']),
   config: z.record(z.unknown()).optional(), // @deprecated: use options instead
   options: z.record(z.unknown()).optional()
 })

--- a/lib/types/src/schema/eslint.ts
+++ b/lib/types/src/schema/eslint.ts
@@ -1,10 +1,10 @@
-import { SchemaOutput } from '../schema'
+import { z } from 'zod'
 
-export const ESLintSchema = {
-  files: 'array.string',
-  config: 'record.unknown?', // @deprecated: use options instead
-  options: 'record.unknown?'
-} as const
-export type ESLintOptions = SchemaOutput<typeof ESLintSchema>
+export const ESLintSchema = z.object({
+  files: z.string().array(),
+  config: z.record(z.unknown()).optional(), // @deprecated: use options instead
+  options: z.record(z.unknown()).optional()
+})
+export type ESLintOptions = z.infer<typeof ESLintSchema>
 
 export const Schema = ESLintSchema

--- a/lib/types/src/schema/heroku.ts
+++ b/lib/types/src/schema/heroku.ts
@@ -1,8 +1,15 @@
-import { SchemaOutput, SchemaPromptGenerator } from '../schema'
+import { SchemaPromptGenerator, PromptGenerators } from '../schema'
+import { z } from 'zod'
 
-export interface HerokuScaling {
-  [app: string]: { [processType: string]: { size: string; quantity: number } }
-}
+export const HerokuScalingSchema = z.record(
+  z.record(
+    z.object({
+      size: z.string(),
+      quantity: z.number()
+    })
+  )
+)
+export type HerokuScaling = z.infer<typeof HerokuScalingSchema>
 
 const scaling: SchemaPromptGenerator<HerokuScaling> = async (logger, prompt, onCancel) => {
   logger.error('You must configure the scaling for each of the Heroku apps in your pipeline.')
@@ -37,11 +44,14 @@ const scaling: SchemaPromptGenerator<HerokuScaling> = async (logger, prompt, onC
   return scaling
 }
 
-export const HerokuSchema = {
-  pipeline: 'string',
-  systemCode: 'string',
-  scaling
-} as const
-export type HerokuOptions = SchemaOutput<typeof HerokuSchema>
+export const HerokuSchema = z.object({
+  pipeline: z.string(),
+  systemCode: z.string(),
+  scaling: HerokuScalingSchema
+})
+export type HerokuOptions = z.infer<typeof HerokuSchema>
 
 export const Schema = HerokuSchema
+export const generators: PromptGenerators<typeof HerokuSchema> = {
+  scaling
+}

--- a/lib/types/src/schema/jest.ts
+++ b/lib/types/src/schema/jest.ts
@@ -1,9 +1,9 @@
-import { SchemaOutput } from '../schema'
+import { z } from 'zod'
 
-export const JestSchema = {
-  configPath: 'string?'
-} as const
-export type JestMode = "ci" | "local"
-export type JestOptions = SchemaOutput<typeof JestSchema>
+export const JestSchema = z.object({
+  configPath: z.string().optional()
+})
+export type JestMode = 'ci' | 'local'
+export type JestOptions = z.infer<typeof JestSchema>
 
 export const Schema = JestSchema

--- a/lib/types/src/schema/lint-staged-npm.ts
+++ b/lib/types/src/schema/lint-staged-npm.ts
@@ -1,9 +1,9 @@
-import { SchemaOutput } from '../schema'
+import { z } from 'zod'
 
-export const LintStagedNpmSchema = {
-  testGlob: 'string?',
-  formatGlob: 'string?'
-} as const
-export type LintStagedNpmOptions = SchemaOutput<typeof LintStagedNpmSchema>
+export const LintStagedNpmSchema = z.object({
+  testGlob: z.string().optional(),
+  formatGlob: z.string().optional()
+})
+export type LintStagedNpmOptions = z.infer<typeof LintStagedNpmSchema>
 
 export const Schema = LintStagedNpmSchema

--- a/lib/types/src/schema/mocha.ts
+++ b/lib/types/src/schema/mocha.ts
@@ -1,9 +1,9 @@
-import { SchemaOutput } from '../schema'
+import { z } from 'zod'
 
-export const MochaSchema = {
-  files: 'string',
-  configPath: 'string?'
-} as const
-export type MochaOptions = SchemaOutput<typeof MochaSchema>
+export const MochaSchema = z.object({
+  files: z.string(),
+  configPath: z.string().optional()
+})
+export type MochaOptions = z.infer<typeof MochaSchema>
 
 export const Schema = MochaSchema

--- a/lib/types/src/schema/mocha.ts
+++ b/lib/types/src/schema/mocha.ts
@@ -1,7 +1,7 @@
 import { z } from 'zod'
 
 export const MochaSchema = z.object({
-  files: z.string(),
+  files: z.string().default('test/**/*.js'),
   configPath: z.string().optional()
 })
 export type MochaOptions = z.infer<typeof MochaSchema>

--- a/lib/types/src/schema/n-test.ts
+++ b/lib/types/src/schema/n-test.ts
@@ -1,12 +1,12 @@
-import { SchemaOutput } from '../schema'
+import { z } from 'zod'
 
-export const SmokeTestSchema = {
-  browsers: 'array.string?',
-  host: 'string?',
-  config: 'string?',
-  interactive: 'boolean?',
-  header: 'record.string?'
-} as const
-export type SmokeTestOptions = SchemaOutput<typeof SmokeTestSchema>
+export const SmokeTestSchema = z.object({
+  browsers: z.string().array().optional(),
+  host: z.string().optional(),
+  config: z.string().optional(),
+  interactive: z.boolean().optional(),
+  header: z.record(z.string()).optional()
+})
+export type SmokeTestOptions = z.infer<typeof SmokeTestSchema>
 
 export const Schema = SmokeTestSchema

--- a/lib/types/src/schema/next-router.ts
+++ b/lib/types/src/schema/next-router.ts
@@ -1,8 +1,8 @@
-import { SchemaOutput } from '../schema'
+import { z } from 'zod'
 
-export const NextRouterSchema = {
-  appName: 'string'
-} as const
-export type NextRouterOptions = SchemaOutput<typeof NextRouterSchema>
+export const NextRouterSchema = z.object({
+  appName: z.string()
+})
+export type NextRouterOptions = z.infer<typeof NextRouterSchema>
 
 export const Schema = NextRouterSchema

--- a/lib/types/src/schema/node.ts
+++ b/lib/types/src/schema/node.ts
@@ -1,10 +1,10 @@
 import { z } from 'zod'
 
 export const NodeSchema = z.object({
-  entry: z.string().optional(),
+  entry: z.string().default('./server/app.js'),
   args: z.string().array().optional(),
-  useVault: z.boolean().optional(),
-  ports: z.number().array().optional()
+  useVault: z.boolean().default(true),
+  ports: z.number().array().default([3001, 3002, 3003])
 })
 export type NodeOptions = z.infer<typeof NodeSchema>
 

--- a/lib/types/src/schema/node.ts
+++ b/lib/types/src/schema/node.ts
@@ -1,11 +1,11 @@
-import { SchemaOutput } from '../schema'
+import { z } from 'zod'
 
-export const NodeSchema = {
-  entry: 'string?',
-  args: 'array.string?',
-  useVault: 'boolean?',
-  ports: 'array.number?'
-} as const
-export type NodeOptions = SchemaOutput<typeof NodeSchema>
+export const NodeSchema = z.object({
+  entry: z.string().optional(),
+  args: z.string().array().optional(),
+  useVault: z.boolean().optional(),
+  ports: z.number().array().optional()
+})
+export type NodeOptions = z.infer<typeof NodeSchema>
 
 export const Schema = NodeSchema

--- a/lib/types/src/schema/nodemon.ts
+++ b/lib/types/src/schema/nodemon.ts
@@ -1,11 +1,11 @@
-import { SchemaOutput } from '../schema'
+import { z } from 'zod'
 
-export const NodemonSchema = {
-  entry: 'string?',
-  configPath: 'string?',
-  useVault: 'boolean?',
-  ports: 'array.number?'
-} as const
-export type NodemonOptions = SchemaOutput<typeof NodemonSchema>
+export const NodemonSchema = z.object({
+  entry: z.string().optional(),
+  configPath: z.string().optional(),
+  useVault: z.boolean().optional(),
+  ports: z.number().array().optional()
+})
+export type NodemonOptions = z.infer<typeof NodemonSchema>
 
 export const Schema = NodemonSchema

--- a/lib/types/src/schema/nodemon.ts
+++ b/lib/types/src/schema/nodemon.ts
@@ -1,10 +1,10 @@
 import { z } from 'zod'
 
 export const NodemonSchema = z.object({
-  entry: z.string().optional(),
+  entry: z.string().default('./server/app.js'),
   configPath: z.string().optional(),
-  useVault: z.boolean().optional(),
-  ports: z.number().array().optional()
+  useVault: z.boolean().default(true),
+  ports: z.number().array().default([3001, 3002, 3003])
 })
 export type NodemonOptions = z.infer<typeof NodemonSchema>
 

--- a/lib/types/src/schema/pa11y.ts
+++ b/lib/types/src/schema/pa11y.ts
@@ -1,8 +1,8 @@
-import { SchemaOutput } from '../schema'
+import { z } from 'zod'
 
-export const Pa11ySchema = {
-  configFile: 'string?'
-} as const
-export type Pa11yOptions = SchemaOutput<typeof Pa11ySchema>
+export const Pa11ySchema = z.object({
+  configFile: z.string().optional()
+})
+export type Pa11yOptions = z.infer<typeof Pa11ySchema>
 
 export const Schema = Pa11ySchema

--- a/lib/types/src/schema/prettier.ts
+++ b/lib/types/src/schema/prettier.ts
@@ -1,11 +1,11 @@
-import { SchemaOutput } from '../schema'
+import { z } from 'zod'
 
-export const PrettierSchema = {
-  files: 'array.string',
-  configFile: 'string?',
-  ignoreFile: 'string?',
-  configOptions: 'record.unknown?'
-} as const
-export type PrettierOptions = SchemaOutput<typeof PrettierSchema>
+export const PrettierSchema = z.object({
+  files: z.string().array(),
+  configFile: z.string().optional(),
+  ignoreFile: z.string().optional(),
+  configOptions: z.record(z.unknown())
+})
+export type PrettierOptions = z.infer<typeof PrettierSchema>
 
 export const Schema = PrettierSchema

--- a/lib/types/src/schema/prettier.ts
+++ b/lib/types/src/schema/prettier.ts
@@ -1,10 +1,16 @@
 import { z } from 'zod'
 
 export const PrettierSchema = z.object({
-  files: z.string().array(),
+  files: z.string().array().default(['**/*.{js,jsx,ts,tsx}']),
   configFile: z.string().optional(),
-  ignoreFile: z.string().optional(),
-  configOptions: z.record(z.unknown())
+  ignoreFile: z.string().default('.prettierignore'),
+  configOptions: z.record(z.unknown()).default({
+    singleQuote: true,
+    useTabs: true,
+    bracketSpacing: true,
+    arrowParens: 'always',
+    trailingComma: 'none'
+  })
 })
 export type PrettierOptions = z.infer<typeof PrettierSchema>
 

--- a/lib/types/src/schema/serverless.ts
+++ b/lib/types/src/schema/serverless.ts
@@ -1,10 +1,10 @@
-import { SchemaOutput } from '../schema'
+import { z } from 'zod'
 
-export const ServerlessSchema = {
-  configPath: 'string?',
-  useVault: 'boolean?',
-  ports: 'array.number?'
-} as const
-export type ServerlessOptions = SchemaOutput<typeof ServerlessSchema>
+export const ServerlessSchema = z.object({
+  configPath: z.string().optional(),
+  useVault: z.boolean().optional(),
+  ports: z.number().array().optional()
+})
+export type ServerlessOptions = z.infer<typeof ServerlessSchema>
 
 export const Schema = ServerlessSchema

--- a/lib/types/src/schema/serverless.ts
+++ b/lib/types/src/schema/serverless.ts
@@ -2,8 +2,8 @@ import { z } from 'zod'
 
 export const ServerlessSchema = z.object({
   configPath: z.string().optional(),
-  useVault: z.boolean().optional(),
-  ports: z.number().array().optional()
+  useVault: z.boolean().default(true),
+  ports: z.number().array().default([3001, 3002, 3003])
 })
 export type ServerlessOptions = z.infer<typeof ServerlessSchema>
 

--- a/lib/types/src/schema/typescript.ts
+++ b/lib/types/src/schema/typescript.ts
@@ -1,9 +1,9 @@
-import { SchemaOutput } from '../schema'
+import { z } from 'zod'
 
-export const TypeScriptSchema = {
-  configPath: 'string?',
-  extraArgs: 'array.string?'
-} as const
-export type TypeScriptOptions = SchemaOutput<typeof TypeScriptSchema>
+export const TypeScriptSchema = z.object({
+  configPath: z.string().optional(),
+  extraArgs: z.string().array().optional()
+})
+export type TypeScriptOptions = z.infer<typeof TypeScriptSchema>
 
 export const Schema = TypeScriptSchema

--- a/lib/types/src/schema/upload-assets-to-s3.ts
+++ b/lib/types/src/schema/upload-assets-to-s3.ts
@@ -1,18 +1,18 @@
-import { SchemaOutput } from '../schema'
+import { z } from 'zod'
 
-export const UploadAssetsToS3Schema = {
-  accessKeyIdEnvVar: 'string?',
-  secretAccessKeyEnvVar: 'string?',
-  accessKeyId: 'string?', // @deprecated: use accessKeyIdEnvVar instead
-  secretAccessKey: 'string?', // @deprecated: use secretAccessKeyEnvVar instead
-  directory: 'string',
-  reviewBucket: 'array.string',
-  prodBucket: 'array.string',
-  region: 'string',
-  destination: 'string',
-  extensions: 'string',
-  cacheControl: 'string'
-} as const
-export type UploadAssetsToS3Options = SchemaOutput<typeof UploadAssetsToS3Schema>
+export const UploadAssetsToS3Schema = z.object({
+  accessKeyIdEnvVar: z.string().optional(),
+  secretAccessKeyEnvVar: z.string().optional(),
+  accessKeyId: z.string().optional(), // @deprecated: use accessKeyIdEnvVar instead
+  secretAccessKey: z.string().optional(), // @deprecated: use secretAccessKeyEnvVar instead
+  directory: z.string(),
+  reviewBucket: z.string().array(),
+  prodBucket: z.string().array(),
+  region: z.string(),
+  destination: z.string(),
+  extensions: z.string(),
+  cacheControl: z.string()
+})
+export type UploadAssetsToS3Options = z.infer<typeof UploadAssetsToS3Schema>
 
 export const Schema = UploadAssetsToS3Schema

--- a/lib/types/src/schema/upload-assets-to-s3.ts
+++ b/lib/types/src/schema/upload-assets-to-s3.ts
@@ -3,15 +3,15 @@ import { z } from 'zod'
 export const UploadAssetsToS3Schema = z.object({
   accessKeyIdEnvVar: z.string().optional(),
   secretAccessKeyEnvVar: z.string().optional(),
-  accessKeyId: z.string().optional(), // @deprecated: use accessKeyIdEnvVar instead
-  secretAccessKey: z.string().optional(), // @deprecated: use secretAccessKeyEnvVar instead
-  directory: z.string(),
-  reviewBucket: z.string().array(),
-  prodBucket: z.string().array(),
-  region: z.string(),
-  destination: z.string(),
-  extensions: z.string(),
-  cacheControl: z.string()
+  accessKeyId: z.string().default('aws_access_hashed_assets'), // @deprecated: use accessKeyIdEnvVar instead
+  secretAccessKey: z.string().default('aws_secret_hashed_assets'), // @deprecated: use secretAccessKeyEnvVar instead
+  directory: z.string().default('public'),
+  reviewBucket: z.string().array().default(['ft-next-hashed-assets-preview']),
+  prodBucket: z.string().array().default(['ft-next-hashed-assets-prod']),
+  region: z.string().default('eu-west-1'),
+  destination: z.string().default('hashed-assets/page-kit'),
+  extensions: z.string().default('js,css,map,gz,br,png,jpg,jpeg,gif,webp,svg,ico,json'),
+  cacheControl: z.string().default('public, max-age=31536000, stale-while-revalidate=60, stale-if-error=3600')
 })
 export type UploadAssetsToS3Options = z.infer<typeof UploadAssetsToS3Schema>
 

--- a/lib/types/src/schema/vault.ts
+++ b/lib/types/src/schema/vault.ts
@@ -1,9 +1,9 @@
-import { SchemaOutput } from '../schema'
+import { z } from 'zod'
 
-export const VaultSchema = {
-  team: 'string',
-  app: 'string'
-} as const
-export type VaultOptions = SchemaOutput<typeof VaultSchema>
+export const VaultSchema = z.object({
+  team: z.string(),
+  app: z.string()
+})
+export type VaultOptions = z.infer<typeof VaultSchema>
 
 export const Schema = VaultSchema

--- a/lib/types/src/schema/webpack.ts
+++ b/lib/types/src/schema/webpack.ts
@@ -1,8 +1,8 @@
-import { SchemaOutput } from '../schema'
+import { z } from 'zod'
 
-export const WebpackSchema = {
-  configPath: 'string?'
-} as const
-export type WebpackOptions = SchemaOutput<typeof WebpackSchema>
+export const WebpackSchema = z.object({
+  configPath: z.string().optional()
+})
+export type WebpackOptions = z.infer<typeof WebpackSchema>
 
 export const Schema = WebpackSchema

--- a/package-lock.json
+++ b/package-lock.json
@@ -58,7 +58,8 @@
         "minimist": "^1.2.5",
         "resolve-from": "^5.0.0",
         "tslib": "^2.3.1",
-        "yaml": "^1.10.2"
+        "yaml": "^1.10.2",
+        "zod-validation-error": "^0.3.0"
       },
       "bin": {
         "dotcom-tool-kit": "bin/run"
@@ -26665,6 +26666,17 @@
         "url": "https://github.com/sponsors/colinhacks"
       }
     },
+    "node_modules/zod-validation-error": {
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/zod-validation-error/-/zod-validation-error-0.3.1.tgz",
+      "integrity": "sha512-3m7VcE4YT3ZdGJoYBZnLt8E1S/r8zPFNDWMc2njaeC7Vxe5FQbgIiwHoerSkli5PgsUyxWQhpFxEAJXkBJvoDg==",
+      "engines": {
+        "node": "^14.17 || >=16.0.0"
+      },
+      "peerDependencies": {
+        "zod": "^3.18.0"
+      }
+    },
     "plugins/babel": {
       "name": "@dotcom-tool-kit/babel",
       "version": "2.0.12",
@@ -37600,7 +37612,8 @@
         "ts-node": "^8.10.2",
         "tslib": "^2.3.1",
         "winston": "^3.5.1",
-        "yaml": "^1.10.2"
+        "yaml": "^1.10.2",
+        "zod-validation-error": "^0.3.0"
       },
       "dependencies": {
         "globby": {
@@ -47800,6 +47813,12 @@
       "version": "3.20.6",
       "resolved": "https://registry.npmjs.org/zod/-/zod-3.20.6.tgz",
       "integrity": "sha512-oyu0m54SGCtzh6EClBVqDDlAYRz4jrVtKwQ7ZnsEmMI9HnzuZFj8QFwAY1M5uniIYACdGvv0PBWPF2kO0aNofA=="
+    },
+    "zod-validation-error": {
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/zod-validation-error/-/zod-validation-error-0.3.1.tgz",
+      "integrity": "sha512-3m7VcE4YT3ZdGJoYBZnLt8E1S/r8zPFNDWMc2njaeC7Vxe5FQbgIiwHoerSkli5PgsUyxWQhpFxEAJXkBJvoDg==",
+      "requires": {}
     }
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -171,8 +171,7 @@
         "@dotcom-tool-kit/secret-squirrel": "file:../../plugins/secret-squirrel",
         "@dotcom-tool-kit/upload-assets-to-s3": "^2.0.0",
         "dotcom-tool-kit": "file:../cli",
-        "nodemon": "^2.0.15",
-        "serverless-offline": "^12.0.4"
+        "nodemon": "^2.0.15"
       }
     },
     "lib/error": {
@@ -265,7 +264,8 @@
         "@dotcom-tool-kit/error": "^2.0.0",
         "@dotcom-tool-kit/logger": "^2.2.0",
         "semver": "^7.3.7",
-        "tslib": "^2.3.1"
+        "tslib": "^2.3.1",
+        "zod": "^3.20.2"
       },
       "devDependencies": {
         "@jest/globals": "^27.4.6",
@@ -496,6 +496,7 @@
       "version": "3.264.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/client-lambda/-/client-lambda-3.264.0.tgz",
       "integrity": "sha512-Z7EnWd1PveFdcSAkqpbMQO/iOBETKAs6/RV5ZfDtNmtzku2FGk02Xm76eQnkJrUNTWesEWw/am03cK2d7brBGw==",
+      "peer": true,
       "dependencies": {
         "@aws-crypto/sha256-browser": "3.0.0",
         "@aws-crypto/sha256-js": "3.0.0",
@@ -542,6 +543,7 @@
       "version": "3.264.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.264.0.tgz",
       "integrity": "sha512-p+7sYpRcdv9omnnsPhD/vOFuZ1SpfV62ZgistBK/RDsQg2W9SIWQRW1KPt7gOCQ0nwp4efntw4Sle0LjS7ykxg==",
+      "peer": true,
       "dependencies": {
         "@aws-crypto/sha256-browser": "3.0.0",
         "@aws-crypto/sha256-js": "3.0.0",
@@ -584,6 +586,7 @@
       "version": "3.264.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso-oidc/-/client-sso-oidc-3.264.0.tgz",
       "integrity": "sha512-82hGEbfsD4lBGIF1q8o82jTNSgBCcBpfFsvA+ltZf0bh4ChIWOi4vVvg8G+zVQN1mm/Rj8vWYO/D0tNF8OSyWw==",
+      "peer": true,
       "dependencies": {
         "@aws-crypto/sha256-browser": "3.0.0",
         "@aws-crypto/sha256-js": "3.0.0",
@@ -626,6 +629,7 @@
       "version": "3.264.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/client-sts/-/client-sts-3.264.0.tgz",
       "integrity": "sha512-sco1jREkDdds4Z3V19Vlu/YpBHSzeEt1KFqOPnbjFw7pSakRNzpyWmLLxOwWjwgGKt6pSF3Aw0ZOMYsAUDc5qQ==",
+      "peer": true,
       "dependencies": {
         "@aws-crypto/sha256-browser": "3.0.0",
         "@aws-crypto/sha256-js": "3.0.0",
@@ -672,6 +676,7 @@
       "version": "3.264.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.264.0.tgz",
       "integrity": "sha512-UU5NNlfn+Go+5PLBzyTH1YE3r/pgykpE4QYFon87sCnEQnQH9xmlRTW1f1cBSQ9kivbFZd2/C2X3qhB3fe2JfA==",
+      "peer": true,
       "dependencies": {
         "@aws-sdk/credential-provider-env": "3.257.0",
         "@aws-sdk/credential-provider-imds": "3.259.0",
@@ -691,6 +696,7 @@
       "version": "3.264.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.264.0.tgz",
       "integrity": "sha512-DPzL7oawcILs5Mduim9Z8SVeJaUpaDRVbUIrBHsMBu+N7Zuqtzr+0ckHc1bEi3iYq2QUCk5pH5vpQaZYkMlbtw==",
+      "peer": true,
       "dependencies": {
         "@aws-sdk/credential-provider-env": "3.257.0",
         "@aws-sdk/credential-provider-imds": "3.259.0",
@@ -711,6 +717,7 @@
       "version": "3.264.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.264.0.tgz",
       "integrity": "sha512-CJuAlqIIJap6LXoqimvEAnYZ7Kb5pTbiS3e+aY+fajO3OPujmQpHuiY8kOmscjwZ4ErJdEskivcTGwXph0dPZQ==",
+      "peer": true,
       "dependencies": {
         "@aws-sdk/client-sso": "3.264.0",
         "@aws-sdk/property-provider": "3.257.0",
@@ -727,6 +734,7 @@
       "version": "3.264.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-endpoint/-/middleware-endpoint-3.264.0.tgz",
       "integrity": "sha512-H9JEAug3Oo3IA2wZIplVVF6NtauCIjICXWgbNbA8Im+I2KPe0jWtOdtQv4U+tqHe9T4zIixaCM3gjUBld+FoOA==",
+      "peer": true,
       "dependencies": {
         "@aws-sdk/middleware-serde": "3.257.0",
         "@aws-sdk/protocol-http": "3.257.0",
@@ -745,6 +753,7 @@
       "version": "3.261.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/smithy-client/-/smithy-client-3.261.0.tgz",
       "integrity": "sha512-j8XQEa3caZUVFVZfhJjaskw80O/tB+IXu84HMN44N7UkXaCFHirUsNjTDztJhnVXf/gKXzIqUqprfRnOvwLtIg==",
+      "peer": true,
       "dependencies": {
         "@aws-sdk/middleware-stack": "3.257.0",
         "@aws-sdk/types": "3.257.0",
@@ -758,6 +767,7 @@
       "version": "3.264.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.264.0.tgz",
       "integrity": "sha512-1N54FCdBJRqrwFWHUoDpGI0rKhI29Or9ZwGjjcBzKzLhz5sEF/DEhuID7h1/KKEkXdQ0+lmXOFGMMrahrMpOow==",
+      "peer": true,
       "dependencies": {
         "@aws-sdk/client-sso-oidc": "3.264.0",
         "@aws-sdk/property-provider": "3.257.0",
@@ -773,6 +783,7 @@
       "version": "3.261.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/util-defaults-mode-browser/-/util-defaults-mode-browser-3.261.0.tgz",
       "integrity": "sha512-lX3X1NfzQVV6cakepGV24uRcqevlDnQ8VgaCV8dhnw1FVThueFigyoFaUA02+uRXbV9KIbNWkEvweNtm2wvyDw==",
+      "peer": true,
       "dependencies": {
         "@aws-sdk/property-provider": "3.257.0",
         "@aws-sdk/types": "3.257.0",
@@ -787,6 +798,7 @@
       "version": "3.261.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/util-defaults-mode-node/-/util-defaults-mode-node-3.261.0.tgz",
       "integrity": "sha512-4AK6yu4bOmHSocUdbGoEHbNXB09UA58ON2HBHY4NxMBuFBAd9XB2tYiyhce+Cm+o+lHbS8oQnw0VZw16WMzzew==",
+      "peer": true,
       "dependencies": {
         "@aws-sdk/config-resolver": "3.259.0",
         "@aws-sdk/credential-provider-imds": "3.259.0",
@@ -802,7 +814,8 @@
     "node_modules/@aws-sdk/client-lambda/node_modules/tslib": {
       "version": "2.5.0",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.0.tgz",
-      "integrity": "sha512-336iVw3rtn2BUK7ORdIAHTyxHGRIHVReokCR3XjbckJMK7ms8FysBfhLR8IXnAgy7T0PTPNBWKiH514FOW/WSg=="
+      "integrity": "sha512-336iVw3rtn2BUK7ORdIAHTyxHGRIHVReokCR3XjbckJMK7ms8FysBfhLR8IXnAgy7T0PTPNBWKiH514FOW/WSg==",
+      "peer": true
     },
     "node_modules/@aws-sdk/client-s3": {
       "version": "3.259.0",
@@ -4655,6 +4668,7 @@
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/@hapi/accept/-/accept-6.0.0.tgz",
       "integrity": "sha512-aG/Ml4kSBWCVmWvR8N8ULRuB385D8K/3OI7lquZQruH11eM7sHR5Nha30BbDzijJHtyV7Vwc6MlMwNfwb70ISg==",
+      "peer": true,
       "dependencies": {
         "@hapi/boom": "^10.0.0",
         "@hapi/hoek": "^10.0.0"
@@ -4664,6 +4678,7 @@
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/@hapi/ammo/-/ammo-6.0.0.tgz",
       "integrity": "sha512-lhX7SYtWScQaeAIL5XnE54WzyDgS5RXVeEtFEovyZcTdVzTYbo0nem56Bwko1PBcRxRUIw1v2tMb6sjFs6vEwg==",
+      "peer": true,
       "dependencies": {
         "@hapi/hoek": "^10.0.0"
       }
@@ -4672,6 +4687,7 @@
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/@hapi/b64/-/b64-6.0.0.tgz",
       "integrity": "sha512-Es6o4BtzvMmNF28KJGuwUzUtMjF6ToZ1hQt3UOjaXc6TNkRefel+NyQSjc9b5q3Re7xwv23r0xK3Vo3yreaJHQ==",
+      "peer": true,
       "dependencies": {
         "@hapi/hoek": "^10.0.0"
       }
@@ -4680,6 +4696,7 @@
       "version": "10.0.0",
       "resolved": "https://registry.npmjs.org/@hapi/boom/-/boom-10.0.0.tgz",
       "integrity": "sha512-1YVs9tLHhypBqqinKQRqh7FUERIolarQApO37OWkzD+z6y6USi871Sv746zBPKcIOBuI6g6y4FrwX87mmJ90Gg==",
+      "peer": true,
       "dependencies": {
         "@hapi/hoek": "10.x.x"
       }
@@ -4688,6 +4705,7 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/@hapi/bounce/-/bounce-3.0.0.tgz",
       "integrity": "sha512-L0G4NcwwOYRhpcXeL76hNrLTUcObqtZMB3z4kcRVUZcR/w3v6C5Q1cTElV4/V7og1fG+wOyDR55UMFA+tWfhtA==",
+      "peer": true,
       "dependencies": {
         "@hapi/boom": "^10.0.0",
         "@hapi/hoek": "^10.0.0"
@@ -4696,12 +4714,14 @@
     "node_modules/@hapi/bourne": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/@hapi/bourne/-/bourne-3.0.0.tgz",
-      "integrity": "sha512-Waj1cwPXJDucOib4a3bAISsKJVb15MKi9IvmTI/7ssVEm6sywXGjVJDhl6/umt1pK1ZS7PacXU3A1PmFKHEZ2w=="
+      "integrity": "sha512-Waj1cwPXJDucOib4a3bAISsKJVb15MKi9IvmTI/7ssVEm6sywXGjVJDhl6/umt1pK1ZS7PacXU3A1PmFKHEZ2w==",
+      "peer": true
     },
     "node_modules/@hapi/call": {
       "version": "9.0.0",
       "resolved": "https://registry.npmjs.org/@hapi/call/-/call-9.0.0.tgz",
       "integrity": "sha512-Z6byqbEtKF3RIH2kWG6cX64RwEqHBWYEVkNoEx6oKvkPaTrC6WTPRgr+ANo9Xa8G1GXyvs/NCMTnn3Mdj12TSA==",
+      "peer": true,
       "dependencies": {
         "@hapi/boom": "^10.0.0",
         "@hapi/hoek": "^10.0.0"
@@ -4711,6 +4731,7 @@
       "version": "12.1.0",
       "resolved": "https://registry.npmjs.org/@hapi/catbox/-/catbox-12.1.0.tgz",
       "integrity": "sha512-60MCN5lgaXcuRTjMZqLR+DV0clS5RAFAwfYAQU2/na6PqrXHDRQcJwVMwP7jJayCrJm4POJlLDzZLuh1ba5XUg==",
+      "peer": true,
       "dependencies": {
         "@hapi/boom": "^10.0.0",
         "@hapi/hoek": "^10.0.0",
@@ -4722,6 +4743,7 @@
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/@hapi/catbox-memory/-/catbox-memory-6.0.0.tgz",
       "integrity": "sha512-A1O30g8GdaODx/GinytF6jFm772pdTPVWJe0cF2RiTOfhgIAAagzCcpBqRgQ8olLui0F5bzUF/SAi4BmkZ4yxA==",
+      "peer": true,
       "dependencies": {
         "@hapi/boom": "^10.0.0",
         "@hapi/hoek": "^10.0.0"
@@ -4731,6 +4753,7 @@
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/@hapi/content/-/content-6.0.0.tgz",
       "integrity": "sha512-CEhs7j+H0iQffKfe5Htdak5LBOz/Qc8TRh51cF+BFv0qnuph3Em4pjGVzJMkI2gfTDdlJKWJISGWS1rK34POGA==",
+      "peer": true,
       "dependencies": {
         "@hapi/boom": "^10.0.0"
       }
@@ -4739,6 +4762,7 @@
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/@hapi/cryptiles/-/cryptiles-6.0.0.tgz",
       "integrity": "sha512-CUypQJI2F3HaKZjwlky3KyLu7p0O4WJXNJj+2AZ0czqwkwQIz8j+btOkzA3OMar8WTntnCrDx0f92PzxEK+JlA==",
+      "peer": true,
       "dependencies": {
         "@hapi/boom": "^10.0.0"
       },
@@ -4749,12 +4773,14 @@
     "node_modules/@hapi/file": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/@hapi/file/-/file-3.0.0.tgz",
-      "integrity": "sha512-w+lKW+yRrLhJu620jT3y+5g2mHqnKfepreykvdOcl9/6up8GrQQn+l3FRTsjHTKbkbfQFkuksHpdv2EcpKcJ4Q=="
+      "integrity": "sha512-w+lKW+yRrLhJu620jT3y+5g2mHqnKfepreykvdOcl9/6up8GrQQn+l3FRTsjHTKbkbfQFkuksHpdv2EcpKcJ4Q==",
+      "peer": true
     },
     "node_modules/@hapi/h2o2": {
       "version": "10.0.0",
       "resolved": "https://registry.npmjs.org/@hapi/h2o2/-/h2o2-10.0.0.tgz",
       "integrity": "sha512-eY5uulCxtvN68xHCXt7dr7yQQrFgsQpCkBRsxbYjdkWCPl2PJBHktQGeXqrumz8XKR1RUmElqNZK2IjdUxK/gw==",
+      "peer": true,
       "dependencies": {
         "@hapi/boom": "^10.0.0",
         "@hapi/hoek": "^10.0.0",
@@ -4769,6 +4795,7 @@
       "version": "21.2.1",
       "resolved": "https://registry.npmjs.org/@hapi/hapi/-/hapi-21.2.1.tgz",
       "integrity": "sha512-mDBhIi/zIYhWPaZF4Z8h7jUtWC3bz7xYuUyI5riXZV9DabFnNOKpQfOob6V5ZcDwEJfmnWHgJO37BVCn31BStQ==",
+      "peer": true,
       "dependencies": {
         "@hapi/accept": "^6.0.0",
         "@hapi/ammo": "^6.0.0",
@@ -4797,6 +4824,7 @@
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/@hapi/heavy/-/heavy-8.0.0.tgz",
       "integrity": "sha512-NpKo74mF66GSwYu31IZwp11/6NmaUYxHeMTKSky09XBs8fVbzQDP83856+l+Ji6wxGmUeg75itCu1ujvEF6mdA==",
+      "peer": true,
       "dependencies": {
         "@hapi/boom": "^10.0.0",
         "@hapi/hoek": "^10.0.0",
@@ -4806,12 +4834,14 @@
     "node_modules/@hapi/hoek": {
       "version": "10.0.1",
       "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-10.0.1.tgz",
-      "integrity": "sha512-CvlW7jmOhWzuqOqiJQ3rQVLMcREh0eel4IBnxDx2FAcK8g7qoJRQK4L1CPBASoCY6y8e6zuCy3f2g+HWdkzcMw=="
+      "integrity": "sha512-CvlW7jmOhWzuqOqiJQ3rQVLMcREh0eel4IBnxDx2FAcK8g7qoJRQK4L1CPBASoCY6y8e6zuCy3f2g+HWdkzcMw==",
+      "peer": true
     },
     "node_modules/@hapi/iron": {
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/@hapi/iron/-/iron-7.0.0.tgz",
       "integrity": "sha512-NNXJP5fpeiTCPj/4OJG2PWBjWC0/V5D8YggS9RZeuBbfUUuTYE6TbdGqLUsCzIpPI54I8W5dhwEGbRv1CnWQtw==",
+      "peer": true,
       "dependencies": {
         "@hapi/b64": "^6.0.0",
         "@hapi/boom": "^10.0.0",
@@ -4824,6 +4854,7 @@
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/@hapi/mimos/-/mimos-7.0.0.tgz",
       "integrity": "sha512-ALORTrZrrBPOUX05rW4htNajoekEjQtUi1PB+17/3xs/hkdQ+gSEFbs5GdJihA49qWf7td3v4PgnvOe8mcf/jQ==",
+      "peer": true,
       "dependencies": {
         "@hapi/hoek": "^10.0.0",
         "mime-db": "^1.52.0"
@@ -4833,6 +4864,7 @@
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/@hapi/nigel/-/nigel-5.0.0.tgz",
       "integrity": "sha512-I9eq43BnSdz1BkvMpG7mFL7J+SIfn6DLNThuxFpIOAMUnkWbPgtcFP+HHrBAeoFkowfgQrr02vsIAkAPml4hvw==",
+      "peer": true,
       "dependencies": {
         "@hapi/hoek": "^10.0.0",
         "@hapi/vise": "^5.0.0"
@@ -4845,6 +4877,7 @@
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/@hapi/pez/-/pez-6.0.0.tgz",
       "integrity": "sha512-3bMmsvlqrVNqaNEe4JWLZVpJ40jXuQ3vDy1+fbhyJmuAdMCMCkWexsKc7fT+mu18pFIwJzlenjc4/VE3weTq7w==",
+      "peer": true,
       "dependencies": {
         "@hapi/b64": "^6.0.0",
         "@hapi/boom": "^10.0.0",
@@ -4857,6 +4890,7 @@
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/@hapi/podium/-/podium-5.0.0.tgz",
       "integrity": "sha512-SbhFdu8LOIscMS82Zsoj9abcllAqbK4qBgznzJ9yr+vS2j1EomJTukkhxb76Lml0BHCd4Hn79F+3EQg06kcf8g==",
+      "peer": true,
       "dependencies": {
         "@hapi/hoek": "^10.0.0",
         "@hapi/teamwork": "^6.0.0",
@@ -4867,6 +4901,7 @@
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/@hapi/shot/-/shot-6.0.0.tgz",
       "integrity": "sha512-RLGgzXy9GciJDunhY40NbVnLgYqp5gfBooZ2fOkAr4KbCEav/SJtYQS1N+knR7WFGzy8aooCR3XBUPI4ghHAkQ==",
+      "peer": true,
       "dependencies": {
         "@hapi/hoek": "^10.0.0",
         "@hapi/validate": "^2.0.0"
@@ -4876,6 +4911,7 @@
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/@hapi/somever/-/somever-4.1.0.tgz",
       "integrity": "sha512-koNBYu7Jdcb7gaC4VcnU78rFxSlsYwuElm6NMznE0EEeznzJtvLLmDZX0SPX8kXWC/E7ONlE29HF/yiSOgWG1Q==",
+      "peer": true,
       "dependencies": {
         "@hapi/bounce": "^3.0.0",
         "@hapi/hoek": "^9.0.0"
@@ -4884,12 +4920,14 @@
     "node_modules/@hapi/somever/node_modules/@hapi/hoek": {
       "version": "9.3.0",
       "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-9.3.0.tgz",
-      "integrity": "sha512-/c6rf4UJlmHlC9b5BaNvzAcFv7HZ2QHaV0D4/HNlBdvFnvQq8RI4kYdhyPCl7Xj+oWvTWQ8ujhqS53LIgAe6KQ=="
+      "integrity": "sha512-/c6rf4UJlmHlC9b5BaNvzAcFv7HZ2QHaV0D4/HNlBdvFnvQq8RI4kYdhyPCl7Xj+oWvTWQ8ujhqS53LIgAe6KQ==",
+      "peer": true
     },
     "node_modules/@hapi/statehood": {
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/@hapi/statehood/-/statehood-8.0.0.tgz",
       "integrity": "sha512-umQTPID7BwmqAv9Rx7yLtbTNzsYg4va96aLqKneb3mlBQG32uq4iOQZ6luwBVACDFhqU3C3ewhznhukN09ZkZQ==",
+      "peer": true,
       "dependencies": {
         "@hapi/boom": "^10.0.0",
         "@hapi/bounce": "^3.0.0",
@@ -4904,6 +4942,7 @@
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/@hapi/subtext/-/subtext-8.0.0.tgz",
       "integrity": "sha512-fD+LY1U1SIUNHZJrNMIbuGl3CAd9JN8slljarFO4b8RrifkzjqbvdlZu/6iT6zlNM35GtDExf7hIepbUFUkT7A==",
+      "peer": true,
       "dependencies": {
         "@hapi/boom": "^10.0.0",
         "@hapi/bourne": "^3.0.0",
@@ -4918,6 +4957,7 @@
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/@hapi/teamwork/-/teamwork-6.0.0.tgz",
       "integrity": "sha512-05HumSy3LWfXpmJ9cr6HzwhAavrHkJ1ZRCmNE2qJMihdM5YcWreWPfyN0yKT2ZjCM92au3ZkuodjBxOibxM67A==",
+      "peer": true,
       "engines": {
         "node": ">=14.0.0"
       }
@@ -4926,6 +4966,7 @@
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/@hapi/topo/-/topo-6.0.0.tgz",
       "integrity": "sha512-aorJvN1Q1n5xrZuA50Z4X6adI6VAM2NalIVm46ALL9LUvdoqhof3JPY69jdJH8asM3PsWr2SUVYzp57EqUP41A==",
+      "peer": true,
       "dependencies": {
         "@hapi/hoek": "^10.0.0"
       }
@@ -4934,6 +4975,7 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/@hapi/validate/-/validate-2.0.0.tgz",
       "integrity": "sha512-w5m8MvBgqGndbMIB+AWmXTb8CLtF1DlIxbnbAHNAo7aFuNQuI1Ywc2e0zDLK5fbFXDoqRzNrHnC7JjNJ+hDigw==",
+      "peer": true,
       "dependencies": {
         "@hapi/hoek": "^10.0.0",
         "@hapi/topo": "^6.0.0"
@@ -4943,6 +4985,7 @@
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/@hapi/vise/-/vise-5.0.0.tgz",
       "integrity": "sha512-bz/PA7DHIvsd/2eoW7t9WpU8+k9pofZHppYEn1mCTOVnC/cGN3hCEYaoAe6BpoeJM72iJDKZEOWvQvfgCrmzxA==",
+      "peer": true,
       "dependencies": {
         "@hapi/hoek": "^10.0.0"
       }
@@ -4951,6 +4994,7 @@
       "version": "18.0.0",
       "resolved": "https://registry.npmjs.org/@hapi/wreck/-/wreck-18.0.0.tgz",
       "integrity": "sha512-Yk9STxoM06Hjjq58cH0KFG91u9F2h9eVE72o8vUr3AfK80qt7I2POG5+cDGTEntbnvvzm0ERow2sjG3QsqCWUA==",
+      "peer": true,
       "dependencies": {
         "@hapi/boom": "^10.0.0",
         "@hapi/bourne": "^3.0.0",
@@ -7095,6 +7139,7 @@
       "version": "6.8.2",
       "resolved": "https://registry.npmjs.org/@serverless/utils/-/utils-6.8.2.tgz",
       "integrity": "sha512-FW8zdG8OPoF6qgyutiMhz4m/5SxbQjoQdbaGcW3wU6xe3QzQh41Hif7I3Xuu4J62CvxiWuz19sxNDJz2mTcskw==",
+      "peer": true,
       "dependencies": {
         "archive-type": "^4.0.0",
         "chalk": "^4.1.2",
@@ -7137,6 +7182,7 @@
       "version": "4.6.0",
       "resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-4.6.0.tgz",
       "integrity": "sha512-t09vSN3MdfsyCHoFcTRCH/iUtG7OJ0CsjzB8cjAmKc/va/kIgeDI/TxsigdncE/4be734m0cvIYwNaV4i2XqAw==",
+      "peer": true,
       "engines": {
         "node": ">=10"
       },
@@ -7148,6 +7194,7 @@
       "version": "4.0.6",
       "resolved": "https://registry.npmjs.org/@szmarczak/http-timer/-/http-timer-4.0.6.tgz",
       "integrity": "sha512-4BAffykYOgO+5nzBWYwE3W90sBgLJoUPRWWcL8wlyiM8IB8ipJz3UMJ9KXQd1RKQXpKp8Tutn80HZtWsu2u76w==",
+      "peer": true,
       "dependencies": {
         "defer-to-connect": "^2.0.0"
       },
@@ -7159,6 +7206,7 @@
       "version": "7.0.2",
       "resolved": "https://registry.npmjs.org/cacheable-request/-/cacheable-request-7.0.2.tgz",
       "integrity": "sha512-pouW8/FmiPQbuGpkXQ9BAPv/Mo5xDGANgSNXzTzJ8DrKGuXOssM4wIQRjfanNRh3Yu5cfYPvcorqbhg2KIJtew==",
+      "peer": true,
       "dependencies": {
         "clone-response": "^1.0.2",
         "get-stream": "^5.1.0",
@@ -7176,6 +7224,7 @@
       "version": "5.2.0",
       "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-5.2.0.tgz",
       "integrity": "sha512-nBF+F1rAZVCu/p7rjzgA+Yb4lfYXrpl7a6VmJrU8wF9I1CKvP/QwPNZHnOlwbTkY6dvtFIzFMSyQXbLoTQPRpA==",
+      "peer": true,
       "dependencies": {
         "pump": "^3.0.0"
       },
@@ -7196,6 +7245,7 @@
           "url": "https://github.com/sponsors/sibiraj-s"
         }
       ],
+      "peer": true,
       "engines": {
         "node": ">=8"
       }
@@ -7204,6 +7254,7 @@
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-6.0.0.tgz",
       "integrity": "sha512-aW35yZM6Bb/4oJlZncMH2LCoZtJXTRxES17vE3hoRiowU2kWHaJKFkSBDnDR+cm9J+9QhXmREyIfv0pji9ejCQ==",
+      "peer": true,
       "dependencies": {
         "mimic-response": "^3.1.0"
       },
@@ -7218,6 +7269,7 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/defer-to-connect/-/defer-to-connect-2.0.1.tgz",
       "integrity": "sha512-4tvttepXG1VaYGrRibk5EwJd1t4udunSOVMdLSAL6mId1ix438oPwPZMALY41FCijukO1L0twNcGsdzS7dHgDg==",
+      "peer": true,
       "engines": {
         "node": ">=10"
       }
@@ -7226,6 +7278,7 @@
       "version": "11.8.6",
       "resolved": "https://registry.npmjs.org/got/-/got-11.8.6.tgz",
       "integrity": "sha512-6tfZ91bOr7bOXnK7PRDCGBLa1H4U080YHNaAQ2KsMGlLEzRbk44nsZF2E1IeRc3vtJHPVbKCYgdFbaGO2ljd8g==",
+      "peer": true,
       "dependencies": {
         "@sindresorhus/is": "^4.0.0",
         "@szmarczak/http-timer": "^4.0.5",
@@ -7250,6 +7303,7 @@
       "version": "8.2.5",
       "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-8.2.5.tgz",
       "integrity": "sha512-QAgPDQMEgrDssk1XiwwHoOGYF9BAbUcc1+j+FhEvaOt8/cKRqyLn0U5qA6F74fGhTMGxf92pOvPBeh29jQJDTQ==",
+      "peer": true,
       "dependencies": {
         "ansi-escapes": "^4.2.1",
         "chalk": "^4.1.1",
@@ -7274,17 +7328,20 @@
     "node_modules/@serverless/utils/node_modules/json-buffer": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.1.tgz",
-      "integrity": "sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ=="
+      "integrity": "sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==",
+      "peer": true
     },
     "node_modules/@serverless/utils/node_modules/jwt-decode": {
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/jwt-decode/-/jwt-decode-3.1.2.tgz",
-      "integrity": "sha512-UfpWE/VZn0iP50d8cz9NrZLM9lSWhcJ+0Gt/nm4by88UL+J1SiKN8/5dkjMmbEzwL2CAe+67GsegCbIKtbp75A=="
+      "integrity": "sha512-UfpWE/VZn0iP50d8cz9NrZLM9lSWhcJ+0Gt/nm4by88UL+J1SiKN8/5dkjMmbEzwL2CAe+67GsegCbIKtbp75A==",
+      "peer": true
     },
     "node_modules/@serverless/utils/node_modules/keyv": {
       "version": "4.5.2",
       "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.5.2.tgz",
       "integrity": "sha512-5MHbFaKn8cNSmVW7BYnijeAVlE4cYA/SVkifVgrh7yotnfhKmjuXpDKjrABLnT0SfHWV21P8ow07OGfRrNDg8g==",
+      "peer": true,
       "dependencies": {
         "json-buffer": "3.0.1"
       }
@@ -7293,6 +7350,7 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-2.0.0.tgz",
       "integrity": "sha512-tqNXrS78oMOE73NMxK4EMLQsQowWf8jKooH9g7xPavRT706R6bkQJ6DY2Te7QukaZsulxa30wQ7bk0pm4XiHmA==",
+      "peer": true,
       "engines": {
         "node": ">=8"
       }
@@ -7301,6 +7359,7 @@
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-3.1.0.tgz",
       "integrity": "sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ==",
+      "peer": true,
       "engines": {
         "node": ">=10"
       },
@@ -7312,6 +7371,7 @@
       "version": "6.1.0",
       "resolved": "https://registry.npmjs.org/normalize-url/-/normalize-url-6.1.0.tgz",
       "integrity": "sha512-DlL+XwOy3NxAQ8xuC0okPgK46iuVNAK01YN7RueYBqqFeGsBjV9XmCAzAdgt+667bCl5kPh9EqKKDwnaPG1I7A==",
+      "peer": true,
       "engines": {
         "node": ">=10"
       },
@@ -7323,6 +7383,7 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/p-cancelable/-/p-cancelable-2.1.1.tgz",
       "integrity": "sha512-BZOr3nRQHOntUjTrH8+Lh54smKHoHyur8We1V8DSMVrl5A2malOOwuJRnKRDjSnkoeBh4at6BwEnb5I7Jl31wg==",
+      "peer": true,
       "engines": {
         "node": ">=8"
       }
@@ -7331,6 +7392,7 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/responselike/-/responselike-2.0.1.tgz",
       "integrity": "sha512-4gl03wn3hj1HP3yzgdI7d3lCkF95F21Pz4BPGvKHinyQzALR5CapwC8yIi0Rh58DEMQ/SguC03wFj2k0M/mHhw==",
+      "peer": true,
       "dependencies": {
         "lowercase-keys": "^2.0.0"
       },
@@ -7342,6 +7404,7 @@
       "version": "8.1.1",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz",
       "integrity": "sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==",
+      "peer": true,
       "dependencies": {
         "has-flag": "^4.0.0"
       },
@@ -7356,6 +7419,7 @@
       "version": "8.3.2",
       "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
       "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
+      "peer": true,
       "bin": {
         "uuid": "dist/bin/uuid"
       }
@@ -7364,6 +7428,7 @@
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-4.0.2.tgz",
       "integrity": "sha512-7KxauUdBmSdWnmpaGFg+ppNjKF8uNLry8LyzjauQDOVONfFLNKrKvQOxZ/VuTIcS/gge/YNahf5RIIQWTSarlg==",
+      "peer": true,
       "dependencies": {
         "imurmurhash": "^0.1.4",
         "signal-exit": "^3.0.7"
@@ -7412,7 +7477,8 @@
     "node_modules/@tokenizer/token": {
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/@tokenizer/token/-/token-0.3.0.tgz",
-      "integrity": "sha512-OvjF+z51L3ov0OyAU0duzsYuvO01PH7x4t6DJx+guahgTnBHkhJdG7soQeTSFLWN3efnHyibZ4Z8l2EuWwJN3A=="
+      "integrity": "sha512-OvjF+z51L3ov0OyAU0duzsYuvO01PH7x4t6DJx+guahgTnBHkhJdG7soQeTSFLWN3efnHyibZ4Z8l2EuWwJN3A==",
+      "peer": true
     },
     "node_modules/@tootallnate/once": {
       "version": "1.1.2",
@@ -7478,6 +7544,7 @@
       "version": "6.0.3",
       "resolved": "https://registry.npmjs.org/@types/cacheable-request/-/cacheable-request-6.0.3.tgz",
       "integrity": "sha512-IQ3EbTzGxIigb1I3qPZc1rWJnH0BmSKv5QYTalEwweFvyBDLSAe24zP0le/hyi7ecGfZVlIVAg4BZqb8WBwKqw==",
+      "peer": true,
       "dependencies": {
         "@types/http-cache-semantics": "*",
         "@types/keyv": "^3.1.4",
@@ -7530,7 +7597,8 @@
     "node_modules/@types/http-cache-semantics": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/@types/http-cache-semantics/-/http-cache-semantics-4.0.1.tgz",
-      "integrity": "sha512-SZs7ekbP8CN0txVG2xVRH6EgKmEm31BOxA07vkFaETzZz1xh+cbt8BcI0slpymvwhx5dlFnQG2rTlPVQn+iRPQ=="
+      "integrity": "sha512-SZs7ekbP8CN0txVG2xVRH6EgKmEm31BOxA07vkFaETzZz1xh+cbt8BcI0slpymvwhx5dlFnQG2rTlPVQn+iRPQ==",
+      "peer": true
     },
     "node_modules/@types/istanbul-lib-coverage": {
       "version": "2.0.4",
@@ -7578,6 +7646,7 @@
       "version": "3.1.4",
       "resolved": "https://registry.npmjs.org/@types/keyv/-/keyv-3.1.4.tgz",
       "integrity": "sha512-BQ5aZNSCpj7D6K2ksrRCTmKRLEpnPvWDiLPfoGyhZ++8YtiK9d/3DBKPJgry359X/P1PfruyYwvnvwFjuEiEIg==",
+      "peer": true,
       "dependencies": {
         "@types/node": "*"
       }
@@ -7752,6 +7821,7 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/@types/responselike/-/responselike-1.0.0.tgz",
       "integrity": "sha512-85Y2BjiufFzaMIlvJDvTTB8Fxl2xfLo4HgmHzVBz08w4wDePCTjYw66PdrolO0kzli3yam/YCgRufyo1DdQVTA==",
+      "peer": true,
       "dependencies": {
         "@types/node": "*"
       }
@@ -8470,6 +8540,7 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/archive-type/-/archive-type-4.0.0.tgz",
       "integrity": "sha512-zV4Ky0v1F8dBrdYElwTvQhweQ0P7Kwc1aluqJsYtOBP01jXcWCyW2IEfI1YiqsG+Iy7ZR+o5LF1N+PGECBxHWA==",
+      "peer": true,
       "dependencies": {
         "file-type": "^4.2.0"
       },
@@ -8481,6 +8552,7 @@
       "version": "4.4.0",
       "resolved": "https://registry.npmjs.org/file-type/-/file-type-4.4.0.tgz",
       "integrity": "sha512-f2UbFQEk7LXgWpi5ntcO86OeA/cC80fuDDDaX/fZ2ZGel+AF7leRQqBBW1eJNiiQkrZlAoM6P+VYP5P6bOlDEQ==",
+      "peer": true,
       "engines": {
         "node": ">=4"
       }
@@ -8615,6 +8687,7 @@
       "version": "0.1.3",
       "resolved": "https://registry.npmjs.org/array-unflat-js/-/array-unflat-js-0.1.3.tgz",
       "integrity": "sha512-8pljkLj4vfz2i7Tf3yB31tRrszjP8/kwIyABGfcZ1GcHlvdUB0Sbx0WzQkOPMqUBxa/bu4+/NAyHEpDtZJzlJw==",
+      "peer": true,
       "engines": {
         "node": ">=14.18.0"
       }
@@ -9435,6 +9508,7 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/buffer-alloc/-/buffer-alloc-1.2.0.tgz",
       "integrity": "sha512-CFsHQgjtW1UChdXgbyJGtnm+O/uLQeZdtbDo8mfUgYXCHSM1wgrVxXm6bSyrUuErEb+4sYVGCzASBRot7zyrow==",
+      "peer": true,
       "dependencies": {
         "buffer-alloc-unsafe": "^1.1.0",
         "buffer-fill": "^1.0.0"
@@ -9443,7 +9517,8 @@
     "node_modules/buffer-alloc-unsafe": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/buffer-alloc-unsafe/-/buffer-alloc-unsafe-1.1.0.tgz",
-      "integrity": "sha512-TEM2iMIEQdJ2yjPJoSIsldnleVaAk1oW3DBVUykyOLsEsFmEc9kn+SFFPz+gl54KQNxlDnAwCXosOS9Okx2xAg=="
+      "integrity": "sha512-TEM2iMIEQdJ2yjPJoSIsldnleVaAk1oW3DBVUykyOLsEsFmEc9kn+SFFPz+gl54KQNxlDnAwCXosOS9Okx2xAg==",
+      "peer": true
     },
     "node_modules/buffer-crc32": {
       "version": "0.2.13",
@@ -9455,7 +9530,8 @@
     "node_modules/buffer-fill": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/buffer-fill/-/buffer-fill-1.0.0.tgz",
-      "integrity": "sha512-T7zexNBwiiaCOGDg9xNX9PBmjrubblRkENuptryuI64URkXDFum9il/JGL8Lm8wYfAXpredVXXZz7eMHilimiQ=="
+      "integrity": "sha512-T7zexNBwiiaCOGDg9xNX9PBmjrubblRkENuptryuI64URkXDFum9il/JGL8Lm8wYfAXpredVXXZz7eMHilimiQ==",
+      "peer": true
     },
     "node_modules/buffer-from": {
       "version": "1.1.2",
@@ -9469,6 +9545,7 @@
       "version": "3.3.0",
       "resolved": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-3.3.0.tgz",
       "integrity": "sha512-zhaCDicdLuWN5UbN5IMnFqNMhNfo919sH85y2/ea+5Yg9TsTkeZxpL+JLbp6cgYFS4sRLp3YV4S6yDuqVWHYOw==",
+      "peer": true,
       "engines": {
         "node": ">=6"
       },
@@ -9562,6 +9639,7 @@
       "version": "5.0.4",
       "resolved": "https://registry.npmjs.org/cacheable-lookup/-/cacheable-lookup-5.0.4.tgz",
       "integrity": "sha512-2/kNscPhpcxrOigMZzbiWF7dz8ilhb/nIHU3EyZiXWXpeq/au8qJ8VhdftMkty3n7Gj6HIGalQG8oiBNB3AJgA==",
+      "peer": true,
       "engines": {
         "node": ">=10.6.0"
       }
@@ -9946,6 +10024,7 @@
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/cli-color/-/cli-color-2.0.3.tgz",
       "integrity": "sha512-OkoZnxyC4ERN3zLzZaY9Emb7f/MhBOIpePv0Ycok0fJYT+Ouo00UBEIwsVsr0yoow++n5YWlSUgST9GKhNHiRQ==",
+      "peer": true,
       "dependencies": {
         "d": "^1.0.1",
         "es5-ext": "^0.10.61",
@@ -9971,6 +10050,7 @@
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/cli-progress-footer/-/cli-progress-footer-2.3.2.tgz",
       "integrity": "sha512-uzHGgkKdeA9Kr57eyH1W5HGiNShP8fV1ETq04HDNM1Un6ShXbHhwi/H8LNV9L1fQXKjEw0q5FUkEVNuZ+yZdSw==",
+      "peer": true,
       "dependencies": {
         "cli-color": "^2.0.2",
         "d": "^1.0.1",
@@ -9998,6 +10078,7 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/cli-sprintf-format/-/cli-sprintf-format-1.1.1.tgz",
       "integrity": "sha512-BbEjY9BEdA6wagVwTqPvmAwGB24U93rQPBFZUT8lNCDxXzre5LFHQUTJc70czjgUomVg8u8R5kW8oY9DYRFNeg==",
+      "peer": true,
       "dependencies": {
         "cli-color": "^2.0.1",
         "es5-ext": "^0.10.53",
@@ -10012,6 +10093,7 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
       "integrity": "sha512-sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw==",
+      "peer": true,
       "engines": {
         "node": ">=4"
       }
@@ -10020,6 +10102,7 @@
       "version": "6.1.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-6.1.0.tgz",
       "integrity": "sha512-qe1jfm1Mg7Nq/NSh6XE24gPXROEVsWHxC1LIx//XNlD9iw7YZQGjZNjYN7xGaEG6iKdA8EtNFW6R0gjnVXp+wQ==",
+      "peer": true,
       "dependencies": {
         "has-flag": "^3.0.0"
       },
@@ -10061,6 +10144,7 @@
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/clone/-/clone-1.0.4.tgz",
       "integrity": "sha512-JQHZ2QMW6l3aH/j6xCqQThY/9OH4D/9ls34cgkUBiEeocRTU04tHfKPBsUK1PqZCUQM7GiA0IIXJSuXHI64Kbg==",
+      "peer": true,
       "engines": {
         "node": ">=0.8"
       }
@@ -10393,6 +10477,7 @@
       "version": "0.5.4",
       "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-0.5.4.tgz",
       "integrity": "sha512-FveZTNuGw04cxlAiWbzi6zTAL/lhehaWbTtgluJh4/E95DqMwTmha3KZN1aAWA8cFIhHzMZUvLevkw5Rqk+tSQ==",
+      "peer": true,
       "dependencies": {
         "safe-buffer": "5.2.1"
       },
@@ -10417,7 +10502,8 @@
           "type": "consulting",
           "url": "https://feross.org/support"
         }
-      ]
+      ],
+      "peer": true
     },
     "node_modules/conventional-changelog-angular": {
       "version": "5.0.13",
@@ -10789,6 +10875,7 @@
       "version": "4.7.1",
       "resolved": "https://registry.npmjs.org/cron-parser/-/cron-parser-4.7.1.tgz",
       "integrity": "sha512-WguFaoQ0hQ61SgsCZLHUcNbAvlK0lypKXu62ARguefYmjzaOXIVRNrAmyXzabTwUn4sQvQLkk6bjH+ipGfw8bA==",
+      "peer": true,
       "dependencies": {
         "luxon": "^3.2.1"
       },
@@ -10907,6 +10994,7 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/d/-/d-1.0.1.tgz",
       "integrity": "sha512-m62ShEObQ39CfralilEQRjH6oAMtNCV1xJyEx5LpRYUVN+EviphDgUc/F3hnYbADmkiNs67Y+3ylmlG7Lnu+FA==",
+      "peer": true,
       "dependencies": {
         "es5-ext": "^0.10.50",
         "type": "^1.0.1"
@@ -10915,7 +11003,8 @@
     "node_modules/d/node_modules/type": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/type/-/type-1.2.0.tgz",
-      "integrity": "sha512-+5nt5AAniqsCnu2cEQQdpzCAh33kVx8n0VoFidKpB1dVVLAN/F+bgVOqOJqOnEnrhp222clB5p3vUlD+1QAnfg=="
+      "integrity": "sha512-+5nt5AAniqsCnu2cEQQdpzCAh33kVx8n0VoFidKpB1dVVLAN/F+bgVOqOJqOnEnrhp222clB5p3vUlD+1QAnfg==",
+      "peer": true
     },
     "node_modules/daemonize2": {
       "version": "0.4.2",
@@ -11029,6 +11118,7 @@
       "version": "4.2.1",
       "resolved": "https://registry.npmjs.org/decompress/-/decompress-4.2.1.tgz",
       "integrity": "sha512-e48kc2IjU+2Zw8cTb6VZcJQ3lgVbS4uuB1TfCHbiZIP/haNXm+SVyhu+87jts5/3ROpd82GSVCoNs/z8l4ZOaQ==",
+      "peer": true,
       "dependencies": {
         "decompress-tar": "^4.0.0",
         "decompress-tarbz2": "^4.0.0",
@@ -11057,6 +11147,7 @@
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/decompress-tar/-/decompress-tar-4.1.1.tgz",
       "integrity": "sha512-JdJMaCrGpB5fESVyxwpCx4Jdj2AagLmv3y58Qy4GE6HMVjWz1FeVQk1Ct4Kye7PftcdOo/7U7UKzYBJgqnGeUQ==",
+      "peer": true,
       "dependencies": {
         "file-type": "^5.2.0",
         "is-stream": "^1.1.0",
@@ -11070,6 +11161,7 @@
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/bl/-/bl-1.2.3.tgz",
       "integrity": "sha512-pvcNpa0UU69UT341rO6AYy4FVAIkUHuZXRIWbq+zHnsVcRzDDjIAhGuuYoi0d//cwIwtt4pkpKycWEfjdV+vww==",
+      "peer": true,
       "dependencies": {
         "readable-stream": "^2.3.5",
         "safe-buffer": "^5.1.1"
@@ -11079,6 +11171,7 @@
       "version": "5.2.0",
       "resolved": "https://registry.npmjs.org/file-type/-/file-type-5.2.0.tgz",
       "integrity": "sha512-Iq1nJ6D2+yIO4c8HHg4fyVb8mAJieo1Oloy1mLLaB2PvezNedhBVm+QU7g0qM42aiMbRXTxKKwGD17rjKNJYVQ==",
+      "peer": true,
       "engines": {
         "node": ">=4"
       }
@@ -11087,6 +11180,7 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
       "integrity": "sha512-uQPm8kcs47jx38atAcWTVxyltQYoPT68y9aWYdV6yWXSyW8mzSat0TL6CiWdZeCdF3KrAvpVtnHbTv4RN+rqdQ==",
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -11095,6 +11189,7 @@
       "version": "2.3.7",
       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
       "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
+      "peer": true,
       "dependencies": {
         "core-util-is": "~1.0.0",
         "inherits": "~2.0.3",
@@ -11109,6 +11204,7 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
       "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+      "peer": true,
       "dependencies": {
         "safe-buffer": "~5.1.0"
       }
@@ -11117,6 +11213,7 @@
       "version": "1.6.2",
       "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-1.6.2.tgz",
       "integrity": "sha512-rzS0heiNf8Xn7/mpdSVVSMAWAoy9bfb1WOTYC78Z0UQKeKa/CWS8FOq0lKGNa8DWKAn9gxjCvMLYc5PGXYlK2A==",
+      "peer": true,
       "dependencies": {
         "bl": "^1.0.0",
         "buffer-alloc": "^1.2.0",
@@ -11134,6 +11231,7 @@
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/decompress-tarbz2/-/decompress-tarbz2-4.1.1.tgz",
       "integrity": "sha512-s88xLzf1r81ICXLAVQVzaN6ZmX4A6U4z2nMbOwobxkLoIIfjVMBg7TeguTUXkKeXni795B6y5rnvDw7rxhAq9A==",
+      "peer": true,
       "dependencies": {
         "decompress-tar": "^4.1.0",
         "file-type": "^6.1.0",
@@ -11149,6 +11247,7 @@
       "version": "6.2.0",
       "resolved": "https://registry.npmjs.org/file-type/-/file-type-6.2.0.tgz",
       "integrity": "sha512-YPcTBDV+2Tm0VqjybVd32MHdlEGAtuxS3VAYsumFokDSMG+ROT5wawGlnHDoz7bfMcMDt9hxuXvXwoKUx2fkOg==",
+      "peer": true,
       "engines": {
         "node": ">=4"
       }
@@ -11157,6 +11256,7 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
       "integrity": "sha512-uQPm8kcs47jx38atAcWTVxyltQYoPT68y9aWYdV6yWXSyW8mzSat0TL6CiWdZeCdF3KrAvpVtnHbTv4RN+rqdQ==",
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -11165,6 +11265,7 @@
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/decompress-targz/-/decompress-targz-4.1.1.tgz",
       "integrity": "sha512-4z81Znfr6chWnRDNfFNqLwPvm4db3WuZkqV+UgXQzSngG3CEKdBkw5jrv3axjjL96glyiiKjsxJG3X6WBZwX3w==",
+      "peer": true,
       "dependencies": {
         "decompress-tar": "^4.1.1",
         "file-type": "^5.2.0",
@@ -11178,6 +11279,7 @@
       "version": "5.2.0",
       "resolved": "https://registry.npmjs.org/file-type/-/file-type-5.2.0.tgz",
       "integrity": "sha512-Iq1nJ6D2+yIO4c8HHg4fyVb8mAJieo1Oloy1mLLaB2PvezNedhBVm+QU7g0qM42aiMbRXTxKKwGD17rjKNJYVQ==",
+      "peer": true,
       "engines": {
         "node": ">=4"
       }
@@ -11186,6 +11288,7 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
       "integrity": "sha512-uQPm8kcs47jx38atAcWTVxyltQYoPT68y9aWYdV6yWXSyW8mzSat0TL6CiWdZeCdF3KrAvpVtnHbTv4RN+rqdQ==",
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -11194,6 +11297,7 @@
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/decompress-unzip/-/decompress-unzip-4.0.1.tgz",
       "integrity": "sha512-1fqeluvxgnn86MOh66u8FjbtJpAFv5wgCT9Iw8rcBqQcCo5tO8eiJw7NNTrvt9n4CRBVq7CstiS922oPgyGLrw==",
+      "peer": true,
       "dependencies": {
         "file-type": "^3.8.0",
         "get-stream": "^2.2.0",
@@ -11208,6 +11312,7 @@
       "version": "3.9.0",
       "resolved": "https://registry.npmjs.org/file-type/-/file-type-3.9.0.tgz",
       "integrity": "sha512-RLoqTXE8/vPmMuTI88DAzhMYC99I8BWv7zYP4A1puo5HIjEJ5EX48ighy4ZyKMG9EDXxBgW6e++cn7d1xuFghA==",
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -11216,6 +11321,7 @@
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-2.3.1.tgz",
       "integrity": "sha512-AUGhbbemXxrZJRD5cDvKtQxLuYaIbNtDTK8YqupCI393Q2KSTreEsLUN3ZxAWFGiKTzL6nKuzfcIvieflUX9qA==",
+      "peer": true,
       "dependencies": {
         "object-assign": "^4.0.1",
         "pinkie-promise": "^2.0.0"
@@ -11228,6 +11334,7 @@
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
       "integrity": "sha512-udgsAY+fTnvv7kI7aaxbqwWNb0AHiB0qBO89PZKPkoTmGOgdbrHDKD+0B2X4uTfJ/FT1R09r9gTsjUjNJotuog==",
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -11236,6 +11343,7 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-1.3.0.tgz",
       "integrity": "sha512-2w31R7SJtieJJnQtGc7RVL2StM2vGYVfqUOvUDxH6bC6aJTxPxTF0GnIgCyu7tjockiUWAYQRbxa7vKn34s5sQ==",
+      "peer": true,
       "dependencies": {
         "pify": "^3.0.0"
       },
@@ -11247,6 +11355,7 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
       "integrity": "sha512-C3FsVNH1udSEX48gGX1xfvwTWfsYWj5U+8/uK15BGzIGrKoUpghX8hWZwa/OFnakBiiVNmBvemTJR5mcy7iPcg==",
+      "peer": true,
       "engines": {
         "node": ">=4"
       }
@@ -11255,6 +11364,7 @@
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
       "integrity": "sha512-udgsAY+fTnvv7kI7aaxbqwWNb0AHiB0qBO89PZKPkoTmGOgdbrHDKD+0B2X4uTfJ/FT1R09r9gTsjUjNJotuog==",
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -11296,6 +11406,7 @@
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/defaults/-/defaults-1.0.4.tgz",
       "integrity": "sha512-eFuaLoy/Rxalv2kr+lqMlUnrDWV+3j4pljOIJgLIhI058IQfWJ7vXhyEIHu+HtC738klGALYxOKDO0bQP3tg8A==",
+      "peer": true,
       "dependencies": {
         "clone": "^1.0.2"
       },
@@ -11311,6 +11422,7 @@
       "version": "0.7.11",
       "resolved": "https://registry.npmjs.org/deferred/-/deferred-0.7.11.tgz",
       "integrity": "sha512-8eluCl/Blx4YOGwMapBvXRKxHXhA8ejDXYzEaK8+/gtcm8hRMhSLmXSqDmNUKNc/C8HNSmuyyp/hflhqDAvK2A==",
+      "peer": true,
       "dependencies": {
         "d": "^1.0.1",
         "es5-ext": "^0.10.50",
@@ -11323,6 +11435,7 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/define-lazy-prop/-/define-lazy-prop-2.0.0.tgz",
       "integrity": "sha512-Ds09qNh8yw3khSjiJjiUInaGX9xlqZDY7JVryGxdxV7NPeuqQfplOpQ66yJFZut3jLa5zOwkXw1g9EI2uKh4Og==",
+      "peer": true,
       "engines": {
         "node": ">=8"
       }
@@ -11388,7 +11501,8 @@
     "node_modules/desm": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/desm/-/desm-1.3.0.tgz",
-      "integrity": "sha512-RvlHN2gfYA0BpCfjpWzCdQeR6p5U+84f5DzcirLow86UA/OcpwuOqXRC4Oz0bG9rzcJPVtMT6ZgNtjp4qh+uqA=="
+      "integrity": "sha512-RvlHN2gfYA0BpCfjpWzCdQeR6p5U+84f5DzcirLow86UA/OcpwuOqXRC4Oz0bG9rzcJPVtMT6ZgNtjp4qh+uqA==",
+      "peer": true
     },
     "node_modules/detect-indent": {
       "version": "6.1.0",
@@ -11622,6 +11736,7 @@
       "version": "0.2.2",
       "resolved": "https://registry.npmjs.org/duration/-/duration-0.2.2.tgz",
       "integrity": "sha512-06kgtea+bGreF5eKYgI/36A6pLXggY7oR4p1pq4SmdFBn1ReOL5D8RhG64VrqfTTKNucqqtBAwEj8aB88mcqrg==",
+      "peer": true,
       "dependencies": {
         "d": "1",
         "es5-ext": "~0.10.46"
@@ -11630,7 +11745,8 @@
     "node_modules/eastasianwidth": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/eastasianwidth/-/eastasianwidth-0.2.0.tgz",
-      "integrity": "sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA=="
+      "integrity": "sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==",
+      "peer": true
     },
     "node_modules/ecc-jsbn": {
       "version": "0.1.2",
@@ -11947,6 +12063,7 @@
       "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.62.tgz",
       "integrity": "sha512-BHLqn0klhEpnOKSrzn/Xsz2UIW8j+cGmo9JLzr8BiUapV8hPL9+FliFqjwr9ngW7jWdnxv6eO+/LqyhJVqgrjA==",
       "hasInstallScript": true,
+      "peer": true,
       "dependencies": {
         "es6-iterator": "^2.0.3",
         "es6-symbol": "^3.1.3",
@@ -11960,6 +12077,7 @@
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/es6-iterator/-/es6-iterator-2.0.3.tgz",
       "integrity": "sha512-zw4SRzoUkd+cl+ZoE15A9o1oQd920Bb0iOJMQkQhl3jNc03YqVjAhG7scf9C5KWRU/R13Orf588uCC6525o02g==",
+      "peer": true,
       "dependencies": {
         "d": "1",
         "es5-ext": "^0.10.35",
@@ -11985,6 +12103,7 @@
       "version": "0.1.6",
       "resolved": "https://registry.npmjs.org/es6-set/-/es6-set-0.1.6.tgz",
       "integrity": "sha512-TE3LgGLDIBX332jq3ypv6bcOpkLO0AslAQo7p2VqX/1N46YNsvIWgvjojjSEnWEGWMhr1qUbYeTSir5J6mFHOw==",
+      "peer": true,
       "dependencies": {
         "d": "^1.0.1",
         "es5-ext": "^0.10.62",
@@ -12001,6 +12120,7 @@
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-3.1.3.tgz",
       "integrity": "sha512-NJ6Yn3FuDinBaBRWl/q5X/s4koRHBrgKAu+yGI6JCBeiu3qrcbJhwT2GeR/EXVfylRk8dpQVJoLEFhK+Mu31NA==",
+      "peer": true,
       "dependencies": {
         "d": "^1.0.1",
         "ext": "^1.1.2"
@@ -12010,6 +12130,7 @@
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/es6-weak-map/-/es6-weak-map-2.0.3.tgz",
       "integrity": "sha512-p5um32HOTO1kP+w7PRnB+5lQ43Z6muuMuIMffvDN8ZB4GcnjLBV6zGStpbASIMk4DCAvEaamhe2zhyCb/QXXsA==",
+      "peer": true,
       "dependencies": {
         "d": "1",
         "es5-ext": "^0.10.46",
@@ -12474,6 +12595,7 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/esniff/-/esniff-1.1.0.tgz",
       "integrity": "sha512-vmHXOeOt7FJLsqofvFk4WB3ejvcHizCd8toXXwADmYfd02p2QwHRgkUbhYDX54y08nqk818CUTWipgZGlyN07g==",
+      "peer": true,
       "dependencies": {
         "d": "1",
         "es5-ext": "^0.10.12"
@@ -12574,6 +12696,7 @@
       "version": "0.3.5",
       "resolved": "https://registry.npmjs.org/event-emitter/-/event-emitter-0.3.5.tgz",
       "integrity": "sha512-D9rRn9y7kLPnJ+hMq7S/nhvoKwwvVJahBi2BPmx3bvbsEdK3W9ii8cBSGjP+72/LnM4n6fo3+dkCX5FeTQruXA==",
+      "peer": true,
       "dependencies": {
         "d": "1",
         "es5-ext": "~0.10.14"
@@ -12711,6 +12834,7 @@
       "version": "1.7.0",
       "resolved": "https://registry.npmjs.org/ext/-/ext-1.7.0.tgz",
       "integrity": "sha512-6hxeJYaL110a9b5TEJSj0gojyHQAmA2ch5Os+ySCiA1QGdS697XWY1pzsrSjqA9LDEEgdB/KypIlR59RcLuHYw==",
+      "peer": true,
       "dependencies": {
         "type": "^2.7.2"
       }
@@ -12719,6 +12843,7 @@
       "version": "2.2.2",
       "resolved": "https://registry.npmjs.org/ext-list/-/ext-list-2.2.2.tgz",
       "integrity": "sha512-u+SQgsubraE6zItfVA0tBuCBhfU9ogSRnsvygI7wht9TS510oLkBRXBsqopeUG/GBOIQyKZO9wjTqIu/sf5zFA==",
+      "peer": true,
       "dependencies": {
         "mime-db": "^1.28.0"
       },
@@ -12730,6 +12855,7 @@
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/ext-name/-/ext-name-5.0.0.tgz",
       "integrity": "sha512-yblEwXAbGv1VQDmow7s38W77hzAgJAO50ztBLMcUyUBfxv1HC+LGwtiEN+Co6LtlqT/5uwVOxsD4TNIilWhwdQ==",
+      "peer": true,
       "dependencies": {
         "ext-list": "^2.0.0",
         "sort-keys-length": "^1.0.0"
@@ -12972,6 +13098,7 @@
           "url": "https://paypal.me/jimmywarting"
         }
       ],
+      "peer": true,
       "dependencies": {
         "node-domexception": "^1.0.0",
         "web-streams-polyfill": "^3.0.3"
@@ -13019,6 +13146,7 @@
       "version": "16.5.4",
       "resolved": "https://registry.npmjs.org/file-type/-/file-type-16.5.4.tgz",
       "integrity": "sha512-/yFHK0aGjFEgDJjEKP0pWCplsPFPhwyfwevf/pVxiN0tmE4L9LmwWxWukdJSHdoCli4VgQLehjJtwQBnqmsKcw==",
+      "peer": true,
       "dependencies": {
         "readable-web-to-node-stream": "^3.0.0",
         "strtok3": "^6.2.4",
@@ -13048,6 +13176,7 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/filename-reserved-regex/-/filename-reserved-regex-2.0.0.tgz",
       "integrity": "sha512-lc1bnsSr4L4Bdif8Xb/qrtokGbq5zlsms/CYH8PP+WtCkGNF65DPiQY8vG3SakEdRn8Dlnm+gW/qWKKjS5sZzQ==",
+      "peer": true,
       "engines": {
         "node": ">=4"
       }
@@ -13056,6 +13185,7 @@
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/filenamify/-/filenamify-4.3.0.tgz",
       "integrity": "sha512-hcFKyUG57yWGAzu1CMt/dPzYZuv+jAJUT85bL8mrXvNe6hWj6yEHEc4EdcgiA6Z3oi1/9wXJdZPXF2dZNgwgOg==",
+      "peer": true,
       "dependencies": {
         "filename-reserved-regex": "^2.0.0",
         "strip-outer": "^1.0.1",
@@ -13209,6 +13339,7 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/find-requires/-/find-requires-1.0.0.tgz",
       "integrity": "sha512-UME7hNwBfzeISSFQcBEDemEEskpOjI/shPrpJM5PI4DSdn6hX0dmz+2dL70blZER2z8tSnTRL+2rfzlYgtbBoQ==",
+      "peer": true,
       "dependencies": {
         "es5-ext": "^0.10.49",
         "esniff": "^1.1.0"
@@ -13357,6 +13488,7 @@
       "version": "4.0.10",
       "resolved": "https://registry.npmjs.org/formdata-polyfill/-/formdata-polyfill-4.0.10.tgz",
       "integrity": "sha512-buewHzMvYL29jdeQTVILecSaZKnt/RJWjoZCF5OW60Z67/GmSLBkOFM7qh1PI3zFNtJbaZL5eQu1vLfazOwj4g==",
+      "peer": true,
       "dependencies": {
         "fetch-blob": "^3.1.2"
       },
@@ -13477,6 +13609,7 @@
       "version": "0.3.9",
       "resolved": "https://registry.npmjs.org/fs2/-/fs2-0.3.9.tgz",
       "integrity": "sha512-WsOqncODWRlkjwll+73bAxVW3JPChDgaPX3DT4iTTm73UmG4VgALa7LaFblP232/DN60itkOrPZ8kaP1feksGQ==",
+      "peer": true,
       "dependencies": {
         "d": "^1.0.1",
         "deferred": "^0.7.11",
@@ -14335,6 +14468,7 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/http2-wrapper/-/http2-wrapper-1.0.3.tgz",
       "integrity": "sha512-V+23sDMr12Wnz7iTcDeJr3O6AIxlnvT/bmaAAAP/Xda35C90p9599p0F1eHR/N1KILWSoWVAiOMFjBBXaXSMxg==",
+      "peer": true,
       "dependencies": {
         "quick-lru": "^5.1.1",
         "resolve-alpn": "^1.0.0"
@@ -14347,6 +14481,7 @@
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/quick-lru/-/quick-lru-5.1.1.tgz",
       "integrity": "sha512-WuyALRjWPDGtt/wzJiadO5AXY+8hZ80hVpe6MyivgraREW751X3SbhRvG3eLKOYN+8VEvqLcf3wdnt44Z4S4SA==",
+      "peer": true,
       "engines": {
         "node": ">=10"
       },
@@ -14490,7 +14625,8 @@
     "node_modules/immediate": {
       "version": "3.0.6",
       "resolved": "https://registry.npmjs.org/immediate/-/immediate-3.0.6.tgz",
-      "integrity": "sha512-XXOFtyqDjNDAQxVfYxuF7g9Il/IbWmmlQg2MYKOH8ExIT1qg6xc4zyS3HaEEATgs1btfzxq15ciUiY7gjSXRGQ=="
+      "integrity": "sha512-XXOFtyqDjNDAQxVfYxuF7g9Il/IbWmmlQg2MYKOH8ExIT1qg6xc4zyS3HaEEATgs1btfzxq15ciUiY7gjSXRGQ==",
+      "peer": true
     },
     "node_modules/import-cwd": {
       "version": "3.0.0",
@@ -14899,6 +15035,7 @@
       "version": "2.2.1",
       "resolved": "https://registry.npmjs.org/is-docker/-/is-docker-2.2.1.tgz",
       "integrity": "sha512-F+i2BKsFrH66iaUFc0woD8sLy8getkwTwtOBjvs56Cx4CgJDeKQeqfz8wAYiSb8JOprWhHH5p77PbmYCvvUuXQ==",
+      "peer": true,
       "bin": {
         "is-docker": "cli.js"
       },
@@ -15000,6 +15137,7 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/is-interactive/-/is-interactive-1.0.0.tgz",
       "integrity": "sha512-2HvIEKRoqS62guEC+qBjpvRubdX910WCMuJTZ+I9yvqKU2/12eSL549HMwtabb4oupdj2sMP50k+XJfB/8JE6w==",
+      "peer": true,
       "engines": {
         "node": ">=8"
       }
@@ -15019,7 +15157,8 @@
     "node_modules/is-natural-number": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/is-natural-number/-/is-natural-number-4.0.1.tgz",
-      "integrity": "sha512-Y4LTamMe0DDQIIAlaer9eKebAlDSV6huy+TWhJVPlzZh2o4tRP5SQWFlLn5N0To4mDD22/qdOq+veo1cSISLgQ=="
+      "integrity": "sha512-Y4LTamMe0DDQIIAlaer9eKebAlDSV6huy+TWhJVPlzZh2o4tRP5SQWFlLn5N0To4mDD22/qdOq+veo1cSISLgQ==",
+      "peer": true
     },
     "node_modules/is-negative-zero": {
       "version": "2.0.2",
@@ -15096,7 +15235,8 @@
     "node_modules/is-promise": {
       "version": "2.2.2",
       "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-2.2.2.tgz",
-      "integrity": "sha512-+lP4/6lKUBfQjZ2pdxThZvLUAafmZb8OAxFb8XXtiQmS35INgr85hdOGoEs124ez1FCnZJt6jau/T+alh58QFQ=="
+      "integrity": "sha512-+lP4/6lKUBfQjZ2pdxThZvLUAafmZb8OAxFb8XXtiQmS35INgr85hdOGoEs124ez1FCnZJt6jau/T+alh58QFQ==",
+      "peer": true
     },
     "node_modules/is-regex": {
       "version": "1.1.4",
@@ -15405,6 +15545,7 @@
       "version": "0.0.6",
       "resolved": "https://registry.npmjs.org/java-invoke-local/-/java-invoke-local-0.0.6.tgz",
       "integrity": "sha512-gZmQKe1QrfkkMjCn8Qv9cpyJFyogTYqkP5WCobX5RNaHsJzIV/6NvAnlnouOcwKr29QrxLGDGcqYuJ+ae98s1A==",
+      "peer": true,
       "bin": {
         "java-invoke-local": "lib/cli.js"
       }
@@ -16081,6 +16222,7 @@
       "version": "4.11.2",
       "resolved": "https://registry.npmjs.org/jose/-/jose-4.11.2.tgz",
       "integrity": "sha512-njj0VL2TsIxCtgzhO+9RRobBvws4oYyCM8TpvoUQwl/MbIM3NFJRR9+e6x0sS5xXaP1t6OCBkaBME98OV9zU5A==",
+      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/panva"
       }
@@ -16093,6 +16235,7 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/js-string-escape/-/js-string-escape-1.0.1.tgz",
       "integrity": "sha512-Smw4xcfIQ5LVjAOuJCvN/zIodzA/BBSsluuoSykP+lUvScIi4U6RJLfwHet5cxFnCswUjISV8oAXaqaJDY3chg==",
+      "peer": true,
       "engines": {
         "node": ">= 0.8"
       }
@@ -16311,6 +16454,7 @@
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/jsonpath-plus/-/jsonpath-plus-7.2.0.tgz",
       "integrity": "sha512-zBfiUPM5nD0YZSBT/o/fbCUlCcepMIdP0CJZxM1+KgA4f2T206f6VAg9e7mX35+KlMaIc5qXW34f3BnwJ3w+RA==",
+      "peer": true,
       "engines": {
         "node": ">=12.0.0"
       }
@@ -16330,6 +16474,7 @@
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/jsonschema/-/jsonschema-1.4.1.tgz",
       "integrity": "sha512-S6cATIPVv1z0IlxdN+zUk5EPjkGCdnhN4wVSBlvoUO1tOLJootbo9CquNJmbIh4yikWHiUedhRYrNPn1arpEmQ==",
+      "peer": true,
       "engines": {
         "node": "*"
       }
@@ -16366,6 +16511,7 @@
       "version": "3.10.1",
       "resolved": "https://registry.npmjs.org/jszip/-/jszip-3.10.1.tgz",
       "integrity": "sha512-xXDvecyTpGLrqFrvkrUSoxxfJI5AH7U8zxxtVclpsUtMCq4JQ290LY8AW5c7Ggnr/Y/oK+bQMbqK2qmtk3pN4g==",
+      "peer": true,
       "dependencies": {
         "lie": "~3.3.0",
         "pako": "~1.0.2",
@@ -16377,6 +16523,7 @@
       "version": "2.3.7",
       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
       "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
+      "peer": true,
       "dependencies": {
         "core-util-is": "~1.0.0",
         "inherits": "~2.0.3",
@@ -16391,6 +16538,7 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
       "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+      "peer": true,
       "dependencies": {
         "safe-buffer": "~5.1.0"
       }
@@ -16666,6 +16814,7 @@
       "version": "3.3.0",
       "resolved": "https://registry.npmjs.org/lie/-/lie-3.3.0.tgz",
       "integrity": "sha512-UaiMJzeWRlEujzAuw5LokY1L5ecNQYZKfmyZ9L7wDHb/p5etKaxXhohBcrw0EYby+G/NA52vRSN4N39dxHAIwQ==",
+      "peer": true,
       "dependencies": {
         "immediate": "~3.0.5"
       }
@@ -16945,6 +17094,7 @@
       "version": "6.3.1",
       "resolved": "https://registry.npmjs.org/log/-/log-6.3.1.tgz",
       "integrity": "sha512-McG47rJEWOkXTDioZzQNydAVvZNeEkSyLJ1VWkFwfW+o1knW+QSi8D1KjPn/TnctV+q99lkvJNe1f0E1IjfY2A==",
+      "peer": true,
       "dependencies": {
         "d": "^1.0.1",
         "duration": "^0.2.2",
@@ -16959,6 +17109,7 @@
       "version": "8.0.3",
       "resolved": "https://registry.npmjs.org/log-node/-/log-node-8.0.3.tgz",
       "integrity": "sha512-1UBwzgYiCIDFs8A0rM2QdBFo8Wd8UQ0HrSTu/MNI+/2zN3NoHRj2fhplurAyuxTYUXu3Oohugq1jAn5s05u1MQ==",
+      "peer": true,
       "dependencies": {
         "ansi-regex": "^5.0.1",
         "cli-color": "^2.0.1",
@@ -16980,6 +17131,7 @@
       "version": "8.1.1",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz",
       "integrity": "sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==",
+      "peer": true,
       "dependencies": {
         "has-flag": "^4.0.0"
       },
@@ -17076,7 +17228,8 @@
     "node_modules/long-timeout": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/long-timeout/-/long-timeout-0.1.1.tgz",
-      "integrity": "sha512-BFRuQUqc7x2NWxfJBCyUrN8iYUYznzL9JROmRz1gZ6KlOIgmoD+njPVbb+VNn2nGMKggMsK79iUNErillsrx7w=="
+      "integrity": "sha512-BFRuQUqc7x2NWxfJBCyUrN8iYUYznzL9JROmRz1gZ6KlOIgmoD+njPVbb+VNn2nGMKggMsK79iUNErillsrx7w==",
+      "peer": true
     },
     "node_modules/loupe": {
       "version": "2.3.4",
@@ -17106,6 +17259,7 @@
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/lru-queue/-/lru-queue-0.1.0.tgz",
       "integrity": "sha512-BpdYkt9EvGl8OfWHDQPISVpcl5xZthb+XPsbELj5AQXxIC8IriDZIQYjBJPEm5rS420sjZ0TLEzRcq5KdBhYrQ==",
+      "peer": true,
       "dependencies": {
         "es5-ext": "~0.10.2"
       }
@@ -17114,6 +17268,7 @@
       "version": "3.2.1",
       "resolved": "https://registry.npmjs.org/luxon/-/luxon-3.2.1.tgz",
       "integrity": "sha512-QrwPArQCNLAKGO/C+ZIilgIuDnEnKx5QYODdDtbFaxzsbZcc/a7WFq7MhsVYgRlwawLtvOUESTlfJ+hc/USqPg==",
+      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -17239,6 +17394,7 @@
       "version": "0.4.15",
       "resolved": "https://registry.npmjs.org/memoizee/-/memoizee-0.4.15.tgz",
       "integrity": "sha512-UBWmJpLZd5STPm7PMUlOw/TSy972M+z8gcyQ5veOnSDRREz/0bmpyTfKt3/51DhEBqCZQn1udM/5flcSPYhkdQ==",
+      "peer": true,
       "dependencies": {
         "d": "^1.0.1",
         "es5-ext": "^0.10.53",
@@ -18086,6 +18242,7 @@
       "version": "4.3.2",
       "resolved": "https://registry.npmjs.org/ncjsm/-/ncjsm-4.3.2.tgz",
       "integrity": "sha512-6d1VWA7FY31CpI4Ki97Fpm36jfURkVbpktizp8aoVViTZRQgr/0ddmlKerALSSlzfwQRBeSq1qwwVcBJK4Sk7Q==",
+      "peer": true,
       "dependencies": {
         "builtin-modules": "^3.3.0",
         "deferred": "^0.7.11",
@@ -18138,7 +18295,8 @@
     "node_modules/next-tick": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/next-tick/-/next-tick-1.1.0.tgz",
-      "integrity": "sha512-CXdUiJembsNjuToQvxayPZF9Vqht7hewsvy2sOWafLvi2awflj9mOC6bHIg50orX8IJvWKY9wYQ/zB2kogPslQ=="
+      "integrity": "sha512-CXdUiJembsNjuToQvxayPZF9Vqht7hewsvy2sOWafLvi2awflj9mOC6bHIg50orX8IJvWKY9wYQ/zB2kogPslQ==",
+      "peer": true
     },
     "node_modules/nice-try": {
       "version": "1.0.5",
@@ -18178,6 +18336,7 @@
           "url": "https://paypal.me/jimmywarting"
         }
       ],
+      "peer": true,
       "engines": {
         "node": ">=10.5.0"
       }
@@ -18357,6 +18516,7 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/node-schedule/-/node-schedule-2.1.1.tgz",
       "integrity": "sha512-OXdegQq03OmXEjt2hZP33W2YPs/E5BcFQks46+G2gAxs4gHOIVD1u7EqlYLYSKsaIpyKCK9Gbk0ta1/gjRSMRQ==",
+      "peer": true,
       "dependencies": {
         "cron-parser": "^4.2.0",
         "long-timeout": "0.1.1",
@@ -19020,6 +19180,7 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/object.hasown/-/object.hasown-1.1.2.tgz",
       "integrity": "sha512-B5UIT3J1W+WuWIU55h0mjlwaqxiE5vYENJXIXZ4VFe05pNYrkKuK0U/6aFcb0pKywYJh7IhfoqUfKVmrJJHZHw==",
+      "peer": true,
       "dependencies": {
         "define-properties": "^1.1.4",
         "es-abstract": "^1.20.4"
@@ -19099,6 +19260,7 @@
       "version": "8.4.0",
       "resolved": "https://registry.npmjs.org/open/-/open-8.4.0.tgz",
       "integrity": "sha512-XgFPPM+B28FtCCgSb9I+s9szOC1vZRSwgWsRUA5ylIxRTgKozqjOCrVOqGsYABPYK5qnfqClxZTFBa8PKt2v6Q==",
+      "peer": true,
       "dependencies": {
         "define-lazy-prop": "^2.0.0",
         "is-docker": "^2.1.1",
@@ -19115,6 +19277,7 @@
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-2.2.0.tgz",
       "integrity": "sha512-fKzAra0rGJUUBwGBgNkHZuToZcn+TtXHpeCgmkMJMMYx1sQDYaCSyjJBSCa2nH1DGm7s3n1oBnohoVTBaN7Lww==",
+      "peer": true,
       "dependencies": {
         "is-docker": "^2.0.0"
       },
@@ -19149,6 +19312,7 @@
       "version": "5.4.1",
       "resolved": "https://registry.npmjs.org/ora/-/ora-5.4.1.tgz",
       "integrity": "sha512-5b6Y85tPxZZ7QytO+BQzysW31HJku27cRIlkbAXaNx+BdcVi+LlRFmVXzeF6a7JCwJpyw5c4b+YSVImQIrBpuQ==",
+      "peer": true,
       "dependencies": {
         "bl": "^4.1.0",
         "chalk": "^4.1.0",
@@ -19197,6 +19361,7 @@
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/p-event/-/p-event-4.2.0.tgz",
       "integrity": "sha512-KXatOjCRXXkSePPb1Nbi0p0m+gQAwdlbhi4wQKJPI1HsMQS9g+Sqp2o+QHziPr7eYJyOZet836KoHEVM1mwOrQ==",
+      "peer": true,
       "dependencies": {
         "p-timeout": "^3.1.0"
       },
@@ -19257,6 +19422,7 @@
       "version": "7.1.1",
       "resolved": "https://registry.npmjs.org/p-memoize/-/p-memoize-7.1.1.tgz",
       "integrity": "sha512-DZ/bONJILHkQ721hSr/E9wMz5Am/OTJ9P6LhLFo2Tu+jL8044tgc9LwHO8g4PiaYePnlVVRAJcKmgy8J9MVFrA==",
+      "peer": true,
       "dependencies": {
         "mimic-fn": "^4.0.0",
         "type-fest": "^3.0.0"
@@ -19272,6 +19438,7 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-4.0.0.tgz",
       "integrity": "sha512-vqiC06CuhBTUdZH+RYl8sFrL096vA45Ok5ISO6sE/Mr1jRbGH4Csnhi8f3wKVl7x8mO4Au7Ir9D3Oyv1VYMFJw==",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -19283,6 +19450,7 @@
       "version": "3.5.4",
       "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-3.5.4.tgz",
       "integrity": "sha512-/Je22Er4LPoln256pcLzj73MUmPrTWg8u4WB1RlxaDl0idJOfD1r259VtKOinp4xLJqJ9zYVMuWOun6Ssp7boA==",
+      "peer": true,
       "engines": {
         "node": ">=14.16"
       },
@@ -20333,6 +20501,7 @@
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/peek-readable/-/peek-readable-4.1.0.tgz",
       "integrity": "sha512-ZI3LnwUv5nOGbQzD9c2iDG6toheuXSZP5esSHBjopsXH4dg19soufvpUGA3uohi5anFtGb2lhAVdHzH6R/Evvg==",
+      "peer": true,
       "engines": {
         "node": ">=8"
       },
@@ -20503,6 +20672,7 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/process-utils/-/process-utils-4.0.0.tgz",
       "integrity": "sha512-fMyMQbKCxX51YxR7YGCzPjLsU3yDzXFkP4oi1/Mt5Ixnk7GO/7uUTj8mrCHUwuvozWzI+V7QSJR9cZYnwNOZPg==",
+      "peer": true,
       "dependencies": {
         "ext": "^1.4.0",
         "fs2": "^0.3.9",
@@ -21077,6 +21247,7 @@
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/readable-web-to-node-stream/-/readable-web-to-node-stream-3.0.2.tgz",
       "integrity": "sha512-ePeK6cc1EcKLEhJFt/AebMCLL+GgSKhuygrZ/GLaKZYEecIgIECf4UaUuaByiGtzckwR4ain9VzUh95T1exYGw==",
+      "peer": true,
       "dependencies": {
         "readable-stream": "^3.6.0"
       },
@@ -21591,7 +21762,8 @@
     "node_modules/resolve-alpn": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/resolve-alpn/-/resolve-alpn-1.2.1.tgz",
-      "integrity": "sha512-0a1F4l73/ZFZOakJnQ3FvkJ2+gSTQWz/r2KE5OdDY0TxPm5h4GkqkWWfM47T7HsbnOtcJVEF4epCVy6u7Q3K+g=="
+      "integrity": "sha512-0a1F4l73/ZFZOakJnQ3FvkJ2+gSTQWz/r2KE5OdDY0TxPm5h4GkqkWWfM47T7HsbnOtcJVEF4epCVy6u7Q3K+g==",
+      "peer": true
     },
     "node_modules/resolve-cwd": {
       "version": "3.0.0",
@@ -21863,6 +22035,7 @@
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/seek-bzip/-/seek-bzip-1.0.6.tgz",
       "integrity": "sha512-e1QtP3YL5tWww8uKaOCQ18UxIT2laNBXHjV/S2WYCiK4udiv8lkG89KRIoCjUagnAmCBurjF4zEVX2ByBbnCjQ==",
+      "peer": true,
       "dependencies": {
         "commander": "^2.8.1"
       },
@@ -21874,7 +22047,8 @@
     "node_modules/seek-bzip/node_modules/commander": {
       "version": "2.20.3",
       "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
-      "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ=="
+      "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
+      "peer": true
     },
     "node_modules/semver": {
       "version": "7.3.7",
@@ -22032,6 +22206,7 @@
       "version": "12.0.4",
       "resolved": "https://registry.npmjs.org/serverless-offline/-/serverless-offline-12.0.4.tgz",
       "integrity": "sha512-G256wDHI12vE0CJ0uTJMBlfnaN7o7td4GgClvQtuedt/n7vKoUfN0och+LybD6YVGsR5h1xpYjPPPLy2QFqWaA==",
+      "peer": true,
       "dependencies": {
         "@aws-sdk/client-lambda": "^3.241.0",
         "@hapi/boom": "^10.0.0",
@@ -22070,12 +22245,14 @@
     "node_modules/serverless-offline/node_modules/@types/retry": {
       "version": "0.12.1",
       "resolved": "https://registry.npmjs.org/@types/retry/-/retry-0.12.1.tgz",
-      "integrity": "sha512-xoDlM2S4ortawSWORYqsdU+2rxdh4LRW9ytc3zmT37RIKQh6IHyKwwtKhKis9ah8ol07DCkZxPt8BBvPjC6v4g=="
+      "integrity": "sha512-xoDlM2S4ortawSWORYqsdU+2rxdh4LRW9ytc3zmT37RIKQh6IHyKwwtKhKis9ah8ol07DCkZxPt8BBvPjC6v4g==",
+      "peer": true
     },
     "node_modules/serverless-offline/node_modules/ansi-regex": {
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.0.1.tgz",
       "integrity": "sha512-n5M855fKb2SsfMIiFFoVrABHJC8QtHwVx+mHWP3QcEqBHYienj5dHSgjbxtC0WEZXYt4wcD6zrQElDPhFuZgfA==",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -22087,6 +22264,7 @@
       "version": "6.2.1",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.1.tgz",
       "integrity": "sha512-bN798gFfQX+viw3R7yrGWRqnrN2oRkEkUjjl4JNn4E8GxxbjtG3FbrEIIY3l8/hrwUwIeCZvi4QuOTP4MErVug==",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -22098,6 +22276,7 @@
       "version": "7.0.1",
       "resolved": "https://registry.npmjs.org/boxen/-/boxen-7.0.1.tgz",
       "integrity": "sha512-8k2eH6SRAK00NDl1iX5q17RJ8rfl53TajdYxE3ssMLehbg487dEVgsad4pIsZb/QqBgYWIl6JOauMTLGX2Kpkw==",
+      "peer": true,
       "dependencies": {
         "ansi-align": "^3.0.1",
         "camelcase": "^7.0.0",
@@ -22119,6 +22298,7 @@
       "version": "7.0.1",
       "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-7.0.1.tgz",
       "integrity": "sha512-xlx1yCK2Oc1APsPXDL2LdlNP6+uu8OCDdhOBSVT279M/S+y75O30C2VuD8T2ogdePBBl7PfPF4504tnLgX3zfw==",
+      "peer": true,
       "engines": {
         "node": ">=14.16"
       },
@@ -22130,6 +22310,7 @@
       "version": "5.2.0",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.2.0.tgz",
       "integrity": "sha512-ree3Gqw/nazQAPuJJEy+avdl7QfZMcUvmHIKgEZkGL+xOBzRvup5Hxo6LHuMceSxOabuJLJm5Yp/92R9eMmMvA==",
+      "peer": true,
       "engines": {
         "node": "^12.17.0 || ^14.13 || >=16.0.0"
       },
@@ -22141,6 +22322,7 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/cli-boxes/-/cli-boxes-3.0.0.tgz",
       "integrity": "sha512-/lzGpEWL/8PfI0BmBOPRwp0c/wFNX1RdUML3jK/RcSBA9T8mZDdQpqYBKtCFTOfQbwPqWEOpjqW+Fnayc0969g==",
+      "peer": true,
       "engines": {
         "node": ">=10"
       },
@@ -22152,6 +22334,7 @@
       "version": "7.0.3",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
       "integrity": "sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==",
+      "peer": true,
       "dependencies": {
         "path-key": "^3.1.0",
         "shebang-command": "^2.0.0",
@@ -22165,6 +22348,7 @@
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-4.0.1.tgz",
       "integrity": "sha512-0R9ikRb668HB7QDxT1vkpuUBtqc53YyAwMwGeUFKRojY/NWKvdZ+9UYtRfGmhqNbRkTSVpMbmyhXipFFv2cb/A==",
+      "peer": true,
       "engines": {
         "node": ">= 12"
       }
@@ -22172,12 +22356,14 @@
     "node_modules/serverless-offline/node_modules/emoji-regex": {
       "version": "9.2.2",
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-9.2.2.tgz",
-      "integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg=="
+      "integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==",
+      "peer": true
     },
     "node_modules/serverless-offline/node_modules/execa": {
       "version": "6.1.0",
       "resolved": "https://registry.npmjs.org/execa/-/execa-6.1.0.tgz",
       "integrity": "sha512-QVWlX2e50heYJcCPG0iWtf8r0xjEYfz/OYLGDYH+IyjWezzPNxz63qNFOu0l4YftGWuizFVZHHs8PrLU5p2IDA==",
+      "peer": true,
       "dependencies": {
         "cross-spawn": "^7.0.3",
         "get-stream": "^6.0.1",
@@ -22200,6 +22386,7 @@
       "version": "11.1.0",
       "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.1.0.tgz",
       "integrity": "sha512-0rcTq621PD5jM/e0a3EJoGC/1TC5ZBCERW82LQuwfGnCa1V8w7dpYH1yNu+SLb6E5dkeCBzKEyLGlFrnr+dUyw==",
+      "peer": true,
       "dependencies": {
         "graceful-fs": "^4.2.0",
         "jsonfile": "^6.0.1",
@@ -22213,6 +22400,7 @@
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-3.0.1.tgz",
       "integrity": "sha512-rQLskxnM/5OCldHo+wNXbpVgDn5A17CUoKX+7Sokwaknlq7CdSnphy0W39GU8dw59XiCXmFXDg4fRuckQRKewQ==",
+      "peer": true,
       "engines": {
         "node": ">=12.20.0"
       }
@@ -22221,6 +22409,7 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-3.0.0.tgz",
       "integrity": "sha512-LnQR4bZ9IADDRSkvpqMGvt/tEJWclzklNgSw48V5EAaAeDd6qGvN8ei6k5p0tvxSR171VmGyHuTiAOfxAbr8kA==",
+      "peer": true,
       "engines": {
         "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
       },
@@ -22232,6 +22421,7 @@
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-2.2.0.tgz",
       "integrity": "sha512-fKzAra0rGJUUBwGBgNkHZuToZcn+TtXHpeCgmkMJMMYx1sQDYaCSyjJBSCa2nH1DGm7s3n1oBnohoVTBaN7Lww==",
+      "peer": true,
       "dependencies": {
         "is-docker": "^2.0.0"
       },
@@ -22243,6 +22433,7 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-4.0.0.tgz",
       "integrity": "sha512-vqiC06CuhBTUdZH+RYl8sFrL096vA45Ok5ISO6sE/Mr1jRbGH4Csnhi8f3wKVl7x8mO4Au7Ir9D3Oyv1VYMFJw==",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -22254,6 +22445,7 @@
       "version": "3.3.0",
       "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-3.3.0.tgz",
       "integrity": "sha512-BKwRP/O0UvoMKp7GNdwPlObhYGB5DQqwhEDQlNKuoqwVYSxkSZCSbHjnFFmUEtwSKRPU4kNK8PbDYYitwaE3QA==",
+      "peer": true,
       "dependencies": {
         "data-uri-to-buffer": "^4.0.0",
         "fetch-blob": "^3.1.4",
@@ -22271,6 +22463,7 @@
       "version": "5.1.0",
       "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-5.1.0.tgz",
       "integrity": "sha512-sJOdmRGrY2sjNTRMbSvluQqg+8X7ZK61yvzBEIDhz4f8z1TZFYABsqjjCBd/0PUNE9M6QDgHJXQkGUEm7Q+l9Q==",
+      "peer": true,
       "dependencies": {
         "path-key": "^4.0.0"
       },
@@ -22285,6 +22478,7 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/path-key/-/path-key-4.0.0.tgz",
       "integrity": "sha512-haREypq7xkM7ErfgIyA0z+Bj4AGKlMSdlQE2jvJo6huWD1EdkKYV+G/T4nq0YEF2vgTT8kqMFKo1uHn950r4SQ==",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -22296,6 +22490,7 @@
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/onetime/-/onetime-6.0.0.tgz",
       "integrity": "sha512-1FlR+gjXK7X+AsAHso35MnyN5KqGwJRi/31ft6x0M194ht7S+rWAvd7PHss9xSKMzE0asv1pyIHaJYq+BbacAQ==",
+      "peer": true,
       "dependencies": {
         "mimic-fn": "^4.0.0"
       },
@@ -22310,6 +22505,7 @@
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/p-retry/-/p-retry-5.1.2.tgz",
       "integrity": "sha512-couX95waDu98NfNZV+i/iLt+fdVxmI7CbrrdC2uDWfPdUAApyxT4wmDlyOtR5KtTDmkDO0zDScDjDou9YHhd9g==",
+      "peer": true,
       "dependencies": {
         "@types/retry": "0.12.1",
         "retry": "^0.13.1"
@@ -22325,6 +22521,7 @@
       "version": "0.13.1",
       "resolved": "https://registry.npmjs.org/retry/-/retry-0.13.1.tgz",
       "integrity": "sha512-XQBQ3I8W1Cge0Seh+6gjj03LbmRFWuoszgK9ooCpwYIrhhoO80pfq4cUkU5DkknwfOfFteRwlZ56PYOGYyFWdg==",
+      "peer": true,
       "engines": {
         "node": ">= 4"
       }
@@ -22333,6 +22530,7 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
       "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+      "peer": true,
       "dependencies": {
         "shebang-regex": "^3.0.0"
       },
@@ -22344,6 +22542,7 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
       "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+      "peer": true,
       "engines": {
         "node": ">=8"
       }
@@ -22352,6 +22551,7 @@
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-5.1.2.tgz",
       "integrity": "sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA==",
+      "peer": true,
       "dependencies": {
         "eastasianwidth": "^0.2.0",
         "emoji-regex": "^9.2.2",
@@ -22368,6 +22568,7 @@
       "version": "7.0.1",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.0.1.tgz",
       "integrity": "sha512-cXNxvT8dFNRVfhVME3JAe98mkXDYN2O1l7jmcwMnOslDeESg1rF/OZMtK0nRAhiari1unG5cD4jG3rapUAkLbw==",
+      "peer": true,
       "dependencies": {
         "ansi-regex": "^6.0.1"
       },
@@ -22382,6 +22583,7 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/strip-final-newline/-/strip-final-newline-3.0.0.tgz",
       "integrity": "sha512-dOESqjYr96iWYylGObzd39EuNTa5VJxyvVAEm5Jnh7KGo75V43Hk1odPQkNDyXNmUR6k+gEiDVXnjB8HJ3crXw==",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -22393,6 +22595,7 @@
       "version": "2.19.0",
       "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-2.19.0.tgz",
       "integrity": "sha512-RAH822pAdBgcNMAfWnCBU3CFZcfZ/i1eZjwFU/dsLKumyuuP3niueg2UAukXYF0E2AAoc82ZSSf9J0WQBinzHA==",
+      "peer": true,
       "engines": {
         "node": ">=12.20"
       },
@@ -22404,6 +22607,7 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
       "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+      "peer": true,
       "dependencies": {
         "isexe": "^2.0.0"
       },
@@ -22418,6 +22622,7 @@
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/widest-line/-/widest-line-4.0.1.tgz",
       "integrity": "sha512-o0cyEG0e8GPzT4iGHphIOh0cJOV8fivsXxddQasHPHfoZf1ZexrfeA21w2NaEN1RHE+fXlfISmOE8R9N3u3Qig==",
+      "peer": true,
       "dependencies": {
         "string-width": "^5.0.1"
       },
@@ -22432,6 +22637,7 @@
       "version": "8.1.0",
       "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-8.1.0.tgz",
       "integrity": "sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ==",
+      "peer": true,
       "dependencies": {
         "ansi-styles": "^6.1.0",
         "string-width": "^5.0.1",
@@ -22448,6 +22654,7 @@
       "version": "8.12.0",
       "resolved": "https://registry.npmjs.org/ws/-/ws-8.12.0.tgz",
       "integrity": "sha512-kU62emKIdKVeEIOIKVegvqpXMSTAMLJozpHZaJNDYqBjzlSYXQGviYwN1osDLJ9av68qHd4a2oSjd7yD4pacig==",
+      "peer": true,
       "engines": {
         "node": ">=10.0.0"
       },
@@ -23155,6 +23362,7 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/sort-keys-length/-/sort-keys-length-1.0.1.tgz",
       "integrity": "sha512-GRbEOUqCxemTAk/b32F2xa8wDTs+Z1QHOkbhJDQTvv/6G3ZkbJ+frYWsTcc7cBB3Fu4wy4XlLCuNtJuMn7Gsvw==",
+      "peer": true,
       "dependencies": {
         "sort-keys": "^1.0.0"
       },
@@ -23166,6 +23374,7 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/sort-keys/-/sort-keys-1.1.2.tgz",
       "integrity": "sha512-vzn8aSqKgytVik0iwdBEi+zevbTYZogewTUM6dtpmGwEcdzbub/TX4bCzRhebDCRC3QzXgJsLRKB2V/Oof7HXg==",
+      "peer": true,
       "dependencies": {
         "is-plain-obj": "^1.0.0"
       },
@@ -23176,7 +23385,8 @@
     "node_modules/sorted-array-functions": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/sorted-array-functions/-/sorted-array-functions-1.3.0.tgz",
-      "integrity": "sha512-2sqgzeFlid6N4Z2fUQ1cvFmTOLRi/sEDzSQ0OKYchqgoPmQBVyM3959qYx3fpS6Esef80KjmpgPeEr028dP3OA=="
+      "integrity": "sha512-2sqgzeFlid6N4Z2fUQ1cvFmTOLRi/sEDzSQ0OKYchqgoPmQBVyM3959qYx3fpS6Esef80KjmpgPeEr028dP3OA==",
+      "peer": true
     },
     "node_modules/source-list-map": {
       "version": "2.0.1",
@@ -23303,6 +23513,7 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/sprintf-kit/-/sprintf-kit-2.0.1.tgz",
       "integrity": "sha512-2PNlcs3j5JflQKcg4wpdqpZ+AjhQJ2OZEo34NXDtlB0tIPG84xaaXhpA8XFacFiwjKA4m49UOYG83y3hbMn/gQ==",
+      "peer": true,
       "dependencies": {
         "es5-ext": "^0.10.53"
       }
@@ -23669,6 +23880,7 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/strip-dirs/-/strip-dirs-2.1.0.tgz",
       "integrity": "sha512-JOCxOeKLm2CAS73y/U4ZeZPTkE+gNVCzKt7Eox84Iej1LT/2pTWYpZKJuxwQpvX1LiZb1xokNR7RLfuBAa7T3g==",
+      "peer": true,
       "dependencies": {
         "is-natural-number": "^4.0.1"
       }
@@ -23705,6 +23917,7 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/strip-outer/-/strip-outer-1.0.1.tgz",
       "integrity": "sha512-k55yxKHwaXnpYGsOzg4Vl8+tDrWylxDEpknGjhTiZB8dFRU5rTo9CAzeycivxV3s+zlTKwrs6WxMxR95n26kwg==",
+      "peer": true,
       "dependencies": {
         "escape-string-regexp": "^1.0.2"
       },
@@ -23716,6 +23929,7 @@
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
       "integrity": "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==",
+      "peer": true,
       "engines": {
         "node": ">=0.8.0"
       }
@@ -23767,6 +23981,7 @@
       "version": "6.3.0",
       "resolved": "https://registry.npmjs.org/strtok3/-/strtok3-6.3.0.tgz",
       "integrity": "sha512-fZtbhtvI9I48xDSywd/somNqgUHl2L2cstmXCCif0itOf96jeW18MBSyrLuNicYQVkvpOxkZtkzujiTJ9LW5Jw==",
+      "peer": true,
       "dependencies": {
         "@tokenizer/token": "^0.3.0",
         "peek-readable": "^4.1.0"
@@ -24219,6 +24434,7 @@
       "version": "0.1.7",
       "resolved": "https://registry.npmjs.org/timers-ext/-/timers-ext-0.1.7.tgz",
       "integrity": "sha512-b85NUNzTSdodShTIbky6ZF02e8STtVVfD+fu4aXXShEELpozH+bCpJLYMPZbsABN2wDH7fJpqIoXxJpzbf0NqQ==",
+      "peer": true,
       "dependencies": {
         "es5-ext": "~0.10.46",
         "next-tick": "1"
@@ -24245,7 +24461,8 @@
     "node_modules/to-buffer": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/to-buffer/-/to-buffer-1.1.1.tgz",
-      "integrity": "sha512-lx9B5iv7msuFYE3dytT+KE5tap+rNYw+K4jVkb9R/asAb+pbBSM17jtunHplhBe6RRJdZx3Pn2Jph24O32mOVg=="
+      "integrity": "sha512-lx9B5iv7msuFYE3dytT+KE5tap+rNYw+K4jVkb9R/asAb+pbBSM17jtunHplhBe6RRJdZx3Pn2Jph24O32mOVg==",
+      "peer": true
     },
     "node_modules/to-fast-properties": {
       "version": "2.0.0",
@@ -24389,6 +24606,7 @@
       "version": "4.2.1",
       "resolved": "https://registry.npmjs.org/token-types/-/token-types-4.2.1.tgz",
       "integrity": "sha512-6udB24Q737UD/SDsKAHI9FCRP7Bqc9D/MQUV02ORQg5iskjtLJlZJNdN4kKtcdtwCeWIwIHDGaUsTsCCAa8sFQ==",
+      "peer": true,
       "dependencies": {
         "@tokenizer/token": "^0.3.0",
         "ieee754": "^1.2.1"
@@ -24471,6 +24689,7 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/trim-repeated/-/trim-repeated-1.0.0.tgz",
       "integrity": "sha512-pkonvlKk8/ZuR0D5tLW8ljt5I8kmxp2XKymhepUeOdCEfKpZaktSArkLHZt76OB1ZvO9bssUsDty4SWhLvZpLg==",
+      "peer": true,
       "dependencies": {
         "escape-string-regexp": "^1.0.2"
       },
@@ -24482,6 +24701,7 @@
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
       "integrity": "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==",
+      "peer": true,
       "engines": {
         "node": ">=0.8.0"
       }
@@ -24638,7 +24858,8 @@
     "node_modules/type": {
       "version": "2.7.2",
       "resolved": "https://registry.npmjs.org/type/-/type-2.7.2.tgz",
-      "integrity": "sha512-dzlvlNlt6AXU7EBSfpAscydQ7gXB+pPGsPnfJnZpiNJBDj7IaJzQlBZYGdEi4R9HmPdBv2XmWJ6YUtoTa7lmCw=="
+      "integrity": "sha512-dzlvlNlt6AXU7EBSfpAscydQ7gXB+pPGsPnfJnZpiNJBDj7IaJzQlBZYGdEi4R9HmPdBv2XmWJ6YUtoTa7lmCw==",
+      "peer": true
     },
     "node_modules/type-check": {
       "version": "0.4.0",
@@ -24775,6 +24996,7 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/uni-global/-/uni-global-1.0.0.tgz",
       "integrity": "sha512-WWM3HP+siTxzIWPNUg7hZ4XO8clKi6NoCAJJWnuRL+BAqyFXF8gC03WNyTefGoUXYc47uYgXxpKLIEvo65PEHw==",
+      "peer": true,
       "dependencies": {
         "type": "^2.5.0"
       }
@@ -25118,6 +25340,7 @@
       "version": "2.0.6",
       "resolved": "https://registry.npmjs.org/velocityjs/-/velocityjs-2.0.6.tgz",
       "integrity": "sha512-QMYLeYLBX6eqekCin3OPmDAHapaUx3foNFE264ml1/yxRZ8TUUlI1+u6rtN4E8tKNqwzpRPeNgJtjLbgRNK4fw==",
+      "peer": true,
       "dependencies": {
         "debug": "^4.3.3"
       },
@@ -25571,6 +25794,7 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/wcwidth/-/wcwidth-1.0.1.tgz",
       "integrity": "sha512-XHPEwS0q6TaxcvG85+8EYkbiCux2XtWG2mkc47Ng2A77BQu9+DqIOJldST4HgPkuea7dvKSj5VgX3P1d4rW8Tg==",
+      "peer": true,
       "dependencies": {
         "defaults": "^1.0.3"
       }
@@ -25579,6 +25803,7 @@
       "version": "3.2.1",
       "resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-3.2.1.tgz",
       "integrity": "sha512-e0MO3wdXWKrLbL0DgGnUV7WHVuw9OUvL4hjgnPkIeEvESk74gAITi5G606JtZPp39cd8HA9VQzCIvA49LpPN5Q==",
+      "peer": true,
       "engines": {
         "node": ">= 8"
       }
@@ -26430,6 +26655,14 @@
       },
       "engines": {
         "node": ">= 6"
+      }
+    },
+    "node_modules/zod": {
+      "version": "3.20.6",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.20.6.tgz",
+      "integrity": "sha512-oyu0m54SGCtzh6EClBVqDDlAYRz4jrVtKwQ7ZnsEmMI9HnzuZFj8QFwAY1M5uniIYACdGvv0PBWPF2kO0aNofA==",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
       }
     },
     "plugins/babel": {
@@ -27871,6 +28104,7 @@
       "version": "3.264.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/client-lambda/-/client-lambda-3.264.0.tgz",
       "integrity": "sha512-Z7EnWd1PveFdcSAkqpbMQO/iOBETKAs6/RV5ZfDtNmtzku2FGk02Xm76eQnkJrUNTWesEWw/am03cK2d7brBGw==",
+      "peer": true,
       "requires": {
         "@aws-crypto/sha256-browser": "3.0.0",
         "@aws-crypto/sha256-js": "3.0.0",
@@ -27914,6 +28148,7 @@
           "version": "3.264.0",
           "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.264.0.tgz",
           "integrity": "sha512-p+7sYpRcdv9omnnsPhD/vOFuZ1SpfV62ZgistBK/RDsQg2W9SIWQRW1KPt7gOCQ0nwp4efntw4Sle0LjS7ykxg==",
+          "peer": true,
           "requires": {
             "@aws-crypto/sha256-browser": "3.0.0",
             "@aws-crypto/sha256-js": "3.0.0",
@@ -27953,6 +28188,7 @@
           "version": "3.264.0",
           "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso-oidc/-/client-sso-oidc-3.264.0.tgz",
           "integrity": "sha512-82hGEbfsD4lBGIF1q8o82jTNSgBCcBpfFsvA+ltZf0bh4ChIWOi4vVvg8G+zVQN1mm/Rj8vWYO/D0tNF8OSyWw==",
+          "peer": true,
           "requires": {
             "@aws-crypto/sha256-browser": "3.0.0",
             "@aws-crypto/sha256-js": "3.0.0",
@@ -27992,6 +28228,7 @@
           "version": "3.264.0",
           "resolved": "https://registry.npmjs.org/@aws-sdk/client-sts/-/client-sts-3.264.0.tgz",
           "integrity": "sha512-sco1jREkDdds4Z3V19Vlu/YpBHSzeEt1KFqOPnbjFw7pSakRNzpyWmLLxOwWjwgGKt6pSF3Aw0ZOMYsAUDc5qQ==",
+          "peer": true,
           "requires": {
             "@aws-crypto/sha256-browser": "3.0.0",
             "@aws-crypto/sha256-js": "3.0.0",
@@ -28035,6 +28272,7 @@
           "version": "3.264.0",
           "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.264.0.tgz",
           "integrity": "sha512-UU5NNlfn+Go+5PLBzyTH1YE3r/pgykpE4QYFon87sCnEQnQH9xmlRTW1f1cBSQ9kivbFZd2/C2X3qhB3fe2JfA==",
+          "peer": true,
           "requires": {
             "@aws-sdk/credential-provider-env": "3.257.0",
             "@aws-sdk/credential-provider-imds": "3.259.0",
@@ -28051,6 +28289,7 @@
           "version": "3.264.0",
           "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.264.0.tgz",
           "integrity": "sha512-DPzL7oawcILs5Mduim9Z8SVeJaUpaDRVbUIrBHsMBu+N7Zuqtzr+0ckHc1bEi3iYq2QUCk5pH5vpQaZYkMlbtw==",
+          "peer": true,
           "requires": {
             "@aws-sdk/credential-provider-env": "3.257.0",
             "@aws-sdk/credential-provider-imds": "3.259.0",
@@ -28068,6 +28307,7 @@
           "version": "3.264.0",
           "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.264.0.tgz",
           "integrity": "sha512-CJuAlqIIJap6LXoqimvEAnYZ7Kb5pTbiS3e+aY+fajO3OPujmQpHuiY8kOmscjwZ4ErJdEskivcTGwXph0dPZQ==",
+          "peer": true,
           "requires": {
             "@aws-sdk/client-sso": "3.264.0",
             "@aws-sdk/property-provider": "3.257.0",
@@ -28081,6 +28321,7 @@
           "version": "3.264.0",
           "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-endpoint/-/middleware-endpoint-3.264.0.tgz",
           "integrity": "sha512-H9JEAug3Oo3IA2wZIplVVF6NtauCIjICXWgbNbA8Im+I2KPe0jWtOdtQv4U+tqHe9T4zIixaCM3gjUBld+FoOA==",
+          "peer": true,
           "requires": {
             "@aws-sdk/middleware-serde": "3.257.0",
             "@aws-sdk/protocol-http": "3.257.0",
@@ -28096,6 +28337,7 @@
           "version": "3.261.0",
           "resolved": "https://registry.npmjs.org/@aws-sdk/smithy-client/-/smithy-client-3.261.0.tgz",
           "integrity": "sha512-j8XQEa3caZUVFVZfhJjaskw80O/tB+IXu84HMN44N7UkXaCFHirUsNjTDztJhnVXf/gKXzIqUqprfRnOvwLtIg==",
+          "peer": true,
           "requires": {
             "@aws-sdk/middleware-stack": "3.257.0",
             "@aws-sdk/types": "3.257.0",
@@ -28106,6 +28348,7 @@
           "version": "3.264.0",
           "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.264.0.tgz",
           "integrity": "sha512-1N54FCdBJRqrwFWHUoDpGI0rKhI29Or9ZwGjjcBzKzLhz5sEF/DEhuID7h1/KKEkXdQ0+lmXOFGMMrahrMpOow==",
+          "peer": true,
           "requires": {
             "@aws-sdk/client-sso-oidc": "3.264.0",
             "@aws-sdk/property-provider": "3.257.0",
@@ -28118,6 +28361,7 @@
           "version": "3.261.0",
           "resolved": "https://registry.npmjs.org/@aws-sdk/util-defaults-mode-browser/-/util-defaults-mode-browser-3.261.0.tgz",
           "integrity": "sha512-lX3X1NfzQVV6cakepGV24uRcqevlDnQ8VgaCV8dhnw1FVThueFigyoFaUA02+uRXbV9KIbNWkEvweNtm2wvyDw==",
+          "peer": true,
           "requires": {
             "@aws-sdk/property-provider": "3.257.0",
             "@aws-sdk/types": "3.257.0",
@@ -28129,6 +28373,7 @@
           "version": "3.261.0",
           "resolved": "https://registry.npmjs.org/@aws-sdk/util-defaults-mode-node/-/util-defaults-mode-node-3.261.0.tgz",
           "integrity": "sha512-4AK6yu4bOmHSocUdbGoEHbNXB09UA58ON2HBHY4NxMBuFBAd9XB2tYiyhce+Cm+o+lHbS8oQnw0VZw16WMzzew==",
+          "peer": true,
           "requires": {
             "@aws-sdk/config-resolver": "3.259.0",
             "@aws-sdk/credential-provider-imds": "3.259.0",
@@ -28141,7 +28386,8 @@
         "tslib": {
           "version": "2.5.0",
           "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.0.tgz",
-          "integrity": "sha512-336iVw3rtn2BUK7ORdIAHTyxHGRIHVReokCR3XjbckJMK7ms8FysBfhLR8IXnAgy7T0PTPNBWKiH514FOW/WSg=="
+          "integrity": "sha512-336iVw3rtn2BUK7ORdIAHTyxHGRIHVReokCR3XjbckJMK7ms8FysBfhLR8IXnAgy7T0PTPNBWKiH514FOW/WSg==",
+          "peer": true
         }
       }
     },
@@ -31552,8 +31798,7 @@
         "@dotcom-tool-kit/secret-squirrel": "file:../../plugins/secret-squirrel",
         "@dotcom-tool-kit/upload-assets-to-s3": "^2.0.0",
         "dotcom-tool-kit": "file:../cli",
-        "nodemon": "^2.0.15",
-        "serverless-offline": "*"
+        "nodemon": "^2.0.15"
       }
     },
     "@dotcom-tool-kit/secret-squirrel": {
@@ -31613,7 +31858,8 @@
         "@types/semver": "^7.3.9",
         "semver": "^7.3.7",
         "tslib": "^2.3.1",
-        "winston": "^3.5.1"
+        "winston": "^3.5.1",
+        "zod": "^3.20.2"
       },
       "dependencies": {
         "tslib": {
@@ -32135,6 +32381,7 @@
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/@hapi/accept/-/accept-6.0.0.tgz",
       "integrity": "sha512-aG/Ml4kSBWCVmWvR8N8ULRuB385D8K/3OI7lquZQruH11eM7sHR5Nha30BbDzijJHtyV7Vwc6MlMwNfwb70ISg==",
+      "peer": true,
       "requires": {
         "@hapi/boom": "^10.0.0",
         "@hapi/hoek": "^10.0.0"
@@ -32144,6 +32391,7 @@
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/@hapi/ammo/-/ammo-6.0.0.tgz",
       "integrity": "sha512-lhX7SYtWScQaeAIL5XnE54WzyDgS5RXVeEtFEovyZcTdVzTYbo0nem56Bwko1PBcRxRUIw1v2tMb6sjFs6vEwg==",
+      "peer": true,
       "requires": {
         "@hapi/hoek": "^10.0.0"
       }
@@ -32152,6 +32400,7 @@
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/@hapi/b64/-/b64-6.0.0.tgz",
       "integrity": "sha512-Es6o4BtzvMmNF28KJGuwUzUtMjF6ToZ1hQt3UOjaXc6TNkRefel+NyQSjc9b5q3Re7xwv23r0xK3Vo3yreaJHQ==",
+      "peer": true,
       "requires": {
         "@hapi/hoek": "^10.0.0"
       }
@@ -32160,6 +32409,7 @@
       "version": "10.0.0",
       "resolved": "https://registry.npmjs.org/@hapi/boom/-/boom-10.0.0.tgz",
       "integrity": "sha512-1YVs9tLHhypBqqinKQRqh7FUERIolarQApO37OWkzD+z6y6USi871Sv746zBPKcIOBuI6g6y4FrwX87mmJ90Gg==",
+      "peer": true,
       "requires": {
         "@hapi/hoek": "10.x.x"
       }
@@ -32168,6 +32418,7 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/@hapi/bounce/-/bounce-3.0.0.tgz",
       "integrity": "sha512-L0G4NcwwOYRhpcXeL76hNrLTUcObqtZMB3z4kcRVUZcR/w3v6C5Q1cTElV4/V7og1fG+wOyDR55UMFA+tWfhtA==",
+      "peer": true,
       "requires": {
         "@hapi/boom": "^10.0.0",
         "@hapi/hoek": "^10.0.0"
@@ -32176,12 +32427,14 @@
     "@hapi/bourne": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/@hapi/bourne/-/bourne-3.0.0.tgz",
-      "integrity": "sha512-Waj1cwPXJDucOib4a3bAISsKJVb15MKi9IvmTI/7ssVEm6sywXGjVJDhl6/umt1pK1ZS7PacXU3A1PmFKHEZ2w=="
+      "integrity": "sha512-Waj1cwPXJDucOib4a3bAISsKJVb15MKi9IvmTI/7ssVEm6sywXGjVJDhl6/umt1pK1ZS7PacXU3A1PmFKHEZ2w==",
+      "peer": true
     },
     "@hapi/call": {
       "version": "9.0.0",
       "resolved": "https://registry.npmjs.org/@hapi/call/-/call-9.0.0.tgz",
       "integrity": "sha512-Z6byqbEtKF3RIH2kWG6cX64RwEqHBWYEVkNoEx6oKvkPaTrC6WTPRgr+ANo9Xa8G1GXyvs/NCMTnn3Mdj12TSA==",
+      "peer": true,
       "requires": {
         "@hapi/boom": "^10.0.0",
         "@hapi/hoek": "^10.0.0"
@@ -32191,6 +32444,7 @@
       "version": "12.1.0",
       "resolved": "https://registry.npmjs.org/@hapi/catbox/-/catbox-12.1.0.tgz",
       "integrity": "sha512-60MCN5lgaXcuRTjMZqLR+DV0clS5RAFAwfYAQU2/na6PqrXHDRQcJwVMwP7jJayCrJm4POJlLDzZLuh1ba5XUg==",
+      "peer": true,
       "requires": {
         "@hapi/boom": "^10.0.0",
         "@hapi/hoek": "^10.0.0",
@@ -32202,6 +32456,7 @@
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/@hapi/catbox-memory/-/catbox-memory-6.0.0.tgz",
       "integrity": "sha512-A1O30g8GdaODx/GinytF6jFm772pdTPVWJe0cF2RiTOfhgIAAagzCcpBqRgQ8olLui0F5bzUF/SAi4BmkZ4yxA==",
+      "peer": true,
       "requires": {
         "@hapi/boom": "^10.0.0",
         "@hapi/hoek": "^10.0.0"
@@ -32211,6 +32466,7 @@
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/@hapi/content/-/content-6.0.0.tgz",
       "integrity": "sha512-CEhs7j+H0iQffKfe5Htdak5LBOz/Qc8TRh51cF+BFv0qnuph3Em4pjGVzJMkI2gfTDdlJKWJISGWS1rK34POGA==",
+      "peer": true,
       "requires": {
         "@hapi/boom": "^10.0.0"
       }
@@ -32219,6 +32475,7 @@
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/@hapi/cryptiles/-/cryptiles-6.0.0.tgz",
       "integrity": "sha512-CUypQJI2F3HaKZjwlky3KyLu7p0O4WJXNJj+2AZ0czqwkwQIz8j+btOkzA3OMar8WTntnCrDx0f92PzxEK+JlA==",
+      "peer": true,
       "requires": {
         "@hapi/boom": "^10.0.0"
       }
@@ -32226,12 +32483,14 @@
     "@hapi/file": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/@hapi/file/-/file-3.0.0.tgz",
-      "integrity": "sha512-w+lKW+yRrLhJu620jT3y+5g2mHqnKfepreykvdOcl9/6up8GrQQn+l3FRTsjHTKbkbfQFkuksHpdv2EcpKcJ4Q=="
+      "integrity": "sha512-w+lKW+yRrLhJu620jT3y+5g2mHqnKfepreykvdOcl9/6up8GrQQn+l3FRTsjHTKbkbfQFkuksHpdv2EcpKcJ4Q==",
+      "peer": true
     },
     "@hapi/h2o2": {
       "version": "10.0.0",
       "resolved": "https://registry.npmjs.org/@hapi/h2o2/-/h2o2-10.0.0.tgz",
       "integrity": "sha512-eY5uulCxtvN68xHCXt7dr7yQQrFgsQpCkBRsxbYjdkWCPl2PJBHktQGeXqrumz8XKR1RUmElqNZK2IjdUxK/gw==",
+      "peer": true,
       "requires": {
         "@hapi/boom": "^10.0.0",
         "@hapi/hoek": "^10.0.0",
@@ -32243,6 +32502,7 @@
       "version": "21.2.1",
       "resolved": "https://registry.npmjs.org/@hapi/hapi/-/hapi-21.2.1.tgz",
       "integrity": "sha512-mDBhIi/zIYhWPaZF4Z8h7jUtWC3bz7xYuUyI5riXZV9DabFnNOKpQfOob6V5ZcDwEJfmnWHgJO37BVCn31BStQ==",
+      "peer": true,
       "requires": {
         "@hapi/accept": "^6.0.0",
         "@hapi/ammo": "^6.0.0",
@@ -32268,6 +32528,7 @@
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/@hapi/heavy/-/heavy-8.0.0.tgz",
       "integrity": "sha512-NpKo74mF66GSwYu31IZwp11/6NmaUYxHeMTKSky09XBs8fVbzQDP83856+l+Ji6wxGmUeg75itCu1ujvEF6mdA==",
+      "peer": true,
       "requires": {
         "@hapi/boom": "^10.0.0",
         "@hapi/hoek": "^10.0.0",
@@ -32277,12 +32538,14 @@
     "@hapi/hoek": {
       "version": "10.0.1",
       "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-10.0.1.tgz",
-      "integrity": "sha512-CvlW7jmOhWzuqOqiJQ3rQVLMcREh0eel4IBnxDx2FAcK8g7qoJRQK4L1CPBASoCY6y8e6zuCy3f2g+HWdkzcMw=="
+      "integrity": "sha512-CvlW7jmOhWzuqOqiJQ3rQVLMcREh0eel4IBnxDx2FAcK8g7qoJRQK4L1CPBASoCY6y8e6zuCy3f2g+HWdkzcMw==",
+      "peer": true
     },
     "@hapi/iron": {
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/@hapi/iron/-/iron-7.0.0.tgz",
       "integrity": "sha512-NNXJP5fpeiTCPj/4OJG2PWBjWC0/V5D8YggS9RZeuBbfUUuTYE6TbdGqLUsCzIpPI54I8W5dhwEGbRv1CnWQtw==",
+      "peer": true,
       "requires": {
         "@hapi/b64": "^6.0.0",
         "@hapi/boom": "^10.0.0",
@@ -32295,6 +32558,7 @@
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/@hapi/mimos/-/mimos-7.0.0.tgz",
       "integrity": "sha512-ALORTrZrrBPOUX05rW4htNajoekEjQtUi1PB+17/3xs/hkdQ+gSEFbs5GdJihA49qWf7td3v4PgnvOe8mcf/jQ==",
+      "peer": true,
       "requires": {
         "@hapi/hoek": "^10.0.0",
         "mime-db": "^1.52.0"
@@ -32304,6 +32568,7 @@
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/@hapi/nigel/-/nigel-5.0.0.tgz",
       "integrity": "sha512-I9eq43BnSdz1BkvMpG7mFL7J+SIfn6DLNThuxFpIOAMUnkWbPgtcFP+HHrBAeoFkowfgQrr02vsIAkAPml4hvw==",
+      "peer": true,
       "requires": {
         "@hapi/hoek": "^10.0.0",
         "@hapi/vise": "^5.0.0"
@@ -32313,6 +32578,7 @@
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/@hapi/pez/-/pez-6.0.0.tgz",
       "integrity": "sha512-3bMmsvlqrVNqaNEe4JWLZVpJ40jXuQ3vDy1+fbhyJmuAdMCMCkWexsKc7fT+mu18pFIwJzlenjc4/VE3weTq7w==",
+      "peer": true,
       "requires": {
         "@hapi/b64": "^6.0.0",
         "@hapi/boom": "^10.0.0",
@@ -32325,6 +32591,7 @@
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/@hapi/podium/-/podium-5.0.0.tgz",
       "integrity": "sha512-SbhFdu8LOIscMS82Zsoj9abcllAqbK4qBgznzJ9yr+vS2j1EomJTukkhxb76Lml0BHCd4Hn79F+3EQg06kcf8g==",
+      "peer": true,
       "requires": {
         "@hapi/hoek": "^10.0.0",
         "@hapi/teamwork": "^6.0.0",
@@ -32335,6 +32602,7 @@
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/@hapi/shot/-/shot-6.0.0.tgz",
       "integrity": "sha512-RLGgzXy9GciJDunhY40NbVnLgYqp5gfBooZ2fOkAr4KbCEav/SJtYQS1N+knR7WFGzy8aooCR3XBUPI4ghHAkQ==",
+      "peer": true,
       "requires": {
         "@hapi/hoek": "^10.0.0",
         "@hapi/validate": "^2.0.0"
@@ -32344,6 +32612,7 @@
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/@hapi/somever/-/somever-4.1.0.tgz",
       "integrity": "sha512-koNBYu7Jdcb7gaC4VcnU78rFxSlsYwuElm6NMznE0EEeznzJtvLLmDZX0SPX8kXWC/E7ONlE29HF/yiSOgWG1Q==",
+      "peer": true,
       "requires": {
         "@hapi/bounce": "^3.0.0",
         "@hapi/hoek": "^9.0.0"
@@ -32352,7 +32621,8 @@
         "@hapi/hoek": {
           "version": "9.3.0",
           "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-9.3.0.tgz",
-          "integrity": "sha512-/c6rf4UJlmHlC9b5BaNvzAcFv7HZ2QHaV0D4/HNlBdvFnvQq8RI4kYdhyPCl7Xj+oWvTWQ8ujhqS53LIgAe6KQ=="
+          "integrity": "sha512-/c6rf4UJlmHlC9b5BaNvzAcFv7HZ2QHaV0D4/HNlBdvFnvQq8RI4kYdhyPCl7Xj+oWvTWQ8ujhqS53LIgAe6KQ==",
+          "peer": true
         }
       }
     },
@@ -32360,6 +32630,7 @@
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/@hapi/statehood/-/statehood-8.0.0.tgz",
       "integrity": "sha512-umQTPID7BwmqAv9Rx7yLtbTNzsYg4va96aLqKneb3mlBQG32uq4iOQZ6luwBVACDFhqU3C3ewhznhukN09ZkZQ==",
+      "peer": true,
       "requires": {
         "@hapi/boom": "^10.0.0",
         "@hapi/bounce": "^3.0.0",
@@ -32374,6 +32645,7 @@
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/@hapi/subtext/-/subtext-8.0.0.tgz",
       "integrity": "sha512-fD+LY1U1SIUNHZJrNMIbuGl3CAd9JN8slljarFO4b8RrifkzjqbvdlZu/6iT6zlNM35GtDExf7hIepbUFUkT7A==",
+      "peer": true,
       "requires": {
         "@hapi/boom": "^10.0.0",
         "@hapi/bourne": "^3.0.0",
@@ -32387,12 +32659,14 @@
     "@hapi/teamwork": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/@hapi/teamwork/-/teamwork-6.0.0.tgz",
-      "integrity": "sha512-05HumSy3LWfXpmJ9cr6HzwhAavrHkJ1ZRCmNE2qJMihdM5YcWreWPfyN0yKT2ZjCM92au3ZkuodjBxOibxM67A=="
+      "integrity": "sha512-05HumSy3LWfXpmJ9cr6HzwhAavrHkJ1ZRCmNE2qJMihdM5YcWreWPfyN0yKT2ZjCM92au3ZkuodjBxOibxM67A==",
+      "peer": true
     },
     "@hapi/topo": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/@hapi/topo/-/topo-6.0.0.tgz",
       "integrity": "sha512-aorJvN1Q1n5xrZuA50Z4X6adI6VAM2NalIVm46ALL9LUvdoqhof3JPY69jdJH8asM3PsWr2SUVYzp57EqUP41A==",
+      "peer": true,
       "requires": {
         "@hapi/hoek": "^10.0.0"
       }
@@ -32401,6 +32675,7 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/@hapi/validate/-/validate-2.0.0.tgz",
       "integrity": "sha512-w5m8MvBgqGndbMIB+AWmXTb8CLtF1DlIxbnbAHNAo7aFuNQuI1Ywc2e0zDLK5fbFXDoqRzNrHnC7JjNJ+hDigw==",
+      "peer": true,
       "requires": {
         "@hapi/hoek": "^10.0.0",
         "@hapi/topo": "^6.0.0"
@@ -32410,6 +32685,7 @@
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/@hapi/vise/-/vise-5.0.0.tgz",
       "integrity": "sha512-bz/PA7DHIvsd/2eoW7t9WpU8+k9pofZHppYEn1mCTOVnC/cGN3hCEYaoAe6BpoeJM72iJDKZEOWvQvfgCrmzxA==",
+      "peer": true,
       "requires": {
         "@hapi/hoek": "^10.0.0"
       }
@@ -32418,6 +32694,7 @@
       "version": "18.0.0",
       "resolved": "https://registry.npmjs.org/@hapi/wreck/-/wreck-18.0.0.tgz",
       "integrity": "sha512-Yk9STxoM06Hjjq58cH0KFG91u9F2h9eVE72o8vUr3AfK80qt7I2POG5+cDGTEntbnvvzm0ERow2sjG3QsqCWUA==",
+      "peer": true,
       "requires": {
         "@hapi/boom": "^10.0.0",
         "@hapi/bourne": "^3.0.0",
@@ -34078,6 +34355,7 @@
       "version": "6.8.2",
       "resolved": "https://registry.npmjs.org/@serverless/utils/-/utils-6.8.2.tgz",
       "integrity": "sha512-FW8zdG8OPoF6qgyutiMhz4m/5SxbQjoQdbaGcW3wU6xe3QzQh41Hif7I3Xuu4J62CvxiWuz19sxNDJz2mTcskw==",
+      "peer": true,
       "requires": {
         "archive-type": "^4.0.0",
         "chalk": "^4.1.2",
@@ -34116,12 +34394,14 @@
         "@sindresorhus/is": {
           "version": "4.6.0",
           "resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-4.6.0.tgz",
-          "integrity": "sha512-t09vSN3MdfsyCHoFcTRCH/iUtG7OJ0CsjzB8cjAmKc/va/kIgeDI/TxsigdncE/4be734m0cvIYwNaV4i2XqAw=="
+          "integrity": "sha512-t09vSN3MdfsyCHoFcTRCH/iUtG7OJ0CsjzB8cjAmKc/va/kIgeDI/TxsigdncE/4be734m0cvIYwNaV4i2XqAw==",
+          "peer": true
         },
         "@szmarczak/http-timer": {
           "version": "4.0.6",
           "resolved": "https://registry.npmjs.org/@szmarczak/http-timer/-/http-timer-4.0.6.tgz",
           "integrity": "sha512-4BAffykYOgO+5nzBWYwE3W90sBgLJoUPRWWcL8wlyiM8IB8ipJz3UMJ9KXQd1RKQXpKp8Tutn80HZtWsu2u76w==",
+          "peer": true,
           "requires": {
             "defer-to-connect": "^2.0.0"
           }
@@ -34130,6 +34410,7 @@
           "version": "7.0.2",
           "resolved": "https://registry.npmjs.org/cacheable-request/-/cacheable-request-7.0.2.tgz",
           "integrity": "sha512-pouW8/FmiPQbuGpkXQ9BAPv/Mo5xDGANgSNXzTzJ8DrKGuXOssM4wIQRjfanNRh3Yu5cfYPvcorqbhg2KIJtew==",
+          "peer": true,
           "requires": {
             "clone-response": "^1.0.2",
             "get-stream": "^5.1.0",
@@ -34144,6 +34425,7 @@
               "version": "5.2.0",
               "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-5.2.0.tgz",
               "integrity": "sha512-nBF+F1rAZVCu/p7rjzgA+Yb4lfYXrpl7a6VmJrU8wF9I1CKvP/QwPNZHnOlwbTkY6dvtFIzFMSyQXbLoTQPRpA==",
+              "peer": true,
               "requires": {
                 "pump": "^3.0.0"
               }
@@ -34153,12 +34435,14 @@
         "ci-info": {
           "version": "3.7.1",
           "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-3.7.1.tgz",
-          "integrity": "sha512-4jYS4MOAaCIStSRwiuxc4B8MYhIe676yO1sYGzARnjXkWpmzZMMYxY6zu8WYWDhSuth5zhrQ1rhNSibyyvv4/w=="
+          "integrity": "sha512-4jYS4MOAaCIStSRwiuxc4B8MYhIe676yO1sYGzARnjXkWpmzZMMYxY6zu8WYWDhSuth5zhrQ1rhNSibyyvv4/w==",
+          "peer": true
         },
         "decompress-response": {
           "version": "6.0.0",
           "resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-6.0.0.tgz",
           "integrity": "sha512-aW35yZM6Bb/4oJlZncMH2LCoZtJXTRxES17vE3hoRiowU2kWHaJKFkSBDnDR+cm9J+9QhXmREyIfv0pji9ejCQ==",
+          "peer": true,
           "requires": {
             "mimic-response": "^3.1.0"
           }
@@ -34166,12 +34450,14 @@
         "defer-to-connect": {
           "version": "2.0.1",
           "resolved": "https://registry.npmjs.org/defer-to-connect/-/defer-to-connect-2.0.1.tgz",
-          "integrity": "sha512-4tvttepXG1VaYGrRibk5EwJd1t4udunSOVMdLSAL6mId1ix438oPwPZMALY41FCijukO1L0twNcGsdzS7dHgDg=="
+          "integrity": "sha512-4tvttepXG1VaYGrRibk5EwJd1t4udunSOVMdLSAL6mId1ix438oPwPZMALY41FCijukO1L0twNcGsdzS7dHgDg==",
+          "peer": true
         },
         "got": {
           "version": "11.8.6",
           "resolved": "https://registry.npmjs.org/got/-/got-11.8.6.tgz",
           "integrity": "sha512-6tfZ91bOr7bOXnK7PRDCGBLa1H4U080YHNaAQ2KsMGlLEzRbk44nsZF2E1IeRc3vtJHPVbKCYgdFbaGO2ljd8g==",
+          "peer": true,
           "requires": {
             "@sindresorhus/is": "^4.0.0",
             "@szmarczak/http-timer": "^4.0.5",
@@ -34190,6 +34476,7 @@
           "version": "8.2.5",
           "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-8.2.5.tgz",
           "integrity": "sha512-QAgPDQMEgrDssk1XiwwHoOGYF9BAbUcc1+j+FhEvaOt8/cKRqyLn0U5qA6F74fGhTMGxf92pOvPBeh29jQJDTQ==",
+          "peer": true,
           "requires": {
             "ansi-escapes": "^4.2.1",
             "chalk": "^4.1.1",
@@ -34211,17 +34498,20 @@
         "json-buffer": {
           "version": "3.0.1",
           "resolved": "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.1.tgz",
-          "integrity": "sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ=="
+          "integrity": "sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==",
+          "peer": true
         },
         "jwt-decode": {
           "version": "3.1.2",
           "resolved": "https://registry.npmjs.org/jwt-decode/-/jwt-decode-3.1.2.tgz",
-          "integrity": "sha512-UfpWE/VZn0iP50d8cz9NrZLM9lSWhcJ+0Gt/nm4by88UL+J1SiKN8/5dkjMmbEzwL2CAe+67GsegCbIKtbp75A=="
+          "integrity": "sha512-UfpWE/VZn0iP50d8cz9NrZLM9lSWhcJ+0Gt/nm4by88UL+J1SiKN8/5dkjMmbEzwL2CAe+67GsegCbIKtbp75A==",
+          "peer": true
         },
         "keyv": {
           "version": "4.5.2",
           "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.5.2.tgz",
           "integrity": "sha512-5MHbFaKn8cNSmVW7BYnijeAVlE4cYA/SVkifVgrh7yotnfhKmjuXpDKjrABLnT0SfHWV21P8ow07OGfRrNDg8g==",
+          "peer": true,
           "requires": {
             "json-buffer": "3.0.1"
           }
@@ -34229,27 +34519,32 @@
         "lowercase-keys": {
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-2.0.0.tgz",
-          "integrity": "sha512-tqNXrS78oMOE73NMxK4EMLQsQowWf8jKooH9g7xPavRT706R6bkQJ6DY2Te7QukaZsulxa30wQ7bk0pm4XiHmA=="
+          "integrity": "sha512-tqNXrS78oMOE73NMxK4EMLQsQowWf8jKooH9g7xPavRT706R6bkQJ6DY2Te7QukaZsulxa30wQ7bk0pm4XiHmA==",
+          "peer": true
         },
         "mimic-response": {
           "version": "3.1.0",
           "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-3.1.0.tgz",
-          "integrity": "sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ=="
+          "integrity": "sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ==",
+          "peer": true
         },
         "normalize-url": {
           "version": "6.1.0",
           "resolved": "https://registry.npmjs.org/normalize-url/-/normalize-url-6.1.0.tgz",
-          "integrity": "sha512-DlL+XwOy3NxAQ8xuC0okPgK46iuVNAK01YN7RueYBqqFeGsBjV9XmCAzAdgt+667bCl5kPh9EqKKDwnaPG1I7A=="
+          "integrity": "sha512-DlL+XwOy3NxAQ8xuC0okPgK46iuVNAK01YN7RueYBqqFeGsBjV9XmCAzAdgt+667bCl5kPh9EqKKDwnaPG1I7A==",
+          "peer": true
         },
         "p-cancelable": {
           "version": "2.1.1",
           "resolved": "https://registry.npmjs.org/p-cancelable/-/p-cancelable-2.1.1.tgz",
-          "integrity": "sha512-BZOr3nRQHOntUjTrH8+Lh54smKHoHyur8We1V8DSMVrl5A2malOOwuJRnKRDjSnkoeBh4at6BwEnb5I7Jl31wg=="
+          "integrity": "sha512-BZOr3nRQHOntUjTrH8+Lh54smKHoHyur8We1V8DSMVrl5A2malOOwuJRnKRDjSnkoeBh4at6BwEnb5I7Jl31wg==",
+          "peer": true
         },
         "responselike": {
           "version": "2.0.1",
           "resolved": "https://registry.npmjs.org/responselike/-/responselike-2.0.1.tgz",
           "integrity": "sha512-4gl03wn3hj1HP3yzgdI7d3lCkF95F21Pz4BPGvKHinyQzALR5CapwC8yIi0Rh58DEMQ/SguC03wFj2k0M/mHhw==",
+          "peer": true,
           "requires": {
             "lowercase-keys": "^2.0.0"
           }
@@ -34258,6 +34553,7 @@
           "version": "8.1.1",
           "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz",
           "integrity": "sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==",
+          "peer": true,
           "requires": {
             "has-flag": "^4.0.0"
           }
@@ -34265,12 +34561,14 @@
         "uuid": {
           "version": "8.3.2",
           "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
-          "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg=="
+          "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
+          "peer": true
         },
         "write-file-atomic": {
           "version": "4.0.2",
           "resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-4.0.2.tgz",
           "integrity": "sha512-7KxauUdBmSdWnmpaGFg+ppNjKF8uNLry8LyzjauQDOVONfFLNKrKvQOxZ/VuTIcS/gge/YNahf5RIIQWTSarlg==",
+          "peer": true,
           "requires": {
             "imurmurhash": "^0.1.4",
             "signal-exit": "^3.0.7"
@@ -34308,7 +34606,8 @@
     "@tokenizer/token": {
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/@tokenizer/token/-/token-0.3.0.tgz",
-      "integrity": "sha512-OvjF+z51L3ov0OyAU0duzsYuvO01PH7x4t6DJx+guahgTnBHkhJdG7soQeTSFLWN3efnHyibZ4Z8l2EuWwJN3A=="
+      "integrity": "sha512-OvjF+z51L3ov0OyAU0duzsYuvO01PH7x4t6DJx+guahgTnBHkhJdG7soQeTSFLWN3efnHyibZ4Z8l2EuWwJN3A==",
+      "peer": true
     },
     "@tootallnate/once": {
       "version": "1.1.2"
@@ -34362,6 +34661,7 @@
       "version": "6.0.3",
       "resolved": "https://registry.npmjs.org/@types/cacheable-request/-/cacheable-request-6.0.3.tgz",
       "integrity": "sha512-IQ3EbTzGxIigb1I3qPZc1rWJnH0BmSKv5QYTalEwweFvyBDLSAe24zP0le/hyi7ecGfZVlIVAg4BZqb8WBwKqw==",
+      "peer": true,
       "requires": {
         "@types/http-cache-semantics": "*",
         "@types/keyv": "^3.1.4",
@@ -34407,7 +34707,8 @@
     "@types/http-cache-semantics": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/@types/http-cache-semantics/-/http-cache-semantics-4.0.1.tgz",
-      "integrity": "sha512-SZs7ekbP8CN0txVG2xVRH6EgKmEm31BOxA07vkFaETzZz1xh+cbt8BcI0slpymvwhx5dlFnQG2rTlPVQn+iRPQ=="
+      "integrity": "sha512-SZs7ekbP8CN0txVG2xVRH6EgKmEm31BOxA07vkFaETzZz1xh+cbt8BcI0slpymvwhx5dlFnQG2rTlPVQn+iRPQ==",
+      "peer": true
     },
     "@types/istanbul-lib-coverage": {
       "version": "2.0.4"
@@ -34448,6 +34749,7 @@
       "version": "3.1.4",
       "resolved": "https://registry.npmjs.org/@types/keyv/-/keyv-3.1.4.tgz",
       "integrity": "sha512-BQ5aZNSCpj7D6K2ksrRCTmKRLEpnPvWDiLPfoGyhZ++8YtiK9d/3DBKPJgry359X/P1PfruyYwvnvwFjuEiEIg==",
+      "peer": true,
       "requires": {
         "@types/node": "*"
       }
@@ -34600,6 +34902,7 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/@types/responselike/-/responselike-1.0.0.tgz",
       "integrity": "sha512-85Y2BjiufFzaMIlvJDvTTB8Fxl2xfLo4HgmHzVBz08w4wDePCTjYw66PdrolO0kzli3yam/YCgRufyo1DdQVTA==",
+      "peer": true,
       "requires": {
         "@types/node": "*"
       }
@@ -35079,6 +35382,7 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/archive-type/-/archive-type-4.0.0.tgz",
       "integrity": "sha512-zV4Ky0v1F8dBrdYElwTvQhweQ0P7Kwc1aluqJsYtOBP01jXcWCyW2IEfI1YiqsG+Iy7ZR+o5LF1N+PGECBxHWA==",
+      "peer": true,
       "requires": {
         "file-type": "^4.2.0"
       },
@@ -35086,7 +35390,8 @@
         "file-type": {
           "version": "4.4.0",
           "resolved": "https://registry.npmjs.org/file-type/-/file-type-4.4.0.tgz",
-          "integrity": "sha512-f2UbFQEk7LXgWpi5ntcO86OeA/cC80fuDDDaX/fZ2ZGel+AF7leRQqBBW1eJNiiQkrZlAoM6P+VYP5P6bOlDEQ=="
+          "integrity": "sha512-f2UbFQEk7LXgWpi5ntcO86OeA/cC80fuDDDaX/fZ2ZGel+AF7leRQqBBW1eJNiiQkrZlAoM6P+VYP5P6bOlDEQ==",
+          "peer": true
         }
       }
     },
@@ -35186,7 +35491,8 @@
     "array-unflat-js": {
       "version": "0.1.3",
       "resolved": "https://registry.npmjs.org/array-unflat-js/-/array-unflat-js-0.1.3.tgz",
-      "integrity": "sha512-8pljkLj4vfz2i7Tf3yB31tRrszjP8/kwIyABGfcZ1GcHlvdUB0Sbx0WzQkOPMqUBxa/bu4+/NAyHEpDtZJzlJw=="
+      "integrity": "sha512-8pljkLj4vfz2i7Tf3yB31tRrszjP8/kwIyABGfcZ1GcHlvdUB0Sbx0WzQkOPMqUBxa/bu4+/NAyHEpDtZJzlJw==",
+      "peer": true
     },
     "array-union": {
       "version": "2.1.0"
@@ -35754,6 +36060,7 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/buffer-alloc/-/buffer-alloc-1.2.0.tgz",
       "integrity": "sha512-CFsHQgjtW1UChdXgbyJGtnm+O/uLQeZdtbDo8mfUgYXCHSM1wgrVxXm6bSyrUuErEb+4sYVGCzASBRot7zyrow==",
+      "peer": true,
       "requires": {
         "buffer-alloc-unsafe": "^1.1.0",
         "buffer-fill": "^1.0.0"
@@ -35762,7 +36069,8 @@
     "buffer-alloc-unsafe": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/buffer-alloc-unsafe/-/buffer-alloc-unsafe-1.1.0.tgz",
-      "integrity": "sha512-TEM2iMIEQdJ2yjPJoSIsldnleVaAk1oW3DBVUykyOLsEsFmEc9kn+SFFPz+gl54KQNxlDnAwCXosOS9Okx2xAg=="
+      "integrity": "sha512-TEM2iMIEQdJ2yjPJoSIsldnleVaAk1oW3DBVUykyOLsEsFmEc9kn+SFFPz+gl54KQNxlDnAwCXosOS9Okx2xAg==",
+      "peer": true
     },
     "buffer-crc32": {
       "version": "0.2.13"
@@ -35770,7 +36078,8 @@
     "buffer-fill": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/buffer-fill/-/buffer-fill-1.0.0.tgz",
-      "integrity": "sha512-T7zexNBwiiaCOGDg9xNX9PBmjrubblRkENuptryuI64URkXDFum9il/JGL8Lm8wYfAXpredVXXZz7eMHilimiQ=="
+      "integrity": "sha512-T7zexNBwiiaCOGDg9xNX9PBmjrubblRkENuptryuI64URkXDFum9il/JGL8Lm8wYfAXpredVXXZz7eMHilimiQ==",
+      "peer": true
     },
     "buffer-from": {
       "version": "1.1.2"
@@ -35781,7 +36090,8 @@
     "builtin-modules": {
       "version": "3.3.0",
       "resolved": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-3.3.0.tgz",
-      "integrity": "sha512-zhaCDicdLuWN5UbN5IMnFqNMhNfo919sH85y2/ea+5Yg9TsTkeZxpL+JLbp6cgYFS4sRLp3YV4S6yDuqVWHYOw=="
+      "integrity": "sha512-zhaCDicdLuWN5UbN5IMnFqNMhNfo919sH85y2/ea+5Yg9TsTkeZxpL+JLbp6cgYFS4sRLp3YV4S6yDuqVWHYOw==",
+      "peer": true
     },
     "builtin-status-codes": {
       "version": "3.0.0"
@@ -35851,7 +36161,8 @@
     "cacheable-lookup": {
       "version": "5.0.4",
       "resolved": "https://registry.npmjs.org/cacheable-lookup/-/cacheable-lookup-5.0.4.tgz",
-      "integrity": "sha512-2/kNscPhpcxrOigMZzbiWF7dz8ilhb/nIHU3EyZiXWXpeq/au8qJ8VhdftMkty3n7Gj6HIGalQG8oiBNB3AJgA=="
+      "integrity": "sha512-2/kNscPhpcxrOigMZzbiWF7dz8ilhb/nIHU3EyZiXWXpeq/au8qJ8VhdftMkty3n7Gj6HIGalQG8oiBNB3AJgA==",
+      "peer": true
     },
     "cacheable-request": {
       "version": "6.1.0",
@@ -36097,6 +36408,7 @@
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/cli-color/-/cli-color-2.0.3.tgz",
       "integrity": "sha512-OkoZnxyC4ERN3zLzZaY9Emb7f/MhBOIpePv0Ycok0fJYT+Ouo00UBEIwsVsr0yoow++n5YWlSUgST9GKhNHiRQ==",
+      "peer": true,
       "requires": {
         "d": "^1.0.1",
         "es5-ext": "^0.10.61",
@@ -36115,6 +36427,7 @@
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/cli-progress-footer/-/cli-progress-footer-2.3.2.tgz",
       "integrity": "sha512-uzHGgkKdeA9Kr57eyH1W5HGiNShP8fV1ETq04HDNM1Un6ShXbHhwi/H8LNV9L1fQXKjEw0q5FUkEVNuZ+yZdSw==",
+      "peer": true,
       "requires": {
         "cli-color": "^2.0.2",
         "d": "^1.0.1",
@@ -36132,6 +36445,7 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/cli-sprintf-format/-/cli-sprintf-format-1.1.1.tgz",
       "integrity": "sha512-BbEjY9BEdA6wagVwTqPvmAwGB24U93rQPBFZUT8lNCDxXzre5LFHQUTJc70czjgUomVg8u8R5kW8oY9DYRFNeg==",
+      "peer": true,
       "requires": {
         "cli-color": "^2.0.1",
         "es5-ext": "^0.10.53",
@@ -36142,12 +36456,14 @@
         "has-flag": {
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
-          "integrity": "sha512-sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw=="
+          "integrity": "sha512-sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw==",
+          "peer": true
         },
         "supports-color": {
           "version": "6.1.0",
           "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-6.1.0.tgz",
           "integrity": "sha512-qe1jfm1Mg7Nq/NSh6XE24gPXROEVsWHxC1LIx//XNlD9iw7YZQGjZNjYN7xGaEG6iKdA8EtNFW6R0gjnVXp+wQ==",
+          "peer": true,
           "requires": {
             "has-flag": "^3.0.0"
           }
@@ -36175,7 +36491,8 @@
     "clone": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/clone/-/clone-1.0.4.tgz",
-      "integrity": "sha512-JQHZ2QMW6l3aH/j6xCqQThY/9OH4D/9ls34cgkUBiEeocRTU04tHfKPBsUK1PqZCUQM7GiA0IIXJSuXHI64Kbg=="
+      "integrity": "sha512-JQHZ2QMW6l3aH/j6xCqQThY/9OH4D/9ls34cgkUBiEeocRTU04tHfKPBsUK1PqZCUQM7GiA0IIXJSuXHI64Kbg==",
+      "peer": true
     },
     "clone-deep": {
       "version": "4.0.1",
@@ -36429,6 +36746,7 @@
       "version": "0.5.4",
       "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-0.5.4.tgz",
       "integrity": "sha512-FveZTNuGw04cxlAiWbzi6zTAL/lhehaWbTtgluJh4/E95DqMwTmha3KZN1aAWA8cFIhHzMZUvLevkw5Rqk+tSQ==",
+      "peer": true,
       "requires": {
         "safe-buffer": "5.2.1"
       },
@@ -36436,7 +36754,8 @@
         "safe-buffer": {
           "version": "5.2.1",
           "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
-          "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ=="
+          "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+          "peer": true
         }
       }
     },
@@ -36680,6 +36999,7 @@
       "version": "4.7.1",
       "resolved": "https://registry.npmjs.org/cron-parser/-/cron-parser-4.7.1.tgz",
       "integrity": "sha512-WguFaoQ0hQ61SgsCZLHUcNbAvlK0lypKXu62ARguefYmjzaOXIVRNrAmyXzabTwUn4sQvQLkk6bjH+ipGfw8bA==",
+      "peer": true,
       "requires": {
         "luxon": "^3.2.1"
       }
@@ -36763,6 +37083,7 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/d/-/d-1.0.1.tgz",
       "integrity": "sha512-m62ShEObQ39CfralilEQRjH6oAMtNCV1xJyEx5LpRYUVN+EviphDgUc/F3hnYbADmkiNs67Y+3ylmlG7Lnu+FA==",
+      "peer": true,
       "requires": {
         "es5-ext": "^0.10.50",
         "type": "^1.0.1"
@@ -36771,7 +37092,8 @@
         "type": {
           "version": "1.2.0",
           "resolved": "https://registry.npmjs.org/type/-/type-1.2.0.tgz",
-          "integrity": "sha512-+5nt5AAniqsCnu2cEQQdpzCAh33kVx8n0VoFidKpB1dVVLAN/F+bgVOqOJqOnEnrhp222clB5p3vUlD+1QAnfg=="
+          "integrity": "sha512-+5nt5AAniqsCnu2cEQQdpzCAh33kVx8n0VoFidKpB1dVVLAN/F+bgVOqOJqOnEnrhp222clB5p3vUlD+1QAnfg==",
+          "peer": true
         }
       }
     },
@@ -36843,6 +37165,7 @@
       "version": "4.2.1",
       "resolved": "https://registry.npmjs.org/decompress/-/decompress-4.2.1.tgz",
       "integrity": "sha512-e48kc2IjU+2Zw8cTb6VZcJQ3lgVbS4uuB1TfCHbiZIP/haNXm+SVyhu+87jts5/3ROpd82GSVCoNs/z8l4ZOaQ==",
+      "peer": true,
       "requires": {
         "decompress-tar": "^4.0.0",
         "decompress-tarbz2": "^4.0.0",
@@ -36858,6 +37181,7 @@
           "version": "1.3.0",
           "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-1.3.0.tgz",
           "integrity": "sha512-2w31R7SJtieJJnQtGc7RVL2StM2vGYVfqUOvUDxH6bC6aJTxPxTF0GnIgCyu7tjockiUWAYQRbxa7vKn34s5sQ==",
+          "peer": true,
           "requires": {
             "pify": "^3.0.0"
           },
@@ -36865,14 +37189,16 @@
             "pify": {
               "version": "3.0.0",
               "resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
-              "integrity": "sha512-C3FsVNH1udSEX48gGX1xfvwTWfsYWj5U+8/uK15BGzIGrKoUpghX8hWZwa/OFnakBiiVNmBvemTJR5mcy7iPcg=="
+              "integrity": "sha512-C3FsVNH1udSEX48gGX1xfvwTWfsYWj5U+8/uK15BGzIGrKoUpghX8hWZwa/OFnakBiiVNmBvemTJR5mcy7iPcg==",
+              "peer": true
             }
           }
         },
         "pify": {
           "version": "2.3.0",
           "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
-          "integrity": "sha512-udgsAY+fTnvv7kI7aaxbqwWNb0AHiB0qBO89PZKPkoTmGOgdbrHDKD+0B2X4uTfJ/FT1R09r9gTsjUjNJotuog=="
+          "integrity": "sha512-udgsAY+fTnvv7kI7aaxbqwWNb0AHiB0qBO89PZKPkoTmGOgdbrHDKD+0B2X4uTfJ/FT1R09r9gTsjUjNJotuog==",
+          "peer": true
         }
       }
     },
@@ -36886,6 +37212,7 @@
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/decompress-tar/-/decompress-tar-4.1.1.tgz",
       "integrity": "sha512-JdJMaCrGpB5fESVyxwpCx4Jdj2AagLmv3y58Qy4GE6HMVjWz1FeVQk1Ct4Kye7PftcdOo/7U7UKzYBJgqnGeUQ==",
+      "peer": true,
       "requires": {
         "file-type": "^5.2.0",
         "is-stream": "^1.1.0",
@@ -36896,6 +37223,7 @@
           "version": "1.2.3",
           "resolved": "https://registry.npmjs.org/bl/-/bl-1.2.3.tgz",
           "integrity": "sha512-pvcNpa0UU69UT341rO6AYy4FVAIkUHuZXRIWbq+zHnsVcRzDDjIAhGuuYoi0d//cwIwtt4pkpKycWEfjdV+vww==",
+          "peer": true,
           "requires": {
             "readable-stream": "^2.3.5",
             "safe-buffer": "^5.1.1"
@@ -36904,17 +37232,20 @@
         "file-type": {
           "version": "5.2.0",
           "resolved": "https://registry.npmjs.org/file-type/-/file-type-5.2.0.tgz",
-          "integrity": "sha512-Iq1nJ6D2+yIO4c8HHg4fyVb8mAJieo1Oloy1mLLaB2PvezNedhBVm+QU7g0qM42aiMbRXTxKKwGD17rjKNJYVQ=="
+          "integrity": "sha512-Iq1nJ6D2+yIO4c8HHg4fyVb8mAJieo1Oloy1mLLaB2PvezNedhBVm+QU7g0qM42aiMbRXTxKKwGD17rjKNJYVQ==",
+          "peer": true
         },
         "is-stream": {
           "version": "1.1.0",
           "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
-          "integrity": "sha512-uQPm8kcs47jx38atAcWTVxyltQYoPT68y9aWYdV6yWXSyW8mzSat0TL6CiWdZeCdF3KrAvpVtnHbTv4RN+rqdQ=="
+          "integrity": "sha512-uQPm8kcs47jx38atAcWTVxyltQYoPT68y9aWYdV6yWXSyW8mzSat0TL6CiWdZeCdF3KrAvpVtnHbTv4RN+rqdQ==",
+          "peer": true
         },
         "readable-stream": {
           "version": "2.3.7",
           "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
           "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
+          "peer": true,
           "requires": {
             "core-util-is": "~1.0.0",
             "inherits": "~2.0.3",
@@ -36929,6 +37260,7 @@
           "version": "1.1.1",
           "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
           "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+          "peer": true,
           "requires": {
             "safe-buffer": "~5.1.0"
           }
@@ -36937,6 +37269,7 @@
           "version": "1.6.2",
           "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-1.6.2.tgz",
           "integrity": "sha512-rzS0heiNf8Xn7/mpdSVVSMAWAoy9bfb1WOTYC78Z0UQKeKa/CWS8FOq0lKGNa8DWKAn9gxjCvMLYc5PGXYlK2A==",
+          "peer": true,
           "requires": {
             "bl": "^1.0.0",
             "buffer-alloc": "^1.2.0",
@@ -36953,6 +37286,7 @@
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/decompress-tarbz2/-/decompress-tarbz2-4.1.1.tgz",
       "integrity": "sha512-s88xLzf1r81ICXLAVQVzaN6ZmX4A6U4z2nMbOwobxkLoIIfjVMBg7TeguTUXkKeXni795B6y5rnvDw7rxhAq9A==",
+      "peer": true,
       "requires": {
         "decompress-tar": "^4.1.0",
         "file-type": "^6.1.0",
@@ -36964,12 +37298,14 @@
         "file-type": {
           "version": "6.2.0",
           "resolved": "https://registry.npmjs.org/file-type/-/file-type-6.2.0.tgz",
-          "integrity": "sha512-YPcTBDV+2Tm0VqjybVd32MHdlEGAtuxS3VAYsumFokDSMG+ROT5wawGlnHDoz7bfMcMDt9hxuXvXwoKUx2fkOg=="
+          "integrity": "sha512-YPcTBDV+2Tm0VqjybVd32MHdlEGAtuxS3VAYsumFokDSMG+ROT5wawGlnHDoz7bfMcMDt9hxuXvXwoKUx2fkOg==",
+          "peer": true
         },
         "is-stream": {
           "version": "1.1.0",
           "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
-          "integrity": "sha512-uQPm8kcs47jx38atAcWTVxyltQYoPT68y9aWYdV6yWXSyW8mzSat0TL6CiWdZeCdF3KrAvpVtnHbTv4RN+rqdQ=="
+          "integrity": "sha512-uQPm8kcs47jx38atAcWTVxyltQYoPT68y9aWYdV6yWXSyW8mzSat0TL6CiWdZeCdF3KrAvpVtnHbTv4RN+rqdQ==",
+          "peer": true
         }
       }
     },
@@ -36977,6 +37313,7 @@
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/decompress-targz/-/decompress-targz-4.1.1.tgz",
       "integrity": "sha512-4z81Znfr6chWnRDNfFNqLwPvm4db3WuZkqV+UgXQzSngG3CEKdBkw5jrv3axjjL96glyiiKjsxJG3X6WBZwX3w==",
+      "peer": true,
       "requires": {
         "decompress-tar": "^4.1.1",
         "file-type": "^5.2.0",
@@ -36986,12 +37323,14 @@
         "file-type": {
           "version": "5.2.0",
           "resolved": "https://registry.npmjs.org/file-type/-/file-type-5.2.0.tgz",
-          "integrity": "sha512-Iq1nJ6D2+yIO4c8HHg4fyVb8mAJieo1Oloy1mLLaB2PvezNedhBVm+QU7g0qM42aiMbRXTxKKwGD17rjKNJYVQ=="
+          "integrity": "sha512-Iq1nJ6D2+yIO4c8HHg4fyVb8mAJieo1Oloy1mLLaB2PvezNedhBVm+QU7g0qM42aiMbRXTxKKwGD17rjKNJYVQ==",
+          "peer": true
         },
         "is-stream": {
           "version": "1.1.0",
           "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
-          "integrity": "sha512-uQPm8kcs47jx38atAcWTVxyltQYoPT68y9aWYdV6yWXSyW8mzSat0TL6CiWdZeCdF3KrAvpVtnHbTv4RN+rqdQ=="
+          "integrity": "sha512-uQPm8kcs47jx38atAcWTVxyltQYoPT68y9aWYdV6yWXSyW8mzSat0TL6CiWdZeCdF3KrAvpVtnHbTv4RN+rqdQ==",
+          "peer": true
         }
       }
     },
@@ -36999,6 +37338,7 @@
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/decompress-unzip/-/decompress-unzip-4.0.1.tgz",
       "integrity": "sha512-1fqeluvxgnn86MOh66u8FjbtJpAFv5wgCT9Iw8rcBqQcCo5tO8eiJw7NNTrvt9n4CRBVq7CstiS922oPgyGLrw==",
+      "peer": true,
       "requires": {
         "file-type": "^3.8.0",
         "get-stream": "^2.2.0",
@@ -37009,12 +37349,14 @@
         "file-type": {
           "version": "3.9.0",
           "resolved": "https://registry.npmjs.org/file-type/-/file-type-3.9.0.tgz",
-          "integrity": "sha512-RLoqTXE8/vPmMuTI88DAzhMYC99I8BWv7zYP4A1puo5HIjEJ5EX48ighy4ZyKMG9EDXxBgW6e++cn7d1xuFghA=="
+          "integrity": "sha512-RLoqTXE8/vPmMuTI88DAzhMYC99I8BWv7zYP4A1puo5HIjEJ5EX48ighy4ZyKMG9EDXxBgW6e++cn7d1xuFghA==",
+          "peer": true
         },
         "get-stream": {
           "version": "2.3.1",
           "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-2.3.1.tgz",
           "integrity": "sha512-AUGhbbemXxrZJRD5cDvKtQxLuYaIbNtDTK8YqupCI393Q2KSTreEsLUN3ZxAWFGiKTzL6nKuzfcIvieflUX9qA==",
+          "peer": true,
           "requires": {
             "object-assign": "^4.0.1",
             "pinkie-promise": "^2.0.0"
@@ -37023,7 +37365,8 @@
         "pify": {
           "version": "2.3.0",
           "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
-          "integrity": "sha512-udgsAY+fTnvv7kI7aaxbqwWNb0AHiB0qBO89PZKPkoTmGOgdbrHDKD+0B2X4uTfJ/FT1R09r9gTsjUjNJotuog=="
+          "integrity": "sha512-udgsAY+fTnvv7kI7aaxbqwWNb0AHiB0qBO89PZKPkoTmGOgdbrHDKD+0B2X4uTfJ/FT1R09r9gTsjUjNJotuog==",
+          "peer": true
         }
       }
     },
@@ -37050,6 +37393,7 @@
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/defaults/-/defaults-1.0.4.tgz",
       "integrity": "sha512-eFuaLoy/Rxalv2kr+lqMlUnrDWV+3j4pljOIJgLIhI058IQfWJ7vXhyEIHu+HtC738klGALYxOKDO0bQP3tg8A==",
+      "peer": true,
       "requires": {
         "clone": "^1.0.2"
       }
@@ -37061,6 +37405,7 @@
       "version": "0.7.11",
       "resolved": "https://registry.npmjs.org/deferred/-/deferred-0.7.11.tgz",
       "integrity": "sha512-8eluCl/Blx4YOGwMapBvXRKxHXhA8ejDXYzEaK8+/gtcm8hRMhSLmXSqDmNUKNc/C8HNSmuyyp/hflhqDAvK2A==",
+      "peer": true,
       "requires": {
         "d": "^1.0.1",
         "es5-ext": "^0.10.50",
@@ -37072,7 +37417,8 @@
     "define-lazy-prop": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/define-lazy-prop/-/define-lazy-prop-2.0.0.tgz",
-      "integrity": "sha512-Ds09qNh8yw3khSjiJjiUInaGX9xlqZDY7JVryGxdxV7NPeuqQfplOpQ66yJFZut3jLa5zOwkXw1g9EI2uKh4Og=="
+      "integrity": "sha512-Ds09qNh8yw3khSjiJjiUInaGX9xlqZDY7JVryGxdxV7NPeuqQfplOpQ66yJFZut3jLa5zOwkXw1g9EI2uKh4Og==",
+      "peer": true
     },
     "define-properties": {
       "version": "1.1.4",
@@ -37112,7 +37458,8 @@
     "desm": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/desm/-/desm-1.3.0.tgz",
-      "integrity": "sha512-RvlHN2gfYA0BpCfjpWzCdQeR6p5U+84f5DzcirLow86UA/OcpwuOqXRC4Oz0bG9rzcJPVtMT6ZgNtjp4qh+uqA=="
+      "integrity": "sha512-RvlHN2gfYA0BpCfjpWzCdQeR6p5U+84f5DzcirLow86UA/OcpwuOqXRC4Oz0bG9rzcJPVtMT6ZgNtjp4qh+uqA==",
+      "peer": true
     },
     "detect-indent": {
       "version": "6.1.0",
@@ -37329,6 +37676,7 @@
       "version": "0.2.2",
       "resolved": "https://registry.npmjs.org/duration/-/duration-0.2.2.tgz",
       "integrity": "sha512-06kgtea+bGreF5eKYgI/36A6pLXggY7oR4p1pq4SmdFBn1ReOL5D8RhG64VrqfTTKNucqqtBAwEj8aB88mcqrg==",
+      "peer": true,
       "requires": {
         "d": "1",
         "es5-ext": "~0.10.46"
@@ -37337,7 +37685,8 @@
     "eastasianwidth": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/eastasianwidth/-/eastasianwidth-0.2.0.tgz",
-      "integrity": "sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA=="
+      "integrity": "sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==",
+      "peer": true
     },
     "ecc-jsbn": {
       "version": "0.1.2",
@@ -37569,6 +37918,7 @@
       "version": "0.10.62",
       "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.62.tgz",
       "integrity": "sha512-BHLqn0klhEpnOKSrzn/Xsz2UIW8j+cGmo9JLzr8BiUapV8hPL9+FliFqjwr9ngW7jWdnxv6eO+/LqyhJVqgrjA==",
+      "peer": true,
       "requires": {
         "es6-iterator": "^2.0.3",
         "es6-symbol": "^3.1.3",
@@ -37579,6 +37929,7 @@
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/es6-iterator/-/es6-iterator-2.0.3.tgz",
       "integrity": "sha512-zw4SRzoUkd+cl+ZoE15A9o1oQd920Bb0iOJMQkQhl3jNc03YqVjAhG7scf9C5KWRU/R13Orf588uCC6525o02g==",
+      "peer": true,
       "requires": {
         "d": "1",
         "es5-ext": "^0.10.35",
@@ -37603,6 +37954,7 @@
       "version": "0.1.6",
       "resolved": "https://registry.npmjs.org/es6-set/-/es6-set-0.1.6.tgz",
       "integrity": "sha512-TE3LgGLDIBX332jq3ypv6bcOpkLO0AslAQo7p2VqX/1N46YNsvIWgvjojjSEnWEGWMhr1qUbYeTSir5J6mFHOw==",
+      "peer": true,
       "requires": {
         "d": "^1.0.1",
         "es5-ext": "^0.10.62",
@@ -37616,6 +37968,7 @@
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-3.1.3.tgz",
       "integrity": "sha512-NJ6Yn3FuDinBaBRWl/q5X/s4koRHBrgKAu+yGI6JCBeiu3qrcbJhwT2GeR/EXVfylRk8dpQVJoLEFhK+Mu31NA==",
+      "peer": true,
       "requires": {
         "d": "^1.0.1",
         "ext": "^1.1.2"
@@ -37625,6 +37978,7 @@
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/es6-weak-map/-/es6-weak-map-2.0.3.tgz",
       "integrity": "sha512-p5um32HOTO1kP+w7PRnB+5lQ43Z6muuMuIMffvDN8ZB4GcnjLBV6zGStpbASIMk4DCAvEaamhe2zhyCb/QXXsA==",
+      "peer": true,
       "requires": {
         "d": "1",
         "es5-ext": "^0.10.46",
@@ -37935,6 +38289,7 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/esniff/-/esniff-1.1.0.tgz",
       "integrity": "sha512-vmHXOeOt7FJLsqofvFk4WB3ejvcHizCd8toXXwADmYfd02p2QwHRgkUbhYDX54y08nqk818CUTWipgZGlyN07g==",
+      "peer": true,
       "requires": {
         "d": "1",
         "es5-ext": "^0.10.12"
@@ -38001,6 +38356,7 @@
       "version": "0.3.5",
       "resolved": "https://registry.npmjs.org/event-emitter/-/event-emitter-0.3.5.tgz",
       "integrity": "sha512-D9rRn9y7kLPnJ+hMq7S/nhvoKwwvVJahBi2BPmx3bvbsEdK3W9ii8cBSGjP+72/LnM4n6fo3+dkCX5FeTQruXA==",
+      "peer": true,
       "requires": {
         "d": "1",
         "es5-ext": "~0.10.14"
@@ -38097,6 +38453,7 @@
       "version": "1.7.0",
       "resolved": "https://registry.npmjs.org/ext/-/ext-1.7.0.tgz",
       "integrity": "sha512-6hxeJYaL110a9b5TEJSj0gojyHQAmA2ch5Os+ySCiA1QGdS697XWY1pzsrSjqA9LDEEgdB/KypIlR59RcLuHYw==",
+      "peer": true,
       "requires": {
         "type": "^2.7.2"
       }
@@ -38105,6 +38462,7 @@
       "version": "2.2.2",
       "resolved": "https://registry.npmjs.org/ext-list/-/ext-list-2.2.2.tgz",
       "integrity": "sha512-u+SQgsubraE6zItfVA0tBuCBhfU9ogSRnsvygI7wht9TS510oLkBRXBsqopeUG/GBOIQyKZO9wjTqIu/sf5zFA==",
+      "peer": true,
       "requires": {
         "mime-db": "^1.28.0"
       }
@@ -38113,6 +38471,7 @@
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/ext-name/-/ext-name-5.0.0.tgz",
       "integrity": "sha512-yblEwXAbGv1VQDmow7s38W77hzAgJAO50ztBLMcUyUBfxv1HC+LGwtiEN+Co6LtlqT/5uwVOxsD4TNIilWhwdQ==",
+      "peer": true,
       "requires": {
         "ext-list": "^2.0.0",
         "sort-keys-length": "^1.0.0"
@@ -38276,6 +38635,7 @@
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/fetch-blob/-/fetch-blob-3.2.0.tgz",
       "integrity": "sha512-7yAQpD2UMJzLi1Dqv7qFYnPbaPx7ZfFK6PiIxQ4PfkGPyNyl2Ugx+a/umUonmKqjhM4DnfbMvdX6otXq83soQQ==",
+      "peer": true,
       "requires": {
         "node-domexception": "^1.0.0",
         "web-streams-polyfill": "^3.0.3"
@@ -38306,6 +38666,7 @@
       "version": "16.5.4",
       "resolved": "https://registry.npmjs.org/file-type/-/file-type-16.5.4.tgz",
       "integrity": "sha512-/yFHK0aGjFEgDJjEKP0pWCplsPFPhwyfwevf/pVxiN0tmE4L9LmwWxWukdJSHdoCli4VgQLehjJtwQBnqmsKcw==",
+      "peer": true,
       "requires": {
         "readable-web-to-node-stream": "^3.0.0",
         "strtok3": "^6.2.4",
@@ -38324,12 +38685,14 @@
     "filename-reserved-regex": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/filename-reserved-regex/-/filename-reserved-regex-2.0.0.tgz",
-      "integrity": "sha512-lc1bnsSr4L4Bdif8Xb/qrtokGbq5zlsms/CYH8PP+WtCkGNF65DPiQY8vG3SakEdRn8Dlnm+gW/qWKKjS5sZzQ=="
+      "integrity": "sha512-lc1bnsSr4L4Bdif8Xb/qrtokGbq5zlsms/CYH8PP+WtCkGNF65DPiQY8vG3SakEdRn8Dlnm+gW/qWKKjS5sZzQ==",
+      "peer": true
     },
     "filenamify": {
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/filenamify/-/filenamify-4.3.0.tgz",
       "integrity": "sha512-hcFKyUG57yWGAzu1CMt/dPzYZuv+jAJUT85bL8mrXvNe6hWj6yEHEc4EdcgiA6Z3oi1/9wXJdZPXF2dZNgwgOg==",
+      "peer": true,
       "requires": {
         "filename-reserved-regex": "^2.0.0",
         "strip-outer": "^1.0.1",
@@ -38429,6 +38792,7 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/find-requires/-/find-requires-1.0.0.tgz",
       "integrity": "sha512-UME7hNwBfzeISSFQcBEDemEEskpOjI/shPrpJM5PI4DSdn6hX0dmz+2dL70blZER2z8tSnTRL+2rfzlYgtbBoQ==",
+      "peer": true,
       "requires": {
         "es5-ext": "^0.10.49",
         "esniff": "^1.1.0"
@@ -38522,6 +38886,7 @@
       "version": "4.0.10",
       "resolved": "https://registry.npmjs.org/formdata-polyfill/-/formdata-polyfill-4.0.10.tgz",
       "integrity": "sha512-buewHzMvYL29jdeQTVILecSaZKnt/RJWjoZCF5OW60Z67/GmSLBkOFM7qh1PI3zFNtJbaZL5eQu1vLfazOwj4g==",
+      "peer": true,
       "requires": {
         "fetch-blob": "^3.1.2"
       }
@@ -38618,6 +38983,7 @@
       "version": "0.3.9",
       "resolved": "https://registry.npmjs.org/fs2/-/fs2-0.3.9.tgz",
       "integrity": "sha512-WsOqncODWRlkjwll+73bAxVW3JPChDgaPX3DT4iTTm73UmG4VgALa7LaFblP232/DN60itkOrPZ8kaP1feksGQ==",
+      "peer": true,
       "requires": {
         "d": "^1.0.1",
         "deferred": "^0.7.11",
@@ -39158,6 +39524,7 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/http2-wrapper/-/http2-wrapper-1.0.3.tgz",
       "integrity": "sha512-V+23sDMr12Wnz7iTcDeJr3O6AIxlnvT/bmaAAAP/Xda35C90p9599p0F1eHR/N1KILWSoWVAiOMFjBBXaXSMxg==",
+      "peer": true,
       "requires": {
         "quick-lru": "^5.1.1",
         "resolve-alpn": "^1.0.0"
@@ -39166,7 +39533,8 @@
         "quick-lru": {
           "version": "5.1.1",
           "resolved": "https://registry.npmjs.org/quick-lru/-/quick-lru-5.1.1.tgz",
-          "integrity": "sha512-WuyALRjWPDGtt/wzJiadO5AXY+8hZ80hVpe6MyivgraREW751X3SbhRvG3eLKOYN+8VEvqLcf3wdnt44Z4S4SA=="
+          "integrity": "sha512-WuyALRjWPDGtt/wzJiadO5AXY+8hZ80hVpe6MyivgraREW751X3SbhRvG3eLKOYN+8VEvqLcf3wdnt44Z4S4SA==",
+          "peer": true
         }
       }
     },
@@ -39248,7 +39616,8 @@
     "immediate": {
       "version": "3.0.6",
       "resolved": "https://registry.npmjs.org/immediate/-/immediate-3.0.6.tgz",
-      "integrity": "sha512-XXOFtyqDjNDAQxVfYxuF7g9Il/IbWmmlQg2MYKOH8ExIT1qg6xc4zyS3HaEEATgs1btfzxq15ciUiY7gjSXRGQ=="
+      "integrity": "sha512-XXOFtyqDjNDAQxVfYxuF7g9Il/IbWmmlQg2MYKOH8ExIT1qg6xc4zyS3HaEEATgs1btfzxq15ciUiY7gjSXRGQ==",
+      "peer": true
     },
     "import-cwd": {
       "version": "3.0.0",
@@ -39508,7 +39877,8 @@
     "is-docker": {
       "version": "2.2.1",
       "resolved": "https://registry.npmjs.org/is-docker/-/is-docker-2.2.1.tgz",
-      "integrity": "sha512-F+i2BKsFrH66iaUFc0woD8sLy8getkwTwtOBjvs56Cx4CgJDeKQeqfz8wAYiSb8JOprWhHH5p77PbmYCvvUuXQ=="
+      "integrity": "sha512-F+i2BKsFrH66iaUFc0woD8sLy8getkwTwtOBjvs56Cx4CgJDeKQeqfz8wAYiSb8JOprWhHH5p77PbmYCvvUuXQ==",
+      "peer": true
     },
     "is-extendable": {
       "version": "0.1.1"
@@ -39558,7 +39928,8 @@
     "is-interactive": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/is-interactive/-/is-interactive-1.0.0.tgz",
-      "integrity": "sha512-2HvIEKRoqS62guEC+qBjpvRubdX910WCMuJTZ+I9yvqKU2/12eSL549HMwtabb4oupdj2sMP50k+XJfB/8JE6w=="
+      "integrity": "sha512-2HvIEKRoqS62guEC+qBjpvRubdX910WCMuJTZ+I9yvqKU2/12eSL549HMwtabb4oupdj2sMP50k+XJfB/8JE6w==",
+      "peer": true
     },
     "is-lambda": {
       "version": "1.0.1"
@@ -39570,7 +39941,8 @@
     "is-natural-number": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/is-natural-number/-/is-natural-number-4.0.1.tgz",
-      "integrity": "sha512-Y4LTamMe0DDQIIAlaer9eKebAlDSV6huy+TWhJVPlzZh2o4tRP5SQWFlLn5N0To4mDD22/qdOq+veo1cSISLgQ=="
+      "integrity": "sha512-Y4LTamMe0DDQIIAlaer9eKebAlDSV6huy+TWhJVPlzZh2o4tRP5SQWFlLn5N0To4mDD22/qdOq+veo1cSISLgQ==",
+      "peer": true
     },
     "is-negative-zero": {
       "version": "2.0.2"
@@ -39605,7 +39977,8 @@
     "is-promise": {
       "version": "2.2.2",
       "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-2.2.2.tgz",
-      "integrity": "sha512-+lP4/6lKUBfQjZ2pdxThZvLUAafmZb8OAxFb8XXtiQmS35INgr85hdOGoEs124ez1FCnZJt6jau/T+alh58QFQ=="
+      "integrity": "sha512-+lP4/6lKUBfQjZ2pdxThZvLUAafmZb8OAxFb8XXtiQmS35INgr85hdOGoEs124ez1FCnZJt6jau/T+alh58QFQ==",
+      "peer": true
     },
     "is-regex": {
       "version": "1.1.4",
@@ -39790,7 +40163,8 @@
     "java-invoke-local": {
       "version": "0.0.6",
       "resolved": "https://registry.npmjs.org/java-invoke-local/-/java-invoke-local-0.0.6.tgz",
-      "integrity": "sha512-gZmQKe1QrfkkMjCn8Qv9cpyJFyogTYqkP5WCobX5RNaHsJzIV/6NvAnlnouOcwKr29QrxLGDGcqYuJ+ae98s1A=="
+      "integrity": "sha512-gZmQKe1QrfkkMjCn8Qv9cpyJFyogTYqkP5WCobX5RNaHsJzIV/6NvAnlnouOcwKr29QrxLGDGcqYuJ+ae98s1A==",
+      "peer": true
     },
     "jest": {
       "version": "27.5.1",
@@ -40253,7 +40627,8 @@
     "jose": {
       "version": "4.11.2",
       "resolved": "https://registry.npmjs.org/jose/-/jose-4.11.2.tgz",
-      "integrity": "sha512-njj0VL2TsIxCtgzhO+9RRobBvws4oYyCM8TpvoUQwl/MbIM3NFJRR9+e6x0sS5xXaP1t6OCBkaBME98OV9zU5A=="
+      "integrity": "sha512-njj0VL2TsIxCtgzhO+9RRobBvws4oYyCM8TpvoUQwl/MbIM3NFJRR9+e6x0sS5xXaP1t6OCBkaBME98OV9zU5A==",
+      "peer": true
     },
     "jpeg-js": {
       "version": "0.4.3"
@@ -40261,7 +40636,8 @@
     "js-string-escape": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/js-string-escape/-/js-string-escape-1.0.1.tgz",
-      "integrity": "sha512-Smw4xcfIQ5LVjAOuJCvN/zIodzA/BBSsluuoSykP+lUvScIi4U6RJLfwHet5cxFnCswUjISV8oAXaqaJDY3chg=="
+      "integrity": "sha512-Smw4xcfIQ5LVjAOuJCvN/zIodzA/BBSsluuoSykP+lUvScIi4U6RJLfwHet5cxFnCswUjISV8oAXaqaJDY3chg==",
+      "peer": true
     },
     "js-tokens": {
       "version": "4.0.0"
@@ -40417,12 +40793,14 @@
     "jsonpath-plus": {
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/jsonpath-plus/-/jsonpath-plus-7.2.0.tgz",
-      "integrity": "sha512-zBfiUPM5nD0YZSBT/o/fbCUlCcepMIdP0CJZxM1+KgA4f2T206f6VAg9e7mX35+KlMaIc5qXW34f3BnwJ3w+RA=="
+      "integrity": "sha512-zBfiUPM5nD0YZSBT/o/fbCUlCcepMIdP0CJZxM1+KgA4f2T206f6VAg9e7mX35+KlMaIc5qXW34f3BnwJ3w+RA==",
+      "peer": true
     },
     "jsonschema": {
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/jsonschema/-/jsonschema-1.4.1.tgz",
-      "integrity": "sha512-S6cATIPVv1z0IlxdN+zUk5EPjkGCdnhN4wVSBlvoUO1tOLJootbo9CquNJmbIh4yikWHiUedhRYrNPn1arpEmQ=="
+      "integrity": "sha512-S6cATIPVv1z0IlxdN+zUk5EPjkGCdnhN4wVSBlvoUO1tOLJootbo9CquNJmbIh4yikWHiUedhRYrNPn1arpEmQ==",
+      "peer": true
     },
     "JSONStream": {
       "version": "1.3.5",
@@ -40445,6 +40823,7 @@
       "version": "3.10.1",
       "resolved": "https://registry.npmjs.org/jszip/-/jszip-3.10.1.tgz",
       "integrity": "sha512-xXDvecyTpGLrqFrvkrUSoxxfJI5AH7U8zxxtVclpsUtMCq4JQ290LY8AW5c7Ggnr/Y/oK+bQMbqK2qmtk3pN4g==",
+      "peer": true,
       "requires": {
         "lie": "~3.3.0",
         "pako": "~1.0.2",
@@ -40456,6 +40835,7 @@
           "version": "2.3.7",
           "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
           "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
+          "peer": true,
           "requires": {
             "core-util-is": "~1.0.0",
             "inherits": "~2.0.3",
@@ -40470,6 +40850,7 @@
           "version": "1.1.1",
           "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
           "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+          "peer": true,
           "requires": {
             "safe-buffer": "~5.1.0"
           }
@@ -40672,6 +41053,7 @@
       "version": "3.3.0",
       "resolved": "https://registry.npmjs.org/lie/-/lie-3.3.0.tgz",
       "integrity": "sha512-UaiMJzeWRlEujzAuw5LokY1L5ecNQYZKfmyZ9L7wDHb/p5etKaxXhohBcrw0EYby+G/NA52vRSN4N39dxHAIwQ==",
+      "peer": true,
       "requires": {
         "immediate": "~3.0.5"
       }
@@ -40859,6 +41241,7 @@
       "version": "6.3.1",
       "resolved": "https://registry.npmjs.org/log/-/log-6.3.1.tgz",
       "integrity": "sha512-McG47rJEWOkXTDioZzQNydAVvZNeEkSyLJ1VWkFwfW+o1knW+QSi8D1KjPn/TnctV+q99lkvJNe1f0E1IjfY2A==",
+      "peer": true,
       "requires": {
         "d": "^1.0.1",
         "duration": "^0.2.2",
@@ -40873,6 +41256,7 @@
       "version": "8.0.3",
       "resolved": "https://registry.npmjs.org/log-node/-/log-node-8.0.3.tgz",
       "integrity": "sha512-1UBwzgYiCIDFs8A0rM2QdBFo8Wd8UQ0HrSTu/MNI+/2zN3NoHRj2fhplurAyuxTYUXu3Oohugq1jAn5s05u1MQ==",
+      "peer": true,
       "requires": {
         "ansi-regex": "^5.0.1",
         "cli-color": "^2.0.1",
@@ -40888,6 +41272,7 @@
           "version": "8.1.1",
           "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz",
           "integrity": "sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==",
+          "peer": true,
           "requires": {
             "has-flag": "^4.0.0"
           }
@@ -40947,7 +41332,8 @@
     "long-timeout": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/long-timeout/-/long-timeout-0.1.1.tgz",
-      "integrity": "sha512-BFRuQUqc7x2NWxfJBCyUrN8iYUYznzL9JROmRz1gZ6KlOIgmoD+njPVbb+VNn2nGMKggMsK79iUNErillsrx7w=="
+      "integrity": "sha512-BFRuQUqc7x2NWxfJBCyUrN8iYUYznzL9JROmRz1gZ6KlOIgmoD+njPVbb+VNn2nGMKggMsK79iUNErillsrx7w==",
+      "peer": true
     },
     "loupe": {
       "version": "2.3.4",
@@ -40971,6 +41357,7 @@
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/lru-queue/-/lru-queue-0.1.0.tgz",
       "integrity": "sha512-BpdYkt9EvGl8OfWHDQPISVpcl5xZthb+XPsbELj5AQXxIC8IriDZIQYjBJPEm5rS420sjZ0TLEzRcq5KdBhYrQ==",
+      "peer": true,
       "requires": {
         "es5-ext": "~0.10.2"
       }
@@ -40978,7 +41365,8 @@
     "luxon": {
       "version": "3.2.1",
       "resolved": "https://registry.npmjs.org/luxon/-/luxon-3.2.1.tgz",
-      "integrity": "sha512-QrwPArQCNLAKGO/C+ZIilgIuDnEnKx5QYODdDtbFaxzsbZcc/a7WFq7MhsVYgRlwawLtvOUESTlfJ+hc/USqPg=="
+      "integrity": "sha512-QrwPArQCNLAKGO/C+ZIilgIuDnEnKx5QYODdDtbFaxzsbZcc/a7WFq7MhsVYgRlwawLtvOUESTlfJ+hc/USqPg==",
+      "peer": true
     },
     "make-dir": {
       "version": "3.1.0",
@@ -41066,6 +41454,7 @@
       "version": "0.4.15",
       "resolved": "https://registry.npmjs.org/memoizee/-/memoizee-0.4.15.tgz",
       "integrity": "sha512-UBWmJpLZd5STPm7PMUlOw/TSy972M+z8gcyQ5veOnSDRREz/0bmpyTfKt3/51DhEBqCZQn1udM/5flcSPYhkdQ==",
+      "peer": true,
       "requires": {
         "d": "^1.0.1",
         "es5-ext": "^0.10.53",
@@ -41651,6 +42040,7 @@
       "version": "4.3.2",
       "resolved": "https://registry.npmjs.org/ncjsm/-/ncjsm-4.3.2.tgz",
       "integrity": "sha512-6d1VWA7FY31CpI4Ki97Fpm36jfURkVbpktizp8aoVViTZRQgr/0ddmlKerALSSlzfwQRBeSq1qwwVcBJK4Sk7Q==",
+      "peer": true,
       "requires": {
         "builtin-modules": "^3.3.0",
         "deferred": "^0.7.11",
@@ -41693,7 +42083,8 @@
     "next-tick": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/next-tick/-/next-tick-1.1.0.tgz",
-      "integrity": "sha512-CXdUiJembsNjuToQvxayPZF9Vqht7hewsvy2sOWafLvi2awflj9mOC6bHIg50orX8IJvWKY9wYQ/zB2kogPslQ=="
+      "integrity": "sha512-CXdUiJembsNjuToQvxayPZF9Vqht7hewsvy2sOWafLvi2awflj9mOC6bHIg50orX8IJvWKY9wYQ/zB2kogPslQ==",
+      "peer": true
     },
     "nice-try": {
       "version": "1.0.5",
@@ -41716,7 +42107,8 @@
     "node-domexception": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/node-domexception/-/node-domexception-1.0.0.tgz",
-      "integrity": "sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ=="
+      "integrity": "sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ==",
+      "peer": true
     },
     "node-fetch": {
       "version": "2.6.7",
@@ -41858,6 +42250,7 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/node-schedule/-/node-schedule-2.1.1.tgz",
       "integrity": "sha512-OXdegQq03OmXEjt2hZP33W2YPs/E5BcFQks46+G2gAxs4gHOIVD1u7EqlYLYSKsaIpyKCK9Gbk0ta1/gjRSMRQ==",
+      "peer": true,
       "requires": {
         "cron-parser": "^4.2.0",
         "long-timeout": "0.1.1",
@@ -42305,6 +42698,7 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/object.hasown/-/object.hasown-1.1.2.tgz",
       "integrity": "sha512-B5UIT3J1W+WuWIU55h0mjlwaqxiE5vYENJXIXZ4VFe05pNYrkKuK0U/6aFcb0pKywYJh7IhfoqUfKVmrJJHZHw==",
+      "peer": true,
       "requires": {
         "define-properties": "^1.1.4",
         "es-abstract": "^1.20.4"
@@ -42356,6 +42750,7 @@
       "version": "8.4.0",
       "resolved": "https://registry.npmjs.org/open/-/open-8.4.0.tgz",
       "integrity": "sha512-XgFPPM+B28FtCCgSb9I+s9szOC1vZRSwgWsRUA5ylIxRTgKozqjOCrVOqGsYABPYK5qnfqClxZTFBa8PKt2v6Q==",
+      "peer": true,
       "requires": {
         "define-lazy-prop": "^2.0.0",
         "is-docker": "^2.1.1",
@@ -42366,6 +42761,7 @@
           "version": "2.2.0",
           "resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-2.2.0.tgz",
           "integrity": "sha512-fKzAra0rGJUUBwGBgNkHZuToZcn+TtXHpeCgmkMJMMYx1sQDYaCSyjJBSCa2nH1DGm7s3n1oBnohoVTBaN7Lww==",
+          "peer": true,
           "requires": {
             "is-docker": "^2.0.0"
           }
@@ -42391,6 +42787,7 @@
       "version": "5.4.1",
       "resolved": "https://registry.npmjs.org/ora/-/ora-5.4.1.tgz",
       "integrity": "sha512-5b6Y85tPxZZ7QytO+BQzysW31HJku27cRIlkbAXaNx+BdcVi+LlRFmVXzeF6a7JCwJpyw5c4b+YSVImQIrBpuQ==",
+      "peer": true,
       "requires": {
         "bl": "^4.1.0",
         "chalk": "^4.1.0",
@@ -42422,6 +42819,7 @@
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/p-event/-/p-event-4.2.0.tgz",
       "integrity": "sha512-KXatOjCRXXkSePPb1Nbi0p0m+gQAwdlbhi4wQKJPI1HsMQS9g+Sqp2o+QHziPr7eYJyOZet836KoHEVM1mwOrQ==",
+      "peer": true,
       "requires": {
         "p-timeout": "^3.1.0"
       }
@@ -42451,6 +42849,7 @@
       "version": "7.1.1",
       "resolved": "https://registry.npmjs.org/p-memoize/-/p-memoize-7.1.1.tgz",
       "integrity": "sha512-DZ/bONJILHkQ721hSr/E9wMz5Am/OTJ9P6LhLFo2Tu+jL8044tgc9LwHO8g4PiaYePnlVVRAJcKmgy8J9MVFrA==",
+      "peer": true,
       "requires": {
         "mimic-fn": "^4.0.0",
         "type-fest": "^3.0.0"
@@ -42459,12 +42858,14 @@
         "mimic-fn": {
           "version": "4.0.0",
           "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-4.0.0.tgz",
-          "integrity": "sha512-vqiC06CuhBTUdZH+RYl8sFrL096vA45Ok5ISO6sE/Mr1jRbGH4Csnhi8f3wKVl7x8mO4Au7Ir9D3Oyv1VYMFJw=="
+          "integrity": "sha512-vqiC06CuhBTUdZH+RYl8sFrL096vA45Ok5ISO6sE/Mr1jRbGH4Csnhi8f3wKVl7x8mO4Au7Ir9D3Oyv1VYMFJw==",
+          "peer": true
         },
         "type-fest": {
           "version": "3.5.4",
           "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-3.5.4.tgz",
-          "integrity": "sha512-/Je22Er4LPoln256pcLzj73MUmPrTWg8u4WB1RlxaDl0idJOfD1r259VtKOinp4xLJqJ9zYVMuWOun6Ssp7boA=="
+          "integrity": "sha512-/Je22Er4LPoln256pcLzj73MUmPrTWg8u4WB1RlxaDl0idJOfD1r259VtKOinp4xLJqJ9zYVMuWOun6Ssp7boA==",
+          "peer": true
         }
       }
     },
@@ -43208,7 +43609,8 @@
     "peek-readable": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/peek-readable/-/peek-readable-4.1.0.tgz",
-      "integrity": "sha512-ZI3LnwUv5nOGbQzD9c2iDG6toheuXSZP5esSHBjopsXH4dg19soufvpUGA3uohi5anFtGb2lhAVdHzH6R/Evvg=="
+      "integrity": "sha512-ZI3LnwUv5nOGbQzD9c2iDG6toheuXSZP5esSHBjopsXH4dg19soufvpUGA3uohi5anFtGb2lhAVdHzH6R/Evvg==",
+      "peer": true
     },
     "pend": {
       "version": "1.2.0"
@@ -43298,6 +43700,7 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/process-utils/-/process-utils-4.0.0.tgz",
       "integrity": "sha512-fMyMQbKCxX51YxR7YGCzPjLsU3yDzXFkP4oi1/Mt5Ixnk7GO/7uUTj8mrCHUwuvozWzI+V7QSJR9cZYnwNOZPg==",
+      "peer": true,
       "requires": {
         "ext": "^1.4.0",
         "fs2": "^0.3.9",
@@ -43687,6 +44090,7 @@
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/readable-web-to-node-stream/-/readable-web-to-node-stream-3.0.2.tgz",
       "integrity": "sha512-ePeK6cc1EcKLEhJFt/AebMCLL+GgSKhuygrZ/GLaKZYEecIgIECf4UaUuaByiGtzckwR4ain9VzUh95T1exYGw==",
+      "peer": true,
       "requires": {
         "readable-stream": "^3.6.0"
       }
@@ -44060,7 +44464,8 @@
     "resolve-alpn": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/resolve-alpn/-/resolve-alpn-1.2.1.tgz",
-      "integrity": "sha512-0a1F4l73/ZFZOakJnQ3FvkJ2+gSTQWz/r2KE5OdDY0TxPm5h4GkqkWWfM47T7HsbnOtcJVEF4epCVy6u7Q3K+g=="
+      "integrity": "sha512-0a1F4l73/ZFZOakJnQ3FvkJ2+gSTQWz/r2KE5OdDY0TxPm5h4GkqkWWfM47T7HsbnOtcJVEF4epCVy6u7Q3K+g==",
+      "peer": true
     },
     "resolve-cwd": {
       "version": "3.0.0",
@@ -44231,6 +44636,7 @@
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/seek-bzip/-/seek-bzip-1.0.6.tgz",
       "integrity": "sha512-e1QtP3YL5tWww8uKaOCQ18UxIT2laNBXHjV/S2WYCiK4udiv8lkG89KRIoCjUagnAmCBurjF4zEVX2ByBbnCjQ==",
+      "peer": true,
       "requires": {
         "commander": "^2.8.1"
       },
@@ -44238,7 +44644,8 @@
         "commander": {
           "version": "2.20.3",
           "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
-          "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ=="
+          "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
+          "peer": true
         }
       }
     },
@@ -44645,6 +45052,7 @@
       "version": "12.0.4",
       "resolved": "https://registry.npmjs.org/serverless-offline/-/serverless-offline-12.0.4.tgz",
       "integrity": "sha512-G256wDHI12vE0CJ0uTJMBlfnaN7o7td4GgClvQtuedt/n7vKoUfN0och+LybD6YVGsR5h1xpYjPPPLy2QFqWaA==",
+      "peer": true,
       "requires": {
         "@aws-sdk/client-lambda": "^3.241.0",
         "@hapi/boom": "^10.0.0",
@@ -44677,22 +45085,26 @@
         "@types/retry": {
           "version": "0.12.1",
           "resolved": "https://registry.npmjs.org/@types/retry/-/retry-0.12.1.tgz",
-          "integrity": "sha512-xoDlM2S4ortawSWORYqsdU+2rxdh4LRW9ytc3zmT37RIKQh6IHyKwwtKhKis9ah8ol07DCkZxPt8BBvPjC6v4g=="
+          "integrity": "sha512-xoDlM2S4ortawSWORYqsdU+2rxdh4LRW9ytc3zmT37RIKQh6IHyKwwtKhKis9ah8ol07DCkZxPt8BBvPjC6v4g==",
+          "peer": true
         },
         "ansi-regex": {
           "version": "6.0.1",
           "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.0.1.tgz",
-          "integrity": "sha512-n5M855fKb2SsfMIiFFoVrABHJC8QtHwVx+mHWP3QcEqBHYienj5dHSgjbxtC0WEZXYt4wcD6zrQElDPhFuZgfA=="
+          "integrity": "sha512-n5M855fKb2SsfMIiFFoVrABHJC8QtHwVx+mHWP3QcEqBHYienj5dHSgjbxtC0WEZXYt4wcD6zrQElDPhFuZgfA==",
+          "peer": true
         },
         "ansi-styles": {
           "version": "6.2.1",
           "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.1.tgz",
-          "integrity": "sha512-bN798gFfQX+viw3R7yrGWRqnrN2oRkEkUjjl4JNn4E8GxxbjtG3FbrEIIY3l8/hrwUwIeCZvi4QuOTP4MErVug=="
+          "integrity": "sha512-bN798gFfQX+viw3R7yrGWRqnrN2oRkEkUjjl4JNn4E8GxxbjtG3FbrEIIY3l8/hrwUwIeCZvi4QuOTP4MErVug==",
+          "peer": true
         },
         "boxen": {
           "version": "7.0.1",
           "resolved": "https://registry.npmjs.org/boxen/-/boxen-7.0.1.tgz",
           "integrity": "sha512-8k2eH6SRAK00NDl1iX5q17RJ8rfl53TajdYxE3ssMLehbg487dEVgsad4pIsZb/QqBgYWIl6JOauMTLGX2Kpkw==",
+          "peer": true,
           "requires": {
             "ansi-align": "^3.0.1",
             "camelcase": "^7.0.0",
@@ -44707,22 +45119,26 @@
         "camelcase": {
           "version": "7.0.1",
           "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-7.0.1.tgz",
-          "integrity": "sha512-xlx1yCK2Oc1APsPXDL2LdlNP6+uu8OCDdhOBSVT279M/S+y75O30C2VuD8T2ogdePBBl7PfPF4504tnLgX3zfw=="
+          "integrity": "sha512-xlx1yCK2Oc1APsPXDL2LdlNP6+uu8OCDdhOBSVT279M/S+y75O30C2VuD8T2ogdePBBl7PfPF4504tnLgX3zfw==",
+          "peer": true
         },
         "chalk": {
           "version": "5.2.0",
           "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.2.0.tgz",
-          "integrity": "sha512-ree3Gqw/nazQAPuJJEy+avdl7QfZMcUvmHIKgEZkGL+xOBzRvup5Hxo6LHuMceSxOabuJLJm5Yp/92R9eMmMvA=="
+          "integrity": "sha512-ree3Gqw/nazQAPuJJEy+avdl7QfZMcUvmHIKgEZkGL+xOBzRvup5Hxo6LHuMceSxOabuJLJm5Yp/92R9eMmMvA==",
+          "peer": true
         },
         "cli-boxes": {
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/cli-boxes/-/cli-boxes-3.0.0.tgz",
-          "integrity": "sha512-/lzGpEWL/8PfI0BmBOPRwp0c/wFNX1RdUML3jK/RcSBA9T8mZDdQpqYBKtCFTOfQbwPqWEOpjqW+Fnayc0969g=="
+          "integrity": "sha512-/lzGpEWL/8PfI0BmBOPRwp0c/wFNX1RdUML3jK/RcSBA9T8mZDdQpqYBKtCFTOfQbwPqWEOpjqW+Fnayc0969g==",
+          "peer": true
         },
         "cross-spawn": {
           "version": "7.0.3",
           "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
           "integrity": "sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==",
+          "peer": true,
           "requires": {
             "path-key": "^3.1.0",
             "shebang-command": "^2.0.0",
@@ -44732,17 +45148,20 @@
         "data-uri-to-buffer": {
           "version": "4.0.1",
           "resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-4.0.1.tgz",
-          "integrity": "sha512-0R9ikRb668HB7QDxT1vkpuUBtqc53YyAwMwGeUFKRojY/NWKvdZ+9UYtRfGmhqNbRkTSVpMbmyhXipFFv2cb/A=="
+          "integrity": "sha512-0R9ikRb668HB7QDxT1vkpuUBtqc53YyAwMwGeUFKRojY/NWKvdZ+9UYtRfGmhqNbRkTSVpMbmyhXipFFv2cb/A==",
+          "peer": true
         },
         "emoji-regex": {
           "version": "9.2.2",
           "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-9.2.2.tgz",
-          "integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg=="
+          "integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==",
+          "peer": true
         },
         "execa": {
           "version": "6.1.0",
           "resolved": "https://registry.npmjs.org/execa/-/execa-6.1.0.tgz",
           "integrity": "sha512-QVWlX2e50heYJcCPG0iWtf8r0xjEYfz/OYLGDYH+IyjWezzPNxz63qNFOu0l4YftGWuizFVZHHs8PrLU5p2IDA==",
+          "peer": true,
           "requires": {
             "cross-spawn": "^7.0.3",
             "get-stream": "^6.0.1",
@@ -44759,6 +45178,7 @@
           "version": "11.1.0",
           "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.1.0.tgz",
           "integrity": "sha512-0rcTq621PD5jM/e0a3EJoGC/1TC5ZBCERW82LQuwfGnCa1V8w7dpYH1yNu+SLb6E5dkeCBzKEyLGlFrnr+dUyw==",
+          "peer": true,
           "requires": {
             "graceful-fs": "^4.2.0",
             "jsonfile": "^6.0.1",
@@ -44768,17 +45188,20 @@
         "human-signals": {
           "version": "3.0.1",
           "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-3.0.1.tgz",
-          "integrity": "sha512-rQLskxnM/5OCldHo+wNXbpVgDn5A17CUoKX+7Sokwaknlq7CdSnphy0W39GU8dw59XiCXmFXDg4fRuckQRKewQ=="
+          "integrity": "sha512-rQLskxnM/5OCldHo+wNXbpVgDn5A17CUoKX+7Sokwaknlq7CdSnphy0W39GU8dw59XiCXmFXDg4fRuckQRKewQ==",
+          "peer": true
         },
         "is-stream": {
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-3.0.0.tgz",
-          "integrity": "sha512-LnQR4bZ9IADDRSkvpqMGvt/tEJWclzklNgSw48V5EAaAeDd6qGvN8ei6k5p0tvxSR171VmGyHuTiAOfxAbr8kA=="
+          "integrity": "sha512-LnQR4bZ9IADDRSkvpqMGvt/tEJWclzklNgSw48V5EAaAeDd6qGvN8ei6k5p0tvxSR171VmGyHuTiAOfxAbr8kA==",
+          "peer": true
         },
         "is-wsl": {
           "version": "2.2.0",
           "resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-2.2.0.tgz",
           "integrity": "sha512-fKzAra0rGJUUBwGBgNkHZuToZcn+TtXHpeCgmkMJMMYx1sQDYaCSyjJBSCa2nH1DGm7s3n1oBnohoVTBaN7Lww==",
+          "peer": true,
           "requires": {
             "is-docker": "^2.0.0"
           }
@@ -44786,12 +45209,14 @@
         "mimic-fn": {
           "version": "4.0.0",
           "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-4.0.0.tgz",
-          "integrity": "sha512-vqiC06CuhBTUdZH+RYl8sFrL096vA45Ok5ISO6sE/Mr1jRbGH4Csnhi8f3wKVl7x8mO4Au7Ir9D3Oyv1VYMFJw=="
+          "integrity": "sha512-vqiC06CuhBTUdZH+RYl8sFrL096vA45Ok5ISO6sE/Mr1jRbGH4Csnhi8f3wKVl7x8mO4Au7Ir9D3Oyv1VYMFJw==",
+          "peer": true
         },
         "node-fetch": {
           "version": "3.3.0",
           "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-3.3.0.tgz",
           "integrity": "sha512-BKwRP/O0UvoMKp7GNdwPlObhYGB5DQqwhEDQlNKuoqwVYSxkSZCSbHjnFFmUEtwSKRPU4kNK8PbDYYitwaE3QA==",
+          "peer": true,
           "requires": {
             "data-uri-to-buffer": "^4.0.0",
             "fetch-blob": "^3.1.4",
@@ -44802,6 +45227,7 @@
           "version": "5.1.0",
           "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-5.1.0.tgz",
           "integrity": "sha512-sJOdmRGrY2sjNTRMbSvluQqg+8X7ZK61yvzBEIDhz4f8z1TZFYABsqjjCBd/0PUNE9M6QDgHJXQkGUEm7Q+l9Q==",
+          "peer": true,
           "requires": {
             "path-key": "^4.0.0"
           },
@@ -44809,7 +45235,8 @@
             "path-key": {
               "version": "4.0.0",
               "resolved": "https://registry.npmjs.org/path-key/-/path-key-4.0.0.tgz",
-              "integrity": "sha512-haREypq7xkM7ErfgIyA0z+Bj4AGKlMSdlQE2jvJo6huWD1EdkKYV+G/T4nq0YEF2vgTT8kqMFKo1uHn950r4SQ=="
+              "integrity": "sha512-haREypq7xkM7ErfgIyA0z+Bj4AGKlMSdlQE2jvJo6huWD1EdkKYV+G/T4nq0YEF2vgTT8kqMFKo1uHn950r4SQ==",
+              "peer": true
             }
           }
         },
@@ -44817,6 +45244,7 @@
           "version": "6.0.0",
           "resolved": "https://registry.npmjs.org/onetime/-/onetime-6.0.0.tgz",
           "integrity": "sha512-1FlR+gjXK7X+AsAHso35MnyN5KqGwJRi/31ft6x0M194ht7S+rWAvd7PHss9xSKMzE0asv1pyIHaJYq+BbacAQ==",
+          "peer": true,
           "requires": {
             "mimic-fn": "^4.0.0"
           }
@@ -44825,6 +45253,7 @@
           "version": "5.1.2",
           "resolved": "https://registry.npmjs.org/p-retry/-/p-retry-5.1.2.tgz",
           "integrity": "sha512-couX95waDu98NfNZV+i/iLt+fdVxmI7CbrrdC2uDWfPdUAApyxT4wmDlyOtR5KtTDmkDO0zDScDjDou9YHhd9g==",
+          "peer": true,
           "requires": {
             "@types/retry": "0.12.1",
             "retry": "^0.13.1"
@@ -44833,12 +45262,14 @@
         "retry": {
           "version": "0.13.1",
           "resolved": "https://registry.npmjs.org/retry/-/retry-0.13.1.tgz",
-          "integrity": "sha512-XQBQ3I8W1Cge0Seh+6gjj03LbmRFWuoszgK9ooCpwYIrhhoO80pfq4cUkU5DkknwfOfFteRwlZ56PYOGYyFWdg=="
+          "integrity": "sha512-XQBQ3I8W1Cge0Seh+6gjj03LbmRFWuoszgK9ooCpwYIrhhoO80pfq4cUkU5DkknwfOfFteRwlZ56PYOGYyFWdg==",
+          "peer": true
         },
         "shebang-command": {
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
           "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+          "peer": true,
           "requires": {
             "shebang-regex": "^3.0.0"
           }
@@ -44846,12 +45277,14 @@
         "shebang-regex": {
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
-          "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A=="
+          "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+          "peer": true
         },
         "string-width": {
           "version": "5.1.2",
           "resolved": "https://registry.npmjs.org/string-width/-/string-width-5.1.2.tgz",
           "integrity": "sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA==",
+          "peer": true,
           "requires": {
             "eastasianwidth": "^0.2.0",
             "emoji-regex": "^9.2.2",
@@ -44862,6 +45295,7 @@
           "version": "7.0.1",
           "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.0.1.tgz",
           "integrity": "sha512-cXNxvT8dFNRVfhVME3JAe98mkXDYN2O1l7jmcwMnOslDeESg1rF/OZMtK0nRAhiari1unG5cD4jG3rapUAkLbw==",
+          "peer": true,
           "requires": {
             "ansi-regex": "^6.0.1"
           }
@@ -44869,17 +45303,20 @@
         "strip-final-newline": {
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/strip-final-newline/-/strip-final-newline-3.0.0.tgz",
-          "integrity": "sha512-dOESqjYr96iWYylGObzd39EuNTa5VJxyvVAEm5Jnh7KGo75V43Hk1odPQkNDyXNmUR6k+gEiDVXnjB8HJ3crXw=="
+          "integrity": "sha512-dOESqjYr96iWYylGObzd39EuNTa5VJxyvVAEm5Jnh7KGo75V43Hk1odPQkNDyXNmUR6k+gEiDVXnjB8HJ3crXw==",
+          "peer": true
         },
         "type-fest": {
           "version": "2.19.0",
           "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-2.19.0.tgz",
-          "integrity": "sha512-RAH822pAdBgcNMAfWnCBU3CFZcfZ/i1eZjwFU/dsLKumyuuP3niueg2UAukXYF0E2AAoc82ZSSf9J0WQBinzHA=="
+          "integrity": "sha512-RAH822pAdBgcNMAfWnCBU3CFZcfZ/i1eZjwFU/dsLKumyuuP3niueg2UAukXYF0E2AAoc82ZSSf9J0WQBinzHA==",
+          "peer": true
         },
         "which": {
           "version": "2.0.2",
           "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
           "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+          "peer": true,
           "requires": {
             "isexe": "^2.0.0"
           }
@@ -44888,6 +45325,7 @@
           "version": "4.0.1",
           "resolved": "https://registry.npmjs.org/widest-line/-/widest-line-4.0.1.tgz",
           "integrity": "sha512-o0cyEG0e8GPzT4iGHphIOh0cJOV8fivsXxddQasHPHfoZf1ZexrfeA21w2NaEN1RHE+fXlfISmOE8R9N3u3Qig==",
+          "peer": true,
           "requires": {
             "string-width": "^5.0.1"
           }
@@ -44896,6 +45334,7 @@
           "version": "8.1.0",
           "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-8.1.0.tgz",
           "integrity": "sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ==",
+          "peer": true,
           "requires": {
             "ansi-styles": "^6.1.0",
             "string-width": "^5.0.1",
@@ -44906,6 +45345,7 @@
           "version": "8.12.0",
           "resolved": "https://registry.npmjs.org/ws/-/ws-8.12.0.tgz",
           "integrity": "sha512-kU62emKIdKVeEIOIKVegvqpXMSTAMLJozpHZaJNDYqBjzlSYXQGviYwN1osDLJ9av68qHd4a2oSjd7yD4pacig==",
+          "peer": true,
           "requires": {}
         }
       }
@@ -45111,6 +45551,7 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/sort-keys-length/-/sort-keys-length-1.0.1.tgz",
       "integrity": "sha512-GRbEOUqCxemTAk/b32F2xa8wDTs+Z1QHOkbhJDQTvv/6G3ZkbJ+frYWsTcc7cBB3Fu4wy4XlLCuNtJuMn7Gsvw==",
+      "peer": true,
       "requires": {
         "sort-keys": "^1.0.0"
       },
@@ -45119,6 +45560,7 @@
           "version": "1.1.2",
           "resolved": "https://registry.npmjs.org/sort-keys/-/sort-keys-1.1.2.tgz",
           "integrity": "sha512-vzn8aSqKgytVik0iwdBEi+zevbTYZogewTUM6dtpmGwEcdzbub/TX4bCzRhebDCRC3QzXgJsLRKB2V/Oof7HXg==",
+          "peer": true,
           "requires": {
             "is-plain-obj": "^1.0.0"
           }
@@ -45128,7 +45570,8 @@
     "sorted-array-functions": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/sorted-array-functions/-/sorted-array-functions-1.3.0.tgz",
-      "integrity": "sha512-2sqgzeFlid6N4Z2fUQ1cvFmTOLRi/sEDzSQ0OKYchqgoPmQBVyM3959qYx3fpS6Esef80KjmpgPeEr028dP3OA=="
+      "integrity": "sha512-2sqgzeFlid6N4Z2fUQ1cvFmTOLRi/sEDzSQ0OKYchqgoPmQBVyM3959qYx3fpS6Esef80KjmpgPeEr028dP3OA==",
+      "peer": true
     },
     "source-list-map": {
       "version": "2.0.1"
@@ -45223,6 +45666,7 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/sprintf-kit/-/sprintf-kit-2.0.1.tgz",
       "integrity": "sha512-2PNlcs3j5JflQKcg4wpdqpZ+AjhQJ2OZEo34NXDtlB0tIPG84xaaXhpA8XFacFiwjKA4m49UOYG83y3hbMn/gQ==",
+      "peer": true,
       "requires": {
         "es5-ext": "^0.10.53"
       }
@@ -45483,6 +45927,7 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/strip-dirs/-/strip-dirs-2.1.0.tgz",
       "integrity": "sha512-JOCxOeKLm2CAS73y/U4ZeZPTkE+gNVCzKt7Eox84Iej1LT/2pTWYpZKJuxwQpvX1LiZb1xokNR7RLfuBAa7T3g==",
+      "peer": true,
       "requires": {
         "is-natural-number": "^4.0.1"
       }
@@ -45504,6 +45949,7 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/strip-outer/-/strip-outer-1.0.1.tgz",
       "integrity": "sha512-k55yxKHwaXnpYGsOzg4Vl8+tDrWylxDEpknGjhTiZB8dFRU5rTo9CAzeycivxV3s+zlTKwrs6WxMxR95n26kwg==",
+      "peer": true,
       "requires": {
         "escape-string-regexp": "^1.0.2"
       },
@@ -45511,7 +45957,8 @@
         "escape-string-regexp": {
           "version": "1.0.5",
           "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-          "integrity": "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg=="
+          "integrity": "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==",
+          "peer": true
         }
       }
     },
@@ -45551,6 +45998,7 @@
       "version": "6.3.0",
       "resolved": "https://registry.npmjs.org/strtok3/-/strtok3-6.3.0.tgz",
       "integrity": "sha512-fZtbhtvI9I48xDSywd/somNqgUHl2L2cstmXCCif0itOf96jeW18MBSyrLuNicYQVkvpOxkZtkzujiTJ9LW5Jw==",
+      "peer": true,
       "requires": {
         "@tokenizer/token": "^0.3.0",
         "peek-readable": "^4.1.0"
@@ -45863,6 +46311,7 @@
       "version": "0.1.7",
       "resolved": "https://registry.npmjs.org/timers-ext/-/timers-ext-0.1.7.tgz",
       "integrity": "sha512-b85NUNzTSdodShTIbky6ZF02e8STtVVfD+fu4aXXShEELpozH+bCpJLYMPZbsABN2wDH7fJpqIoXxJpzbf0NqQ==",
+      "peer": true,
       "requires": {
         "es5-ext": "~0.10.46",
         "next-tick": "1"
@@ -45883,7 +46332,8 @@
     "to-buffer": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/to-buffer/-/to-buffer-1.1.1.tgz",
-      "integrity": "sha512-lx9B5iv7msuFYE3dytT+KE5tap+rNYw+K4jVkb9R/asAb+pbBSM17jtunHplhBe6RRJdZx3Pn2Jph24O32mOVg=="
+      "integrity": "sha512-lx9B5iv7msuFYE3dytT+KE5tap+rNYw+K4jVkb9R/asAb+pbBSM17jtunHplhBe6RRJdZx3Pn2Jph24O32mOVg==",
+      "peer": true
     },
     "to-fast-properties": {
       "version": "2.0.0"
@@ -45975,6 +46425,7 @@
       "version": "4.2.1",
       "resolved": "https://registry.npmjs.org/token-types/-/token-types-4.2.1.tgz",
       "integrity": "sha512-6udB24Q737UD/SDsKAHI9FCRP7Bqc9D/MQUV02ORQg5iskjtLJlZJNdN4kKtcdtwCeWIwIHDGaUsTsCCAa8sFQ==",
+      "peer": true,
       "requires": {
         "@tokenizer/token": "^0.3.0",
         "ieee754": "^1.2.1"
@@ -46027,6 +46478,7 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/trim-repeated/-/trim-repeated-1.0.0.tgz",
       "integrity": "sha512-pkonvlKk8/ZuR0D5tLW8ljt5I8kmxp2XKymhepUeOdCEfKpZaktSArkLHZt76OB1ZvO9bssUsDty4SWhLvZpLg==",
+      "peer": true,
       "requires": {
         "escape-string-regexp": "^1.0.2"
       },
@@ -46034,7 +46486,8 @@
         "escape-string-regexp": {
           "version": "1.0.5",
           "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-          "integrity": "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg=="
+          "integrity": "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==",
+          "peer": true
         }
       }
     },
@@ -46125,7 +46578,8 @@
     "type": {
       "version": "2.7.2",
       "resolved": "https://registry.npmjs.org/type/-/type-2.7.2.tgz",
-      "integrity": "sha512-dzlvlNlt6AXU7EBSfpAscydQ7gXB+pPGsPnfJnZpiNJBDj7IaJzQlBZYGdEi4R9HmPdBv2XmWJ6YUtoTa7lmCw=="
+      "integrity": "sha512-dzlvlNlt6AXU7EBSfpAscydQ7gXB+pPGsPnfJnZpiNJBDj7IaJzQlBZYGdEi4R9HmPdBv2XmWJ6YUtoTa7lmCw==",
+      "peer": true
     },
     "type-check": {
       "version": "0.4.0",
@@ -46210,6 +46664,7 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/uni-global/-/uni-global-1.0.0.tgz",
       "integrity": "sha512-WWM3HP+siTxzIWPNUg7hZ4XO8clKi6NoCAJJWnuRL+BAqyFXF8gC03WNyTefGoUXYc47uYgXxpKLIEvo65PEHw==",
+      "peer": true,
       "requires": {
         "type": "^2.5.0"
       }
@@ -46442,6 +46897,7 @@
       "version": "2.0.6",
       "resolved": "https://registry.npmjs.org/velocityjs/-/velocityjs-2.0.6.tgz",
       "integrity": "sha512-QMYLeYLBX6eqekCin3OPmDAHapaUx3foNFE264ml1/yxRZ8TUUlI1+u6rtN4E8tKNqwzpRPeNgJtjLbgRNK4fw==",
+      "peer": true,
       "requires": {
         "debug": "^4.3.3"
       }
@@ -46769,6 +47225,7 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/wcwidth/-/wcwidth-1.0.1.tgz",
       "integrity": "sha512-XHPEwS0q6TaxcvG85+8EYkbiCux2XtWG2mkc47Ng2A77BQu9+DqIOJldST4HgPkuea7dvKSj5VgX3P1d4rW8Tg==",
+      "peer": true,
       "requires": {
         "defaults": "^1.0.3"
       }
@@ -46776,7 +47233,8 @@
     "web-streams-polyfill": {
       "version": "3.2.1",
       "resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-3.2.1.tgz",
-      "integrity": "sha512-e0MO3wdXWKrLbL0DgGnUV7WHVuw9OUvL4hjgnPkIeEvESk74gAITi5G606JtZPp39cd8HA9VQzCIvA49LpPN5Q=="
+      "integrity": "sha512-e0MO3wdXWKrLbL0DgGnUV7WHVuw9OUvL4hjgnPkIeEvESk74gAITi5G606JtZPp39cd8HA9VQzCIvA49LpPN5Q==",
+      "peer": true
     },
     "webdriver": {
       "version": "5.23.0",
@@ -47337,6 +47795,11 @@
         "compress-commons": "^2.1.1",
         "readable-stream": "^3.4.0"
       }
+    },
+    "zod": {
+      "version": "3.20.6",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.20.6.tgz",
+      "integrity": "sha512-oyu0m54SGCtzh6EClBVqDDlAYRz4jrVtKwQ7ZnsEmMI9HnzuZFj8QFwAY1M5uniIYACdGvv0PBWPF2kO0aNofA=="
     }
   }
 }

--- a/plugins/eslint/.toolkitrc.yml
+++ b/plugins/eslint/.toolkitrc.yml
@@ -2,7 +2,3 @@ hooks:
   'test:local': Eslint
   'test:ci': Eslint
   'test:staged': Eslint
-
-options:
-  '@dotcom-tool-kit/eslint':
-    files: '**/*.js'

--- a/plugins/eslint/src/tasks/eslint.ts
+++ b/plugins/eslint/src/tasks/eslint.ts
@@ -1,15 +1,11 @@
 import { ToolKitError } from '@dotcom-tool-kit/error'
 import { styles } from '@dotcom-tool-kit/logger'
 import { Task } from '@dotcom-tool-kit/types'
-import { ESLintOptions, ESLintSchema } from '@dotcom-tool-kit/types/lib/schema/eslint'
+import { ESLintSchema } from '@dotcom-tool-kit/types/lib/schema/eslint'
 import { ESLint } from 'eslint'
 
 export default class Eslint extends Task<typeof ESLintSchema> {
   static description = ''
-
-  static defaultOptions: ESLintOptions = {
-    files: ['**/*.js']
-  }
 
   async run(files?: string[]): Promise<void> {
     const eslint = new ESLint(this.options.options)

--- a/plugins/heroku/src/tasks/production.ts
+++ b/plugins/heroku/src/tasks/production.ts
@@ -22,23 +22,6 @@ export default class HerokuProduction extends Task<typeof HerokuSchema> {
 
       const { scaling } = this.options
 
-      if (!scaling) {
-        const error = new ToolKitError('your heroku pipeline must have its scaling configured')
-        error.details = `configure it in your ${styles.filepath(
-          '.toolkitrc.yml'
-        )}, with a quantity and size for each production app, e.g.:
-
-options:
-  '@dotcom-tool-kit/heroku':
-    scaling:
-      ft-next-static-eu:
-        web:
-          size: standard-1x
-          quantity: 2`
-
-        throw error
-      }
-
       const scale = async () => {
         for (const [appName, typeConfig] of Object.entries(scaling)) {
           this.logger.verbose(`scaling app ${styles.app(appName)}...`)

--- a/plugins/heroku/src/tasks/review.ts
+++ b/plugins/heroku/src/tasks/review.ts
@@ -1,4 +1,3 @@
-import { styles } from '@dotcom-tool-kit/logger'
 import { Task } from '@dotcom-tool-kit/types'
 import { getHerokuReviewApp } from '../getHerokuReviewApp'
 import { buildHerokuReviewApp } from '../buildHerokuReviewApp'
@@ -15,21 +14,8 @@ export default class HerokuReview extends Task<typeof HerokuSchema> {
 
   async run(): Promise<void> {
     try {
-      if (!this.options.pipeline) {
-        const error = new ToolKitError('no pipeline option in your Tool Kit configuration')
-        error.details = `the ${styles.plugin(
-          'Heroku'
-        )} plugin needs to know your pipeline name to deploy Review Apps. add it to your configuration, e.g.:
-
-options:
-  '@dotcom-tool-kit/heroku':
-    pipeline: your-heroku-pipeline`
-
-        throw error
-      }
-
       const pipeline: HerokuApiResPipeline = await herokuClient.get(`/pipelines/${this.options.pipeline}`)
-      
+
       await setStageConfigVars(this.logger, 'review', 'production', pipeline.id)
 
       let reviewAppId = await getHerokuReviewApp(this.logger, pipeline.id)

--- a/plugins/heroku/src/tasks/staging.ts
+++ b/plugins/heroku/src/tasks/staging.ts
@@ -1,6 +1,5 @@
 import { Task } from '@dotcom-tool-kit/types'
 import { ToolKitError } from '@dotcom-tool-kit/error'
-import { styles } from '@dotcom-tool-kit/logger'
 import { getHerokuStagingApp } from '../getHerokuStagingApp'
 import { setAppConfigVars } from '../setConfigVars'
 import { createBuild } from '../createBuild'
@@ -16,20 +15,6 @@ export default class HerokuStaging extends Task<typeof HerokuSchema> {
 
   async run(): Promise<void> {
     try {
-      if (!this.options.pipeline || !this.options.systemCode) {
-        const error = new ToolKitError('no pipeline and/or system code option in your Tool Kit configuration')
-        error.details = `the ${styles.plugin(
-          'Heroku'
-        )} plugin needs to know your pipeline name and Biz Ops' system code to deploy staging. add it to your configuration, e.g.:
-
-options:
-  '@dotcom-tool-kit/heroku':
-    pipeline: your-heroku-pipeline
-    systemCode: your-system-code`
-
-        throw error
-      }
-
       this.logger.verbose(`retrieving pipeline details...`)
       await getPipelineCouplings(this.logger, this.options.pipeline)
 
@@ -45,7 +30,7 @@ options:
       // wait for build to complete
       if (buildDetails.slug === null) {
         const id = await repeatedCheckForBuildSuccess(this.logger, appName, buildDetails.id)
-        buildDetails.slug = {id}
+        buildDetails.slug = { id }
       }
 
       // apply build

--- a/plugins/jest/tests/jest-plugin.test.ts
+++ b/plugins/jest/tests/jest-plugin.test.ts
@@ -30,7 +30,7 @@ describe('jest plugin', () => {
     })
 
     it('should call jest cli without configPath by default', async () => {
-      const jestLocal = new JestLocal(logger)
+      const jestLocal = new JestLocal(logger, {})
       await jestLocal.run()
 
       expect(fork).toBeCalledWith(expect.any(String), ['--colors', '', ''], { silent: true })
@@ -48,7 +48,7 @@ describe('jest plugin', () => {
     })
 
     it('should call jest cli without configPath by default', async () => {
-      const jestCI = new JestCI(logger)
+      const jestCI = new JestCI(logger, {})
       await jestCI.run()
 
       expect(fork).toBeCalledWith(expect.any(String), ['--colors', '--ci', ''], { silent: true })

--- a/plugins/mocha/.toolkitrc.yml
+++ b/plugins/mocha/.toolkitrc.yml
@@ -1,7 +1,3 @@
 hooks:
   'test:local': Mocha
   'test:ci': Mocha
-
-options:
-  '@dotcom-tool-kit/mocha':
-    files: 'test/**/*.js'

--- a/plugins/mocha/src/tasks/mocha.ts
+++ b/plugins/mocha/src/tasks/mocha.ts
@@ -1,17 +1,13 @@
 import { hookFork, waitOnExit } from '@dotcom-tool-kit/logger'
 import { Task } from '@dotcom-tool-kit/types'
 import { glob } from 'glob'
-import { MochaOptions, MochaSchema } from '@dotcom-tool-kit/types/lib/schema/mocha'
+import { MochaSchema } from '@dotcom-tool-kit/types/lib/schema/mocha'
 import { fork } from 'child_process'
 import { promisify } from 'util'
 const mochaCLIPath = require.resolve('mocha/bin/mocha')
 
 export default class Mocha extends Task<typeof MochaSchema> {
   static description = ''
-
-  static defaultOptions: MochaOptions = {
-    files: 'test/**/*.js'
-  }
 
   async run(): Promise<void> {
     const files = await promisify(glob)(this.options.files)

--- a/plugins/next-router/src/tasks/next-router.ts
+++ b/plugins/next-router/src/tasks/next-router.ts
@@ -11,19 +11,6 @@ export default class NextRouter extends Task<typeof NextRouterSchema> {
   static description = ''
 
   async run(): Promise<void> {
-    if (!this.options.appName) {
-      const error = new ToolKitError('your app name must be configured to use next-router')
-      error.details = `this should be the same as its "name" field in next-service-registry. configure it in your ${styles.filepath(
-        '.toolkitrc.yml'
-      )}, e.g.:
-
-options:
-  '@dotcom-tool-kit/next-router':
-    appName: article`
-
-      throw error
-    }
-
     const vault = new VaultEnvVars(this.logger, {
       environment: 'development',
       vaultPath: {

--- a/plugins/node/src/tasks/node.ts
+++ b/plugins/node/src/tasks/node.ts
@@ -1,5 +1,5 @@
 import { Task } from '@dotcom-tool-kit/types'
-import { NodeOptions, NodeSchema } from '@dotcom-tool-kit/types/lib/schema/node'
+import { NodeSchema } from '@dotcom-tool-kit/types/lib/schema/node'
 import { ToolKitError } from '@dotcom-tool-kit/error'
 import { fork } from 'child_process'
 import { VaultEnvVars } from '@dotcom-tool-kit/vault'
@@ -10,12 +10,6 @@ import waitPort from 'wait-port'
 
 export default class Node extends Task<typeof NodeSchema> {
   static description = ''
-
-  static defaultOptions: NodeOptions = {
-    entry: './server/app.js',
-    useVault: true,
-    ports: [3001, 3002, 3003]
-  }
 
   async run(): Promise<void> {
     const { entry, args, useVault, ports } = this.options

--- a/plugins/nodemon/src/tasks/nodemon.ts
+++ b/plugins/nodemon/src/tasks/nodemon.ts
@@ -1,5 +1,4 @@
-import { ToolKitError } from '@dotcom-tool-kit/error'
-import { hookFork, styles } from '@dotcom-tool-kit/logger'
+import { hookFork } from '@dotcom-tool-kit/logger'
 import { Task } from '@dotcom-tool-kit/types'
 import { NodemonSchema } from '@dotcom-tool-kit/types/lib/schema/nodemon'
 import { writeState } from '@dotcom-tool-kit/state'
@@ -29,14 +28,6 @@ export default class Nodemon extends Task<typeof NodemonSchema> {
       (await getPort({
         port: ports
       }))
-
-    if (!entry) {
-      const error = new ToolKitError(
-        `the ${styles.task('Nodemon')} task requires an ${styles.option('entry')} option`
-      )
-      error.details = `this is the entrypoint for your app, e.g. ${styles.filepath('server/app.js')}`
-      throw error
-    }
 
     this.logger.verbose('starting the child nodemon process...')
 

--- a/plugins/nodemon/src/tasks/nodemon.ts
+++ b/plugins/nodemon/src/tasks/nodemon.ts
@@ -1,7 +1,7 @@
 import { ToolKitError } from '@dotcom-tool-kit/error'
 import { hookFork, styles } from '@dotcom-tool-kit/logger'
 import { Task } from '@dotcom-tool-kit/types'
-import { NodemonOptions, NodemonSchema } from '@dotcom-tool-kit/types/lib/schema/nodemon'
+import { NodemonSchema } from '@dotcom-tool-kit/types/lib/schema/nodemon'
 import { writeState } from '@dotcom-tool-kit/state'
 import { VaultEnvVars } from '@dotcom-tool-kit/vault'
 import getPort from 'get-port'
@@ -10,12 +10,6 @@ import { Readable } from 'stream'
 
 export default class Nodemon extends Task<typeof NodemonSchema> {
   static description = ''
-
-  static defaultOptions: NodemonOptions = {
-    entry: './server/app.js',
-    useVault: true,
-    ports: [3001, 3002, 3003]
-  }
 
   async run(): Promise<void> {
     const { entry, configPath, useVault, ports } = this.options

--- a/plugins/pa11y/test/pa11y.test.ts
+++ b/plugins/pa11y/test/pa11y.test.ts
@@ -24,7 +24,7 @@ describe('pa11y', () => {
   it("sets process.env.TEST_URL if readState('review') is truthy", async () => {
     jest.mocked(state.readState).mockReturnValue({ appName } as state.ReviewState)
 
-    const pa11y = new Pa11y(logger)
+    const pa11y = new Pa11y(logger, {})
     await pa11y.run()
 
     expect(process.env.TEST_URL).toBe(`https://${appName}.herokuapp.com`)

--- a/plugins/prettier/src/tasks/prettier.ts
+++ b/plugins/prettier/src/tasks/prettier.ts
@@ -9,18 +9,6 @@ import { ToolKitError } from '@dotcom-tool-kit/error'
 export default class Prettier extends Task<typeof PrettierSchema> {
   static description = ''
 
-  static defaultOptions: PrettierOptions = {
-    files: ['**/*.{js,jsx,ts,tsx}'],
-    ignoreFile: '.prettierignore',
-    configOptions: {
-      singleQuote: true,
-      useTabs: true,
-      bracketSpacing: true,
-      arrowParens: 'always',
-      trailingComma: 'none'
-    }
-  }
-
   async run(files?: string[]): Promise<void> {
     try {
       const filepaths = await fg(files ?? this.options.files)

--- a/plugins/prettier/test/tasks/prettier.test.ts
+++ b/plugins/prettier/test/tasks/prettier.test.ts
@@ -8,6 +8,14 @@ const logger = (winston as unknown) as Logger
 
 const testDirectory = path.join(__dirname, '../files')
 
+const defaultConfig = {
+  singleQuote: true,
+  useTabs: true,
+  bracketSpacing: true,
+  arrowParens: 'always',
+  trailingComma: 'none'
+}
+
 describe('prettier', () => {
   let unformattedFixture: string
   let formattedDefaultFixture: string
@@ -37,7 +45,8 @@ describe('prettier', () => {
   it('should format the correct file with default configOptions', async () => {
     const task = new Prettier(logger, {
       files: [path.join(testDirectory, 'unformatted.ts')],
-      ignoreFile: 'nonexistent prettierignore'
+      ignoreFile: 'nonexistent prettierignore',
+      configOptions: defaultConfig
     })
     await task.run()
     const prettified = await fsp.readFile(path.join(testDirectory, 'unformatted.ts'), 'utf8')
@@ -49,7 +58,8 @@ describe('prettier', () => {
     const task = new Prettier(logger, {
       files: [path.join(testDirectory, 'unformatted.ts')],
       configFile: path.join(__dirname, '../.prettierrc-test.json'),
-      ignoreFile: 'nonexistent prettierignore'
+      ignoreFile: 'nonexistent prettierignore',
+      configOptions: defaultConfig
     })
     await task.run()
     const prettified = await fsp.readFile(path.join(testDirectory, 'unformatted.ts'), 'utf8')
@@ -73,18 +83,5 @@ describe('prettier', () => {
     await task.run()
     const prettified = await fsp.readFile(path.join(testDirectory, 'unformatted.ts'), 'utf8')
     expect(prettified).toEqual(formattedConfigOptionsFixture)
-  })
-
-  it('should use .prettierignore as ignorefile by default', async () => {
-    const task = new Prettier(logger, {
-      files: [path.join(testDirectory, 'unformatted.ts')]
-    })
-
-    await task.run()
-    const prettified = await fsp.readFile(path.join(testDirectory, 'unformatted.ts'), 'utf8')
-
-    // .prettierignore in the dotcom-tool-kit root includes the prettier fixtures,
-    // so using that ignore file we'd expect this file not to get formatted
-    expect(prettified).toEqual(unformattedFixture)
   })
 })

--- a/plugins/serverless/src/tasks/run.ts
+++ b/plugins/serverless/src/tasks/run.ts
@@ -1,5 +1,5 @@
 import { Task } from '@dotcom-tool-kit/types'
-import { ServerlessOptions, ServerlessSchema } from '@dotcom-tool-kit/types/lib/schema/serverless'
+import { ServerlessSchema } from '@dotcom-tool-kit/types/lib/schema/serverless'
 import { spawn } from 'child_process'
 import { VaultEnvVars } from '@dotcom-tool-kit/vault'
 import { hookConsole, hookFork } from '@dotcom-tool-kit/logger'
@@ -8,11 +8,6 @@ import waitPort from 'wait-port'
 
 export default class ServerlessRun extends Task<typeof ServerlessSchema> {
   static description = 'Run serverless functions locally'
-
-  static defaultOptions: ServerlessOptions = {
-    useVault: true,
-    ports: [3001, 3002, 3003]
-  }
 
   async run(): Promise<void> {
     const { useVault, ports, configPath } = this.options

--- a/plugins/upload-assets-to-s3/.toolkitrc.yml
+++ b/plugins/upload-assets-to-s3/.toolkitrc.yml
@@ -1,10 +1,2 @@
 hooks:
   'release:remote': UploadAssetsToS3
-
-options:
-  '@dotcom-tool-kit/upload-static-assets':
-    directory: 'public'
-    bucket: 'ft-next-hashed-assets-prod'
-    destination: 'hashed-assets/uploaded'
-    extensions: 'js,css,map,gz,br,png,jpg,jpeg,gif,webp,svg,ico,json'
-    cacheControl: 'public, max-age=31536000, stale-while-revalidate=60, stale-if-error=3600'

--- a/plugins/upload-assets-to-s3/src/tasks/upload-assets-to-s3.ts
+++ b/plugins/upload-assets-to-s3/src/tasks/upload-assets-to-s3.ts
@@ -14,18 +14,6 @@ import {
 export default class UploadAssetsToS3 extends Task<typeof UploadAssetsToS3Schema> {
   static description = ''
 
-  static defaultOptions: UploadAssetsToS3Options = {
-    accessKeyId: 'aws_access_hashed_assets',
-    secretAccessKey: 'aws_secret_hashed_assets',
-    directory: 'public',
-    reviewBucket: ['ft-next-hashed-assets-preview'],
-    prodBucket: ['ft-next-hashed-assets-prod'],
-    region: 'eu-west-1',
-    destination: 'hashed-assets/page-kit',
-    extensions: 'js,css,map,gz,br,png,jpg,jpeg,gif,webp,svg,ico,json',
-    cacheControl: 'public, max-age=31536000, stale-while-revalidate=60, stale-if-error=3600'
-  }
-
   async run(): Promise<void> {
     await this.uploadAssetsToS3(this.options)
   }
@@ -94,10 +82,10 @@ export default class UploadAssetsToS3 extends Task<typeof UploadAssetsToS3Schema
       credentials: {
         accessKeyId:
           /* eslint-disable-next-line */
-          process.env[options.accessKeyIdEnvVar ?? options.accessKeyId!]!,
+          process.env[options.accessKeyIdEnvVar ?? options.accessKeyId]!,
         secretAccessKey:
           /* eslint-disable-next-line */
-          process.env[options.secretAccessKeyEnvVar ?? options.secretAccessKey!]!
+          process.env[options.secretAccessKeyEnvVar ?? options.secretAccessKey]!
       }
     })
 

--- a/plugins/upload-assets-to-s3/test/tasks/upload-assets-to-s3.test.ts
+++ b/plugins/upload-assets-to-s3/test/tasks/upload-assets-to-s3.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, beforeAll } from '@jest/globals'
 import { S3Client, PutObjectCommand } from '@aws-sdk/client-s3'
+import { UploadAssetsToS3Options } from '@dotcom-tool-kit/types/lib/schema/upload-assets-to-s3'
 import * as path from 'path'
 import winston, { Logger } from 'winston'
 import UploadAssetsToS3 from '../../src/tasks/upload-assets-to-s3'
@@ -11,6 +12,18 @@ const logger = (winston as unknown) as Logger
 
 const testDirectory = path.join(__dirname, '../files')
 
+const defaults: UploadAssetsToS3Options = {
+  accessKeyId: 'aws_access_hashed_assets',
+  secretAccessKey: 'aws_secret_hashed_assets',
+  directory: 'public',
+  reviewBucket: ['ft-next-hashed-assets-preview'],
+  prodBucket: ['ft-next-hashed-assets-prod'],
+  region: 'eu-west-1',
+  destination: 'hashed-assets/page-kit',
+  extensions: 'js,css,map,gz,br,png,jpg,jpeg,gif,webp,svg,ico,json',
+  cacheControl: 'public, max-age=31536000, stale-while-revalidate=60, stale-if-error=3600'
+}
+
 describe('upload-assets-to-s3', () => {
   beforeAll(() => {
     mockedS3Client.prototype.send.mockReturnValue({
@@ -20,6 +33,7 @@ describe('upload-assets-to-s3', () => {
 
   it('should upload all globbed files for review', async () => {
     const task = new UploadAssetsToS3(logger, {
+      ...defaults,
       directory: testDirectory
     })
     process.env.NODE_ENV = 'branch'
@@ -32,6 +46,7 @@ describe('upload-assets-to-s3', () => {
 
   it('should upload all globbed files for prod', async () => {
     const task = new UploadAssetsToS3(logger, {
+      ...defaults,
       directory: testDirectory
     })
     process.env.NODE_ENV = 'production'
@@ -44,6 +59,7 @@ describe('upload-assets-to-s3', () => {
 
   it('should strip base path from S3 key', async () => {
     const task = new UploadAssetsToS3(logger, {
+      ...defaults,
       extensions: 'gz',
       directory: testDirectory,
       destination: 'testdir'
@@ -58,6 +74,7 @@ describe('upload-assets-to-s3', () => {
 
   it('should use correct Content-Encoding for compressed files', async () => {
     const task = new UploadAssetsToS3(logger, {
+      ...defaults,
       extensions: 'gz',
       directory: testDirectory
     })
@@ -77,6 +94,7 @@ describe('upload-assets-to-s3', () => {
     ;(mockedS3Client.prototype.send as any).mockRejectedValue(new Error(mockError))
 
     const task = new UploadAssetsToS3(logger, {
+      ...defaults,
       directory: testDirectory
     })
 


### PR DESCRIPTION
# Description

I've been working on moving Tool Kit to use Zod over the last few 10% days. This is the result! [zod](https://zod.dev) is a schema library that I am now using to parse and validate the options that users set in Tool Kit config files. The features that Zod provides us are

1. validation of options that are passed – we're currently assuming that any options are of the correct type and that they exist if they are required which can lead to confusing errors if these assumptions are false. we'd sometimes try and work around this by checking that options were defined in a Task's `run()` method, even though the type wasn't given as `undefined`. this was easy to forget and created a lot of boilerplate code to give helpful error messages that can now be generated automatically from Zod errors via [`zod-validation-errors`](https://github.com/causaly/zod-validation-error).
2. standardising the way we specify object schemas – we previously supported the specification of options using a custom DSL declared via string literals. these strings would then be converted to TypeScript types using a special conditional mapping type which was fun to write but was inscrutable and inextensible. zod's schema definitions, on the other hand uses classes constructed via simple function calls that are well specified in their API and mirror TypeScript's type system. it also allows us to define more complex option types, like the [nested object used to specify Heroku pipelines](https://github.com/Financial-Times/dotcom-tool-kit/pull/354/files#diff-a6a41016c972b91e7774358c85a44aa966e6dff999deca90ea8b5638214e82d9R4-R11).
3. handling of default options – Zod [allows default values to be specified](https://zod.dev/?id=default) when options are undefined in the configuration. this allows us to remove the `defaultOptions` static field from tasks which was previously separated from the schema specification itself. this separation meant that even though a option might be optional in the schema, it would always be defined in reality if it had a value specified in `defaultOptions` and thus null assertions (`!`) would be required. we can now also get the default values for schemas and print them when users are being guided through options configuration in the `@dotcom-tool-kit/create` script.

These changes shouldn't be breaking, as we already assumed that the options in a configuration file were well-formed.

# Checklist:

- [x] My branch has been rebased onto the latest commit on main (don't merge main into your branch)
- [x] My commit messages are [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/), for example: `feat(circleci): add support for nightly workflows`, `fix: set Heroku app name for staging apps too`
