### PR TITLE
Validate options even when none are given for a plugin 

### DIFF
--- a/core/cli/test/files/conflict-resolution/.toolkitrc.yml
+++ b/core/cli/test/files/conflict-resolution/.toolkitrc.yml
@@ -5,6 +5,17 @@ plugins:
   - '@dotcom-tool-kit/heroku' # for build:remote hook and build:local via npm plugin
 
 options:
+  '@dotcom-tool-kit/heroku':
+    pipeline: tool-kit-test
+    systemCode: tool-kit-test
+    scaling:
+      tool-kit-test:
+        web:
+          size: standard-1x
+          quantity: 1
+  '@dotcom-tool-kit/vault':
+    team: platforms
+    app: tool-kit-test
 
 hooks:
   build:local:

--- a/core/cli/test/files/duplicate/.toolkitrc.yml
+++ b/core/cli/test/files/duplicate/.toolkitrc.yml
@@ -3,5 +3,16 @@ plugins:
   - '@dotcom-tool-kit/heroku'
 
 options:
+  '@dotcom-tool-kit/heroku':
+    pipeline: tool-kit-test
+    systemCode: tool-kit-test
+    scaling:
+      tool-kit-test:
+        web:
+          size: standard-1x
+          quantity: 1
+  '@dotcom-tool-kit/vault':
+    team: platforms
+    app: tool-kit-test
 
 hooks:


### PR DESCRIPTION
# Description

Now that we've moved the setting of default options into the zod schema validation, we need to make sure we're using zod to parse options for plugins even when no options have been specified explicitly in your `.toolkitrc.yml` config. This is also important to ensure that plugins with required options are having those set.

For example, @andygout was encountering an [issue](https://financialtimes.slack.com/archives/C3TJ6KXEU/p1678702462886019) with the latest Tool Kit versions where the `run:local` hook was failing to run with an error
```
Nodemon:
Cannot destructure property ‘entry’ of ‘this.options’ as it is undefined.
```
This is because `nodemon` has a default value [specified](https://github.com/Financial-Times/dotcom-tool-kit/blob/5a450eabee673c8a4ceecf72f6eba7bf2e9dfcd2/lib/types/src/schema/nodemon.ts#L4) for the `entry` option, but seeing as they [weren't explicitly setting](https://github.com/Financial-Times/next-newsletter-signup/blob/e9a8cc11e8c531fdcbe32239a3372cc470fc1368/.toolkitrc.yml#L31) any options for `@dotcom-tool-kit/nodemon`, the plugin's option schema would never be loaded, and therefore zod would never have a chance to parse the (empty) option object and return a validated object with default values set for unspecified fields.

I've now updated the configuration validation code to iterate over the loaded plugins rather than the loaded options. This means we won't miss any plugins that haven't had any options explicitly set. Note that we won't miss any options that aren't associated with a plugin, as unused options were already disallowed. Any options that are created implicitly like this will be linked to the user's root configuration rather than a nested `.toolkitrc.yml` file.

# Checklist:

- [x] My branch has been rebased onto the latest commit on main (don't merge main into your branch)
- [x] My commit messages are [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/), for example: `feat(circleci): add support for nightly workflows`, `fix: set Heroku app name for staging apps too`
