### PR TITLE
fix: tidy up references in tsconfig files

### DIFF
--- a/plugins/circleci-deploy/tsconfig.json
+++ b/plugins/circleci-deploy/tsconfig.json
@@ -9,6 +9,9 @@
       "path": "../../lib/types"
     },
     {
+      "path": "../../lib/options"
+    },
+    {
       "path": "../circleci"
     }
   ],

--- a/plugins/cypress/tsconfig.json
+++ b/plugins/cypress/tsconfig.json
@@ -7,6 +7,12 @@
   "references": [
     {
       "path": "../../lib/types"
+    },
+    {
+      "path": "../../lib/logger"
+    },
+    {
+      "path": "../../lib/state"
     }
   ],
   "include": ["src/**/*"]

--- a/plugins/lint-staged/tsconfig.json
+++ b/plugins/lint-staged/tsconfig.json
@@ -10,9 +10,10 @@
     },
     {
       "path": "../../lib/logger"
+    },
+    {
+      "path": "../../lib/error"
     }
   ],
-  "include": [
-    "src/**/*"
-  ]
+  "include": ["src/**/*"]
 }

--- a/plugins/mocha/tsconfig.json
+++ b/plugins/mocha/tsconfig.json
@@ -2,9 +2,6 @@
   "extends": "../../tsconfig.settings.json",
   "references": [
     {
-      "path": "../../lib/error"
-    },
-    {
       "path": "../../lib/logger"
     },
     {

--- a/plugins/node/tsconfig.json
+++ b/plugins/node/tsconfig.json
@@ -15,7 +15,10 @@
       "path": "../../lib/logger"
     },
     {
-      "path": "../../lib/options"
+      "path": "../../lib/vault"
+    },
+    {
+      "path": "../../lib/state"
     }
   ],
   "include": ["src/**/*"]

--- a/plugins/pa11y/tsconfig.json
+++ b/plugins/pa11y/tsconfig.json
@@ -8,6 +8,12 @@
   "references": [
     {
       "path": "../../lib/types"
+    },
+    {
+      "path": "../../lib/logger"
+    },
+    {
+      "path": "../../lib/error"
     }
   ],
   "include": ["src/**/*"]

--- a/plugins/secret-squirrel/tsconfig.json
+++ b/plugins/secret-squirrel/tsconfig.json
@@ -7,6 +7,9 @@
   "references": [
     {
       "path": "../../lib/types"
+    },
+    {
+      "path": "../../lib/logger"
     }
   ],
   "include": ["src/**/*"]

--- a/plugins/webpack/tsconfig.json
+++ b/plugins/webpack/tsconfig.json
@@ -7,9 +7,6 @@
   },
   "references": [
     {
-      "path": "../../lib/error"
-    },
-    {
       "path": "../../lib/logger"
     },
     {


### PR DESCRIPTION
# Description
We noticed in a previous PR that the references in the `tsconfig` files in some plugins were out of date. This tides them up.

# Checklist:

- [x] My branch has been rebased onto the latest commit on main (don't merge main into your branch)
- [x] My commit messages are [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/), for example: `feat(circleci): add support for nightly workflows`, `fix: set Heroku app name for staging apps too`
