### PR TITLE
CPP-1053 Add ServerlessProvision task with OIDC token support

### DIFF
--- a/lib/types/src/circleci.ts
+++ b/lib/types/src/circleci.ts
@@ -7,6 +7,7 @@ export type JobConfig = {
   requires?: string[]
   filters?: { branches?: { only?: string; ignore?: string }; tags?: { only?: string } }
   executor?: string
+  [parameter: string]: unknown
 }
 
 type TriggerConfig = {

--- a/lib/types/src/schema.ts
+++ b/lib/types/src/schema.ts
@@ -39,6 +39,7 @@ import { NodeSchema } from './schema/node'
 import { NodemonSchema } from './schema/nodemon'
 import { Pa11ySchema } from './schema/pa11y'
 import { PrettierSchema } from './schema/prettier'
+import { ServerlessSchema } from './schema/serverless'
 import { TypeScriptSchema } from './schema/typescript'
 import { UploadAssetsToS3Schema } from './schema/upload-assets-to-s3'
 import { VaultSchema } from './schema/vault'
@@ -59,6 +60,7 @@ export const Schemas = {
   '@dotcom-tool-kit/nodemon': NodemonSchema,
   '@dotcom-tool-kit/pa11y': Pa11ySchema,
   '@dotcom-tool-kit/prettier': PrettierSchema,
+  '@dotcom-tool-kit/serverless': ServerlessSchema,
   '@dotcom-tool-kit/typescript': TypeScriptSchema,
   '@dotcom-tool-kit/upload-assets-to-s3': UploadAssetsToS3Schema,
   '@dotcom-tool-kit/vault': VaultSchema,

--- a/lib/types/src/schema/serverless.ts
+++ b/lib/types/src/schema/serverless.ts
@@ -1,9 +1,13 @@
 import { z } from 'zod'
 
 export const ServerlessSchema = z.object({
+  awsAccountId: z.string(),
+  systemCode: z.string(),
+  region: z.string(),
   configPath: z.string().optional(),
   useVault: z.boolean().default(true),
-  ports: z.number().array().default([3001, 3002, 3003])
+  ports: z.number().array().default([3001, 3002, 3003]),
+  buildNumVariable: z.string().default("CIRCLE_BUILD_NUM")
 })
 export type ServerlessOptions = z.infer<typeof ServerlessSchema>
 

--- a/orb/src/@orb.yml
+++ b/orb/src/@orb.yml
@@ -13,3 +13,5 @@ display:
 orbs:
   node: circleci/node@5.0.2
   change-api: financial-times/change-api@1.0.1
+  aws-cli: circleci/aws-cli@3.1.4
+  serverless-framework: circleci/serverless-framework@2.0.1

--- a/orb/src/commands/serverless-assume-role.yml
+++ b/orb/src/commands/serverless-assume-role.yml
@@ -1,0 +1,16 @@
+description: >
+  Assume AWS role configured to use a CircleCI OIDC token to allow you to
+  deploy the project via Serverless
+
+parameters:
+  aws-account-id:
+    type: string
+  system-code:
+    type: string
+
+steps:
+  - aws-cli/setup:
+      role-arn: arn:aws:iam::<< parameters.aws-account-id >>:role/CircleCI-role-<< parameters.system-code >>
+      role-session-name: CircleCI-role-<< parameters.system-code >>
+      profile-name: CircleCI-role-<< parameters.system-code >>
+  - serverless-framework/setup

--- a/orb/src/jobs/heroku-provision.yml
+++ b/orb/src/jobs/heroku-provision.yml
@@ -2,11 +2,26 @@ parameters:
   executor:
     default: default
     type: executor
+  aws-account-id:
+    default: ''
+    type: string
+  system-code:
+    default: ''
+    type: string
 
 executor: << parameters.executor >>
 
 steps:
   - attach-workspace
+  - when:
+      condition:
+        and:
+          - << parameters.aws-account-id >>
+          - << parameters.system-code >>
+      steps:
+        - serverless-assume-role:
+            aws-account-id: << parameters.aws-account-id >>
+            system-code: << parameters.system-code >>
   - run:
       name: Create and test Heroku review app
       command: npx dotcom-tool-kit deploy:review

--- a/package-lock.json
+++ b/package-lock.json
@@ -39205,7 +39205,7 @@
       "version": "13.13.0",
       "dev": true,
       "requires": {
-        "type-fest": "^0.20.2"
+        "type-fest": "3.6.0"
       }
     },
     "globalthis": {
@@ -41519,7 +41519,7 @@
         "read-pkg-up": "^7.0.1",
         "redent": "^3.0.0",
         "trim-newlines": "^3.0.0",
-        "type-fest": "^0.18.0",
+        "type-fest": "3.6.0",
         "yargs-parser": "^20.2.3"
       },
       "dependencies": {
@@ -44053,7 +44053,7 @@
       "requires": {
         "find-up": "^4.1.0",
         "read-pkg": "^5.2.0",
-        "type-fest": "^0.8.1"
+        "type-fest": "3.6.0"
       },
       "dependencies": {
         "find-up": {
@@ -44296,7 +44296,7 @@
         "node-html-parser": "^6.0.0",
         "parse-github-repo-url": "^1.4.1",
         "semver": "^7.0.0",
-        "type-fest": "^3.0.0",
+        "type-fest": "3.6.0",
         "typescript": "^4.6.4",
         "unist-util-visit": "^2.0.3",
         "unist-util-visit-parents": "^3.1.1",
@@ -44384,8 +44384,7 @@
           }
         },
         "type-fest": {
-          "version": "3.4.0",
-          "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-3.4.0.tgz",
+          "version": "https://registry.npmjs.org/type-fest/-/type-fest-3.4.0.tgz",
           "integrity": "sha512-PEPg6RHlB9cFwoTMNENNrQFL0cXX04voWr2UPwQBJ3pVs7Mt8Y1oLWdUeMdGEwZE8HFFlujq8gS9enmyiQ8pLg==",
           "dev": true
         }

--- a/package-lock.json
+++ b/package-lock.json
@@ -26763,6 +26763,9 @@
         "@dotcom-tool-kit/circleci": "^3.0.2",
         "tslib": "^2.3.1"
       },
+      "devDependencies": {
+        "type-fest": "^3.6.0"
+      },
       "peerDependencies": {
         "dotcom-tool-kit": "2.x"
       }
@@ -26771,6 +26774,18 @@
       "version": "2.4.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
       "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA=="
+    },
+    "plugins/circleci-deploy/node_modules/type-fest": {
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-3.6.0.tgz",
+      "integrity": "sha512-RqTRtKTzvPpNdDUp1dVkKQRunlPITk4mXeqFlAZoJsS+fLRn8AdPK0TcQDumGayhU7fjlBfiBjsq3pe3rIfXZQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=14.16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
     },
     "plugins/circleci-heroku": {
       "name": "@dotcom-tool-kit/circleci-heroku",
@@ -31099,13 +31114,20 @@
       "version": "file:plugins/circleci-deploy",
       "requires": {
         "@dotcom-tool-kit/circleci": "^3.0.2",
-        "tslib": "^2.3.1"
+        "tslib": "^2.3.1",
+        "type-fest": "^3.6.0"
       },
       "dependencies": {
         "tslib": {
           "version": "2.4.1",
           "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
           "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA=="
+        },
+        "type-fest": {
+          "version": "3.6.0",
+          "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-3.6.0.tgz",
+          "integrity": "sha512-RqTRtKTzvPpNdDUp1dVkKQRunlPITk4mXeqFlAZoJsS+fLRn8AdPK0TcQDumGayhU7fjlBfiBjsq3pe3rIfXZQ==",
+          "dev": true
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -62,5 +62,8 @@
   "engines": {
     "node": "14.x || 16.x",
     "npm": "7.x || 8.x"
+  },
+  "overrides": {
+    "type-fest": "3.6.0"
   }
 }

--- a/plugins/circleci-deploy/package.json
+++ b/plugins/circleci-deploy/package.json
@@ -29,5 +29,8 @@
   },
   "peerDependencies": {
     "dotcom-tool-kit": "2.x"
+  },
+  "devDependencies": {
+    "type-fest": "^3.6.0"
   }
 }

--- a/plugins/serverless/readme.md
+++ b/plugins/serverless/readme.md
@@ -21,12 +21,17 @@ plugins:
 
 | Key | Description | Default value |
 |-|-|-|
+| `awsAccountId` | [required] the ID of the AWS account you wish to deploy to (account IDs can be found at the [FT login page](https://awslogin.in.ft.com/)) | none |
+| `systemCode` | [required] the system code for your app | none |
+| `region` | [require] what AWS region you want to deploy to (usually `eu-west-1`) | none |
 | `configPath` | [optional] path to your serverless config file. If this is not provided aws defaults to `./serverless.yml` but [other config fomats are accepted](https://www.serverless.com/framework/docs/providers/aws/guide/intro#alternative-configuration-format)| |
 | `useVault` | option to run the application with environment variables from Vault | `true` |
 | `ports` | ports to try to bind to for this application | `[3001, 3002, 3003]` |
+| `buildNumVariable` | an environment variable used to get a unique ID to use in the provisioning stage | `CIRCLE_BUILD_NUM` |
 
 ## Tasks
 
 | Task | Description | Default hooks |
 |-|-|-|
 | `ServerlessRun` | Run application with `serverless` | `run:local` |
+| `ServerlessProvision` | Deploy review app with `serverless` | `deploy:review` |

--- a/plugins/serverless/src/index.ts
+++ b/plugins/serverless/src/index.ts
@@ -1,3 +1,4 @@
+import ServerlessProvision from './tasks/provision'
 import ServerlessRun from './tasks/run'
 
-export const tasks = [ServerlessRun]
+export const tasks = [ServerlessRun, ServerlessProvision]

--- a/plugins/serverless/src/tasks/provision.ts
+++ b/plugins/serverless/src/tasks/provision.ts
@@ -1,0 +1,55 @@
+import { ToolKitError } from '@dotcom-tool-kit/error'
+import { hookFork, styles } from '@dotcom-tool-kit/logger'
+import { Task } from '@dotcom-tool-kit/types'
+import { ServerlessSchema } from '@dotcom-tool-kit/types/lib/schema/serverless'
+import { VaultEnvVars } from '@dotcom-tool-kit/vault'
+import { spawn } from 'child_process'
+
+export default class ServerlessProvision extends Task<typeof ServerlessSchema> {
+  static description = 'Provisions a job on AWS'
+
+  async run(): Promise<void> {
+    const { useVault, configPath } = this.options
+    const buildNum = process.env[this.options.buildNumVariable]
+
+    if (buildNum === undefined) {
+      throw new ToolKitError(
+        `the ${styles.task('ServerlessProvision')} task requires the ${styles.code(
+          `$${this.options.buildNumVariable}`
+        )} environment variable to be defined`
+      )
+    }
+
+    let vaultEnv = {}
+    if (useVault) {
+      const vault = new VaultEnvVars(this.logger, {
+        environment: 'development'
+      })
+
+      vaultEnv = await vault.get()
+    }
+
+    this.logger.verbose('starting the child serverless process...')
+    const args = [
+      'deploy',
+      '--region',
+      this.options.region,
+      '--stage',
+      `ci${buildNum}`,
+      '--aws-profile',
+      `CircleCI-role-${this.options.systemCode}`
+    ]
+    if (configPath) {
+      args.push('--config', './serverless.yml')
+    }
+
+    const child = spawn('serverless', args, {
+      env: {
+        ...vaultEnv,
+        ...process.env
+      }
+    })
+
+    hookFork(this.logger, 'serverless', child)
+  }
+}


### PR DESCRIPTION
# Description

This adds a task to the serverless plugin to deploy review apps to AWS via Serverless. The task itself tries to mirror the `provision` target present in the `Makefile`'s of projects still using n-gage to deploy to AWS, like [next-anubis-config-api](https://github.com/Financial-Times/next-anubis-config-api/blob/39f48d9d100d5d3d8fceeec0459e19d77e1f1a9d/Makefile#L24). The main point of interest is the introduction of using [OIDC tokens](https://tech.in.ft.com/tech-topics/continuous-delivery/circleci-aws-oidc-authentication#create-circleci-config-using-the-aws-cli-orb-in-your-project) to [deploy to CircleCI](https://circleci.com/docs/openid-connect-tokens/). I've had to add some additional logic to the plugin loading code and the Tool Kit orb in order to support this, as it requires the use of commands specified in the `circleci/aws-cli` and `circleci/serverless-framework` orbs to be run before the other commands in the `heroku-provision` orb job (pending a rename...) are. This is written on top of the work done recently to revamp the `circleci` plugin, though in the end we didn't actually need to use the ability to define multiple jobs for a single hook that the revamp now allows as I moved the problematic commands inside the orb itself 😅

# Checklist:

- [x] My branch has been rebased onto the latest commit on main (don't merge main into your branch)
- [x] My commit messages are [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/), for example: `feat(circleci): add support for nightly workflows`, `fix: set Heroku app name for staging apps too`
