### PR TITLE
docs: next-router plugin README updates

### DIFF
--- a/plugins/next-router/readme.md
+++ b/plugins/next-router/readme.md
@@ -37,7 +37,7 @@ options:
     appName: appName # system's `name` field as it appears in next-service-registry
   '@dotcom-tool-kit/vault':
     team: 'next'
-    app: 'next-[appName]' # corresponding Vault directory name
+    app: '[systemCode]' # corresponding Vault directory name
 ```
 
 ## Options

--- a/plugins/next-router/readme.md
+++ b/plugins/next-router/readme.md
@@ -34,17 +34,17 @@ hooks:
 
 options:
   '@dotcom-tool-kit/next-router':
-    appName: next-[appName]
+    appName: appName # system's `name` field as it appears in next-service-registry
   '@dotcom-tool-kit/vault':
     team: 'next'
-    app: 'next-[appName]'
+    app: 'next-[appName]' # corresponding Vault directory name
 ```
 
 ## Options
 
 | Key | Description | Default value | Required |
 |-|-|-|-|
-| `appName` | system code for the application (same as its "name" field in next-service-registry) | | ✅ |
+| `appName` | the system's `name` field as it appears in [next-service-registry](https://next-registry.ft.com/v2), which is _often different to its `code` value so be sure to check_) | | ✅ |
 
 ## Tasks
 


### PR DESCRIPTION
# Description

This PR updates the `next-router` plugin's README to clarify the value required for the `appName` option for the `next-router` plugin.

# Checklist:

- [x] My branch has been rebased onto the latest commit on main (don't merge main into your branch)
- [x] My commit messages are [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/), for example: `feat(circleci): add support for nightly workflows`, `fix: set Heroku app name for staging apps too`