### PR TITLE
CPP-1353: add upload-assets-to-s3 plugin to frontend app

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -45,13 +45,13 @@
     },
     "core/cli": {
       "name": "dotcom-tool-kit",
-      "version": "2.6.0",
+      "version": "2.6.1",
       "license": "MIT",
       "dependencies": {
         "@dotcom-tool-kit/error": "^2.0.1",
         "@dotcom-tool-kit/logger": "^2.2.1",
-        "@dotcom-tool-kit/options": "^2.0.13",
-        "@dotcom-tool-kit/types": "^2.9.0",
+        "@dotcom-tool-kit/options": "^2.0.14",
+        "@dotcom-tool-kit/types": "^2.9.1",
         "@dotcom-tool-kit/wait-for-ok": "^2.0.1",
         "cosmiconfig": "^7.0.0",
         "lodash": "^4.17.21",
@@ -65,17 +65,17 @@
         "dotcom-tool-kit": "bin/run"
       },
       "devDependencies": {
-        "@dotcom-tool-kit/babel": "^2.0.13",
-        "@dotcom-tool-kit/backend-heroku-app": "^1.0.1",
-        "@dotcom-tool-kit/circleci": "^4.0.0",
-        "@dotcom-tool-kit/circleci-deploy": "^2.0.0",
-        "@dotcom-tool-kit/eslint": "^2.3.0",
-        "@dotcom-tool-kit/frontend-app": "^2.2.1",
-        "@dotcom-tool-kit/heroku": "^2.1.4",
-        "@dotcom-tool-kit/mocha": "^2.3.0",
-        "@dotcom-tool-kit/n-test": "^2.1.8",
-        "@dotcom-tool-kit/npm": "^2.0.14",
-        "@dotcom-tool-kit/webpack": "^2.1.12",
+        "@dotcom-tool-kit/babel": "^2.0.14",
+        "@dotcom-tool-kit/backend-heroku-app": "^1.0.2",
+        "@dotcom-tool-kit/circleci": "^4.0.1",
+        "@dotcom-tool-kit/circleci-deploy": "^2.0.1",
+        "@dotcom-tool-kit/eslint": "^2.3.1",
+        "@dotcom-tool-kit/frontend-app": "^2.2.2",
+        "@dotcom-tool-kit/heroku": "^2.1.5",
+        "@dotcom-tool-kit/mocha": "^2.3.1",
+        "@dotcom-tool-kit/n-test": "^2.1.9",
+        "@dotcom-tool-kit/npm": "^2.0.15",
+        "@dotcom-tool-kit/webpack": "^2.1.13",
         "@jest/globals": "^27.4.6",
         "@types/lodash": "^4.14.185",
         "@types/node": "^12.20.24",
@@ -113,12 +113,12 @@
     },
     "core/create": {
       "name": "@dotcom-tool-kit/create",
-      "version": "2.6.0",
+      "version": "2.6.1",
       "license": "ISC",
       "dependencies": {
         "@dotcom-tool-kit/error": "^2.0.1",
         "@dotcom-tool-kit/logger": "^2.2.1",
-        "@dotcom-tool-kit/types": "^2.9.0",
+        "@dotcom-tool-kit/types": "^2.9.1",
         "@financial-times/package-json": "^3.0.0",
         "@quarterto/parse-makefile-rules": "^1.1.0",
         "import-cwd": "^3.0.0",
@@ -143,7 +143,7 @@
         "@types/pacote": "^11.1.3",
         "@types/prompts": "^2.0.14",
         "cosmiconfig": "^7.0.1",
-        "dotcom-tool-kit": "^2.6.0"
+        "dotcom-tool-kit": "^2.6.1"
       }
     },
     "core/create/node_modules/tslib": {
@@ -212,10 +212,10 @@
     },
     "lib/options": {
       "name": "@dotcom-tool-kit/options",
-      "version": "2.0.13",
+      "version": "2.0.14",
       "license": "ISC",
       "dependencies": {
-        "@dotcom-tool-kit/types": "^2.9.0",
+        "@dotcom-tool-kit/types": "^2.9.1",
         "tslib": "^2.3.1"
       }
     },
@@ -259,7 +259,7 @@
     },
     "lib/types": {
       "name": "@dotcom-tool-kit/types",
-      "version": "2.9.0",
+      "version": "2.9.1",
       "license": "ISC",
       "dependencies": {
         "@dotcom-tool-kit/error": "^2.0.0",
@@ -282,12 +282,12 @@
     },
     "lib/vault": {
       "name": "@dotcom-tool-kit/vault",
-      "version": "2.0.13",
+      "version": "2.0.14",
       "license": "ISC",
       "dependencies": {
         "@dotcom-tool-kit/error": "^2.0.1",
-        "@dotcom-tool-kit/options": "^2.0.13",
-        "@dotcom-tool-kit/types": "^2.9.0",
+        "@dotcom-tool-kit/options": "^2.0.14",
+        "@dotcom-tool-kit/types": "^2.9.1",
         "@financial-times/n-fetch": "^1.0.0-beta.7",
         "fs": "0.0.1-security",
         "os": "^0.1.2",
@@ -26679,12 +26679,12 @@
     },
     "plugins/babel": {
       "name": "@dotcom-tool-kit/babel",
-      "version": "2.0.13",
+      "version": "2.0.14",
       "license": "MIT",
       "dependencies": {
         "@dotcom-tool-kit/error": "^2.0.1",
         "@dotcom-tool-kit/logger": "^2.2.1",
-        "@dotcom-tool-kit/types": "^2.9.0",
+        "@dotcom-tool-kit/types": "^2.9.1",
         "fast-glob": "^3.2.11",
         "tslib": "^2.3.1"
       },
@@ -26705,10 +26705,10 @@
     },
     "plugins/backend-app": {
       "name": "@dotcom-tool-kit/backend-app",
-      "version": "2.2.1",
+      "version": "2.2.2",
       "license": "ISC",
       "dependencies": {
-        "@dotcom-tool-kit/backend-heroku-app": "^1.0.1"
+        "@dotcom-tool-kit/backend-heroku-app": "^1.0.2"
       },
       "peerDependencies": {
         "dotcom-tool-kit": "^2.6.0"
@@ -26716,15 +26716,15 @@
     },
     "plugins/backend-heroku-app": {
       "name": "@dotcom-tool-kit/backend-heroku-app",
-      "version": "1.0.1",
+      "version": "1.0.2",
       "license": "ISC",
       "dependencies": {
-        "@dotcom-tool-kit/circleci-deploy": "^2.0.0",
-        "@dotcom-tool-kit/heroku": "^2.1.4",
+        "@dotcom-tool-kit/circleci-deploy": "^2.0.1",
+        "@dotcom-tool-kit/heroku": "^2.1.5",
         "@dotcom-tool-kit/husky-npm": "^3.0.0",
-        "@dotcom-tool-kit/node": "^2.3.0",
-        "@dotcom-tool-kit/npm": "^2.0.14",
-        "@dotcom-tool-kit/secret-squirrel": "^1.0.12"
+        "@dotcom-tool-kit/node": "^2.3.1",
+        "@dotcom-tool-kit/npm": "^2.0.15",
+        "@dotcom-tool-kit/secret-squirrel": "^1.0.13"
       },
       "peerDependencies": {
         "dotcom-tool-kit": "^2.6.0"
@@ -26732,13 +26732,13 @@
     },
     "plugins/circleci": {
       "name": "@dotcom-tool-kit/circleci",
-      "version": "4.0.0",
+      "version": "4.0.1",
       "license": "ISC",
       "dependencies": {
         "@dotcom-tool-kit/error": "^2.0.0",
         "@dotcom-tool-kit/logger": "^2.2.1",
         "@dotcom-tool-kit/state": "^2.0.0",
-        "@dotcom-tool-kit/types": "^2.9.0",
+        "@dotcom-tool-kit/types": "^2.9.1",
         "lodash": "^4.17.21",
         "tslib": "^2.3.1",
         "type-fest": "^3.5.4",
@@ -26757,10 +26757,10 @@
     },
     "plugins/circleci-deploy": {
       "name": "@dotcom-tool-kit/circleci-deploy",
-      "version": "2.0.0",
+      "version": "2.0.1",
       "license": "ISC",
       "dependencies": {
-        "@dotcom-tool-kit/circleci": "^4.0.0",
+        "@dotcom-tool-kit/circleci": "^4.0.1",
         "tslib": "^2.3.1"
       },
       "devDependencies": {
@@ -26789,11 +26789,11 @@
     },
     "plugins/circleci-heroku": {
       "name": "@dotcom-tool-kit/circleci-heroku",
-      "version": "2.3.1",
+      "version": "2.3.2",
       "license": "ISC",
       "dependencies": {
-        "@dotcom-tool-kit/circleci-deploy": "^2.0.0",
-        "@dotcom-tool-kit/heroku": "^2.1.4",
+        "@dotcom-tool-kit/circleci-deploy": "^2.0.1",
+        "@dotcom-tool-kit/heroku": "^2.1.5",
         "tslib": "^2.3.1"
       },
       "peerDependencies": {
@@ -26807,12 +26807,12 @@
     },
     "plugins/circleci-npm": {
       "name": "@dotcom-tool-kit/circleci-npm",
-      "version": "4.0.0",
+      "version": "4.0.1",
       "license": "ISC",
       "dependencies": {
-        "@dotcom-tool-kit/circleci": "^4.0.0",
-        "@dotcom-tool-kit/npm": "^2.0.14",
-        "@dotcom-tool-kit/types": "^2.9.0",
+        "@dotcom-tool-kit/circleci": "^4.0.1",
+        "@dotcom-tool-kit/npm": "^2.0.15",
+        "@dotcom-tool-kit/types": "^2.9.1",
         "tslib": "^2.3.1"
       },
       "peerDependencies": {
@@ -26850,13 +26850,13 @@
     },
     "plugins/component": {
       "name": "@dotcom-tool-kit/component",
-      "version": "2.1.2",
+      "version": "2.1.3",
       "license": "ISC",
       "dependencies": {
-        "@dotcom-tool-kit/circleci-npm": "^4.0.0",
+        "@dotcom-tool-kit/circleci-npm": "^4.0.1",
         "@dotcom-tool-kit/husky-npm": "^3.0.0",
-        "@dotcom-tool-kit/npm": "^2.0.14",
-        "@dotcom-tool-kit/secret-squirrel": "^1.0.12"
+        "@dotcom-tool-kit/npm": "^2.0.15",
+        "@dotcom-tool-kit/secret-squirrel": "^1.0.13"
       },
       "peerDependencies": {
         "dotcom-tool-kit": "^2.6.0"
@@ -26872,12 +26872,12 @@
     },
     "plugins/eslint": {
       "name": "@dotcom-tool-kit/eslint",
-      "version": "2.3.0",
+      "version": "2.3.1",
       "license": "ISC",
       "dependencies": {
         "@dotcom-tool-kit/error": "^2.0.1",
         "@dotcom-tool-kit/logger": "^2.2.1",
-        "@dotcom-tool-kit/types": "^2.9.0",
+        "@dotcom-tool-kit/types": "^2.9.1",
         "tslib": "^2.3.1"
       },
       "devDependencies": {
@@ -27090,11 +27090,12 @@
     },
     "plugins/frontend-app": {
       "name": "@dotcom-tool-kit/frontend-app",
-      "version": "2.2.1",
+      "version": "2.2.2",
       "license": "ISC",
       "dependencies": {
-        "@dotcom-tool-kit/backend-heroku-app": "^1.0.1",
-        "@dotcom-tool-kit/webpack": "^2.1.12"
+        "@dotcom-tool-kit/backend-heroku-app": "^1.0.2",
+        "@dotcom-tool-kit/upload-assets-to-s3": "^2.1.1",
+        "@dotcom-tool-kit/webpack": "^2.1.13"
       },
       "peerDependencies": {
         "dotcom-tool-kit": "^2.6.0"
@@ -27102,16 +27103,16 @@
     },
     "plugins/heroku": {
       "name": "@dotcom-tool-kit/heroku",
-      "version": "2.1.4",
+      "version": "2.1.5",
       "license": "ISC",
       "dependencies": {
         "@dotcom-tool-kit/error": "^2.0.1",
         "@dotcom-tool-kit/logger": "^2.2.1",
-        "@dotcom-tool-kit/npm": "^2.0.14",
+        "@dotcom-tool-kit/npm": "^2.0.15",
         "@dotcom-tool-kit/package-json-hook": "^3.0.0",
         "@dotcom-tool-kit/state": "^2.0.1",
-        "@dotcom-tool-kit/types": "^2.9.0",
-        "@dotcom-tool-kit/vault": "^2.0.13",
+        "@dotcom-tool-kit/types": "^2.9.1",
+        "@dotcom-tool-kit/vault": "^2.0.14",
         "@dotcom-tool-kit/wait-for-ok": "^2.0.1",
         "@octokit/request": "^5.6.0",
         "@octokit/request-error": "^2.1.0",
@@ -27155,11 +27156,11 @@
     },
     "plugins/jest": {
       "name": "@dotcom-tool-kit/jest",
-      "version": "2.0.13",
+      "version": "2.0.14",
       "license": "ISC",
       "dependencies": {
         "@dotcom-tool-kit/logger": "^2.2.1",
-        "@dotcom-tool-kit/types": "^2.9.0",
+        "@dotcom-tool-kit/types": "^2.9.1",
         "tslib": "^2.3.1"
       },
       "devDependencies": {
@@ -27178,12 +27179,12 @@
     },
     "plugins/lint-staged": {
       "name": "@dotcom-tool-kit/lint-staged",
-      "version": "3.0.3",
+      "version": "3.0.4",
       "license": "ISC",
       "dependencies": {
         "@dotcom-tool-kit/logger": "^2.2.1",
         "@dotcom-tool-kit/package-json-hook": "^3.0.0",
-        "@dotcom-tool-kit/types": "^2.9.0",
+        "@dotcom-tool-kit/types": "^2.9.1",
         "lint-staged": "^11.2.3",
         "tslib": "^2.3.1"
       },
@@ -27193,12 +27194,12 @@
     },
     "plugins/lint-staged-npm": {
       "name": "@dotcom-tool-kit/lint-staged-npm",
-      "version": "2.0.15",
+      "version": "2.0.16",
       "license": "ISC",
       "dependencies": {
         "@dotcom-tool-kit/husky-npm": "^3.0.0",
-        "@dotcom-tool-kit/lint-staged": "^3.0.3",
-        "@dotcom-tool-kit/options": "^2.0.13",
+        "@dotcom-tool-kit/lint-staged": "^3.0.4",
+        "@dotcom-tool-kit/options": "^2.0.14",
         "tslib": "^2.3.1"
       },
       "peerDependencies": {
@@ -27267,12 +27268,12 @@
     },
     "plugins/mocha": {
       "name": "@dotcom-tool-kit/mocha",
-      "version": "2.3.0",
+      "version": "2.3.1",
       "license": "ISC",
       "dependencies": {
         "@dotcom-tool-kit/error": "^2.0.1",
         "@dotcom-tool-kit/logger": "^2.2.1",
-        "@dotcom-tool-kit/types": "^2.9.0",
+        "@dotcom-tool-kit/types": "^2.9.1",
         "glob": "^7.1.7",
         "tslib": "^2.3.1"
       },
@@ -27294,12 +27295,12 @@
     },
     "plugins/n-test": {
       "name": "@dotcom-tool-kit/n-test",
-      "version": "2.1.8",
+      "version": "2.1.9",
       "license": "ISC",
       "dependencies": {
         "@dotcom-tool-kit/logger": "^2.2.1",
         "@dotcom-tool-kit/state": "^2.0.1",
-        "@dotcom-tool-kit/types": "^2.9.0",
+        "@dotcom-tool-kit/types": "^2.9.1",
         "@financial-times/n-test": "^4.0.1",
         "tslib": "^2.3.1"
       },
@@ -27319,14 +27320,14 @@
     },
     "plugins/next-router": {
       "name": "@dotcom-tool-kit/next-router",
-      "version": "2.0.13",
+      "version": "2.0.14",
       "license": "ISC",
       "dependencies": {
         "@dotcom-tool-kit/error": "^2.0.1",
         "@dotcom-tool-kit/logger": "^2.2.1",
         "@dotcom-tool-kit/state": "^2.0.1",
-        "@dotcom-tool-kit/types": "^2.9.0",
-        "@dotcom-tool-kit/vault": "^2.0.13",
+        "@dotcom-tool-kit/types": "^2.9.1",
+        "@dotcom-tool-kit/vault": "^2.0.14",
         "ft-next-router": "^1.0.0",
         "tslib": "^2.3.1"
       },
@@ -27341,13 +27342,13 @@
     },
     "plugins/node": {
       "name": "@dotcom-tool-kit/node",
-      "version": "2.3.0",
+      "version": "2.3.1",
       "license": "ISC",
       "dependencies": {
         "@dotcom-tool-kit/error": "^2.0.1",
         "@dotcom-tool-kit/state": "^2.0.1",
-        "@dotcom-tool-kit/types": "^2.9.0",
-        "@dotcom-tool-kit/vault": "^2.0.13",
+        "@dotcom-tool-kit/types": "^2.9.1",
+        "@dotcom-tool-kit/vault": "^2.0.14",
         "get-port": "^5.1.1",
         "tslib": "^2.3.1",
         "wait-port": "^0.2.9"
@@ -27363,13 +27364,13 @@
     },
     "plugins/nodemon": {
       "name": "@dotcom-tool-kit/nodemon",
-      "version": "2.2.0",
+      "version": "2.2.1",
       "license": "ISC",
       "dependencies": {
         "@dotcom-tool-kit/error": "^2.0.1",
         "@dotcom-tool-kit/state": "^2.0.1",
-        "@dotcom-tool-kit/types": "^2.9.0",
-        "@dotcom-tool-kit/vault": "^2.0.13",
+        "@dotcom-tool-kit/types": "^2.9.1",
+        "@dotcom-tool-kit/vault": "^2.0.14",
         "get-port": "^5.1.1",
         "tslib": "^2.3.1"
       },
@@ -27388,14 +27389,14 @@
     },
     "plugins/npm": {
       "name": "@dotcom-tool-kit/npm",
-      "version": "2.0.14",
+      "version": "2.0.15",
       "license": "ISC",
       "dependencies": {
         "@actions/exec": "^1.1.0",
         "@dotcom-tool-kit/error": "^2.0.1",
         "@dotcom-tool-kit/package-json-hook": "^3.0.0",
         "@dotcom-tool-kit/state": "^2.0.1",
-        "@dotcom-tool-kit/types": "^2.9.0",
+        "@dotcom-tool-kit/types": "^2.9.1",
         "libnpmpack": "^3.1.0",
         "libnpmpublish": "^5.0.1",
         "pacote": "^12.0.3",
@@ -27552,10 +27553,10 @@
     },
     "plugins/pa11y": {
       "name": "@dotcom-tool-kit/pa11y",
-      "version": "0.3.10",
+      "version": "0.3.11",
       "license": "ISC",
       "dependencies": {
-        "@dotcom-tool-kit/types": "^2.9.0",
+        "@dotcom-tool-kit/types": "^2.9.1",
         "pa11y-ci": "^3.0.1",
         "tslib": "^2.3.1"
       },
@@ -27573,13 +27574,13 @@
     },
     "plugins/prettier": {
       "name": "@dotcom-tool-kit/prettier",
-      "version": "2.2.0",
+      "version": "2.2.1",
       "license": "ISC",
       "dependencies": {
         "@dotcom-tool-kit/error": "^2.0.1",
         "@dotcom-tool-kit/logger": "^2.2.1",
         "@dotcom-tool-kit/package-json-hook": "^3.0.0",
-        "@dotcom-tool-kit/types": "^2.9.0",
+        "@dotcom-tool-kit/types": "^2.9.1",
         "fast-glob": "^3.2.7",
         "hook-std": "^2.0.0",
         "prettier": "^2.2.1",
@@ -27602,11 +27603,11 @@
     },
     "plugins/secret-squirrel": {
       "name": "@dotcom-tool-kit/secret-squirrel",
-      "version": "1.0.12",
+      "version": "1.0.13",
       "license": "ISC",
       "dependencies": {
         "@dotcom-tool-kit/logger": "^2.2.1",
-        "@dotcom-tool-kit/types": "^2.9.0",
+        "@dotcom-tool-kit/types": "^2.9.1",
         "tslib": "^2.3.1"
       },
       "peerDependencies": {
@@ -27644,11 +27645,11 @@
     },
     "plugins/typescript": {
       "name": "@dotcom-tool-kit/typescript",
-      "version": "1.0.2",
+      "version": "1.0.3",
       "license": "ISC",
       "dependencies": {
         "@dotcom-tool-kit/logger": "^2.2.1",
-        "@dotcom-tool-kit/types": "^2.9.0"
+        "@dotcom-tool-kit/types": "^2.9.1"
       },
       "devDependencies": {
         "@jest/globals": "^29.3.1",
@@ -27848,13 +27849,13 @@
     },
     "plugins/upload-assets-to-s3": {
       "name": "@dotcom-tool-kit/upload-assets-to-s3",
-      "version": "2.1.0",
+      "version": "2.1.1",
       "license": "ISC",
       "dependencies": {
         "@aws-sdk/client-s3": "^3.256.0",
         "@dotcom-tool-kit/error": "^2.0.1",
         "@dotcom-tool-kit/logger": "^2.2.1",
-        "@dotcom-tool-kit/types": "^2.9.0",
+        "@dotcom-tool-kit/types": "^2.9.1",
         "glob": "^7.1.6",
         "mime": "^2.5.2",
         "tslib": "^2.3.1"
@@ -27878,12 +27879,12 @@
     },
     "plugins/webpack": {
       "name": "@dotcom-tool-kit/webpack",
-      "version": "2.1.12",
+      "version": "2.1.13",
       "license": "MIT",
       "dependencies": {
         "@dotcom-tool-kit/error": "^2.0.1",
         "@dotcom-tool-kit/logger": "^2.2.1",
-        "@dotcom-tool-kit/types": "^2.9.0",
+        "@dotcom-tool-kit/types": "^2.9.1",
         "tslib": "^2.3.1",
         "webpack-cli": "^4.6.0"
       },
@@ -31044,7 +31045,7 @@
         "@babel/preset-env": "^7.16.11",
         "@dotcom-tool-kit/error": "^2.0.1",
         "@dotcom-tool-kit/logger": "^2.2.1",
-        "@dotcom-tool-kit/types": "^2.9.0",
+        "@dotcom-tool-kit/types": "^2.9.1",
         "@jest/globals": "^27.4.6",
         "fast-glob": "^3.2.11",
         "tslib": "^2.3.1",
@@ -31061,18 +31062,18 @@
     "@dotcom-tool-kit/backend-app": {
       "version": "file:plugins/backend-app",
       "requires": {
-        "@dotcom-tool-kit/backend-heroku-app": "^1.0.1"
+        "@dotcom-tool-kit/backend-heroku-app": "^1.0.2"
       }
     },
     "@dotcom-tool-kit/backend-heroku-app": {
       "version": "file:plugins/backend-heroku-app",
       "requires": {
-        "@dotcom-tool-kit/circleci-deploy": "^2.0.0",
-        "@dotcom-tool-kit/heroku": "^2.1.4",
+        "@dotcom-tool-kit/circleci-deploy": "^2.0.1",
+        "@dotcom-tool-kit/heroku": "^2.1.5",
         "@dotcom-tool-kit/husky-npm": "^3.0.0",
-        "@dotcom-tool-kit/node": "^2.3.0",
-        "@dotcom-tool-kit/npm": "^2.0.14",
-        "@dotcom-tool-kit/secret-squirrel": "^1.0.12"
+        "@dotcom-tool-kit/node": "^2.3.1",
+        "@dotcom-tool-kit/npm": "^2.0.15",
+        "@dotcom-tool-kit/secret-squirrel": "^1.0.13"
       }
     },
     "@dotcom-tool-kit/circleci": {
@@ -31081,7 +31082,7 @@
         "@dotcom-tool-kit/error": "^2.0.0",
         "@dotcom-tool-kit/logger": "^2.2.1",
         "@dotcom-tool-kit/state": "^2.0.0",
-        "@dotcom-tool-kit/types": "^2.9.0",
+        "@dotcom-tool-kit/types": "^2.9.1",
         "@jest/globals": "^27.4.6",
         "@types/jest": "^27.4.0",
         "@types/js-yaml": "^4.0.3",
@@ -31113,7 +31114,7 @@
     "@dotcom-tool-kit/circleci-deploy": {
       "version": "file:plugins/circleci-deploy",
       "requires": {
-        "@dotcom-tool-kit/circleci": "^4.0.0",
+        "@dotcom-tool-kit/circleci": "^4.0.1",
         "tslib": "^2.3.1",
         "type-fest": "^3.6.0"
       },
@@ -31134,8 +31135,8 @@
     "@dotcom-tool-kit/circleci-heroku": {
       "version": "file:plugins/circleci-heroku",
       "requires": {
-        "@dotcom-tool-kit/circleci-deploy": "^2.0.0",
-        "@dotcom-tool-kit/heroku": "^2.1.4",
+        "@dotcom-tool-kit/circleci-deploy": "^2.0.1",
+        "@dotcom-tool-kit/heroku": "^2.1.5",
         "tslib": "^2.3.1"
       },
       "dependencies": {
@@ -31149,9 +31150,9 @@
     "@dotcom-tool-kit/circleci-npm": {
       "version": "file:plugins/circleci-npm",
       "requires": {
-        "@dotcom-tool-kit/circleci": "^4.0.0",
-        "@dotcom-tool-kit/npm": "^2.0.14",
-        "@dotcom-tool-kit/types": "^2.9.0",
+        "@dotcom-tool-kit/circleci": "^4.0.1",
+        "@dotcom-tool-kit/npm": "^2.0.15",
+        "@dotcom-tool-kit/types": "^2.9.1",
         "tslib": "^2.3.1"
       },
       "dependencies": {
@@ -31165,10 +31166,10 @@
     "@dotcom-tool-kit/component": {
       "version": "file:plugins/component",
       "requires": {
-        "@dotcom-tool-kit/circleci-npm": "^4.0.0",
+        "@dotcom-tool-kit/circleci-npm": "^4.0.1",
         "@dotcom-tool-kit/husky-npm": "^3.0.0",
-        "@dotcom-tool-kit/npm": "^2.0.14",
-        "@dotcom-tool-kit/secret-squirrel": "^1.0.12"
+        "@dotcom-tool-kit/npm": "^2.0.15",
+        "@dotcom-tool-kit/secret-squirrel": "^1.0.13"
       }
     },
     "@dotcom-tool-kit/create": {
@@ -31176,7 +31177,7 @@
       "requires": {
         "@dotcom-tool-kit/error": "^2.0.1",
         "@dotcom-tool-kit/logger": "^2.2.1",
-        "@dotcom-tool-kit/types": "^2.9.0",
+        "@dotcom-tool-kit/types": "^2.9.1",
         "@financial-times/package-json": "^3.0.0",
         "@quarterto/parse-makefile-rules": "^1.1.0",
         "@types/financial-times__package-json": "^1.9.0",
@@ -31187,7 +31188,7 @@
         "@types/pacote": "^11.1.3",
         "@types/prompts": "^2.0.14",
         "cosmiconfig": "^7.0.1",
-        "dotcom-tool-kit": "^2.6.0",
+        "dotcom-tool-kit": "^2.6.1",
         "import-cwd": "^3.0.0",
         "js-yaml": "^4.1.0",
         "komatsu": "^1.3.0",
@@ -31226,7 +31227,7 @@
       "requires": {
         "@dotcom-tool-kit/error": "^2.0.1",
         "@dotcom-tool-kit/logger": "^2.2.1",
-        "@dotcom-tool-kit/types": "^2.9.0",
+        "@dotcom-tool-kit/types": "^2.9.1",
         "@jest/globals": "^27.4.6",
         "@types/eslint": "^7.2.13",
         "eslint": "^8.15.0",
@@ -31372,8 +31373,9 @@
     "@dotcom-tool-kit/frontend-app": {
       "version": "file:plugins/frontend-app",
       "requires": {
-        "@dotcom-tool-kit/backend-heroku-app": "^1.0.1",
-        "@dotcom-tool-kit/webpack": "^2.1.12"
+        "@dotcom-tool-kit/backend-heroku-app": "^1.0.2",
+        "@dotcom-tool-kit/upload-assets-to-s3": "^2.1.1",
+        "@dotcom-tool-kit/webpack": "^2.1.13"
       }
     },
     "@dotcom-tool-kit/heroku": {
@@ -31381,11 +31383,11 @@
       "requires": {
         "@dotcom-tool-kit/error": "^2.0.1",
         "@dotcom-tool-kit/logger": "^2.2.1",
-        "@dotcom-tool-kit/npm": "^2.0.14",
+        "@dotcom-tool-kit/npm": "^2.0.15",
         "@dotcom-tool-kit/package-json-hook": "^3.0.0",
         "@dotcom-tool-kit/state": "^2.0.1",
-        "@dotcom-tool-kit/types": "^2.9.0",
-        "@dotcom-tool-kit/vault": "^2.0.13",
+        "@dotcom-tool-kit/types": "^2.9.1",
+        "@dotcom-tool-kit/vault": "^2.0.14",
         "@dotcom-tool-kit/wait-for-ok": "^2.0.1",
         "@octokit/request": "^5.6.0",
         "@octokit/request-error": "^2.1.0",
@@ -31424,7 +31426,7 @@
       "version": "file:plugins/jest",
       "requires": {
         "@dotcom-tool-kit/logger": "^2.2.1",
-        "@dotcom-tool-kit/types": "^2.9.0",
+        "@dotcom-tool-kit/types": "^2.9.1",
         "@jest/globals": "^27.4.6",
         "tslib": "^2.3.1",
         "winston": "^3.5.1"
@@ -31442,7 +31444,7 @@
       "requires": {
         "@dotcom-tool-kit/logger": "^2.2.1",
         "@dotcom-tool-kit/package-json-hook": "^3.0.0",
-        "@dotcom-tool-kit/types": "^2.9.0",
+        "@dotcom-tool-kit/types": "^2.9.1",
         "lint-staged": "^11.2.3",
         "tslib": "^2.3.1"
       },
@@ -31489,8 +31491,8 @@
       "version": "file:plugins/lint-staged-npm",
       "requires": {
         "@dotcom-tool-kit/husky-npm": "^3.0.0",
-        "@dotcom-tool-kit/lint-staged": "^3.0.3",
-        "@dotcom-tool-kit/options": "^2.0.13",
+        "@dotcom-tool-kit/lint-staged": "^3.0.4",
+        "@dotcom-tool-kit/options": "^2.0.14",
         "tslib": "^2.3.1"
       },
       "dependencies": {
@@ -31526,7 +31528,7 @@
       "requires": {
         "@dotcom-tool-kit/error": "^2.0.1",
         "@dotcom-tool-kit/logger": "^2.2.1",
-        "@dotcom-tool-kit/types": "^2.9.0",
+        "@dotcom-tool-kit/types": "^2.9.1",
         "@jest/globals": "^27.4.6",
         "@types/glob": "^7.1.3",
         "@types/mocha": "^8.2.2",
@@ -31547,7 +31549,7 @@
       "requires": {
         "@dotcom-tool-kit/logger": "^2.2.1",
         "@dotcom-tool-kit/state": "^2.0.1",
-        "@dotcom-tool-kit/types": "^2.9.0",
+        "@dotcom-tool-kit/types": "^2.9.1",
         "@financial-times/n-test": "^4.0.1",
         "@jest/globals": "^27.4.6",
         "@types/jest": "^27.4.0",
@@ -31568,8 +31570,8 @@
         "@dotcom-tool-kit/error": "^2.0.1",
         "@dotcom-tool-kit/logger": "^2.2.1",
         "@dotcom-tool-kit/state": "^2.0.1",
-        "@dotcom-tool-kit/types": "^2.9.0",
-        "@dotcom-tool-kit/vault": "^2.0.13",
+        "@dotcom-tool-kit/types": "^2.9.1",
+        "@dotcom-tool-kit/vault": "^2.0.14",
         "ft-next-router": "^1.0.0",
         "tslib": "^2.3.1"
       },
@@ -31586,8 +31588,8 @@
       "requires": {
         "@dotcom-tool-kit/error": "^2.0.1",
         "@dotcom-tool-kit/state": "^2.0.1",
-        "@dotcom-tool-kit/types": "^2.9.0",
-        "@dotcom-tool-kit/vault": "^2.0.13",
+        "@dotcom-tool-kit/types": "^2.9.1",
+        "@dotcom-tool-kit/vault": "^2.0.14",
         "get-port": "^5.1.1",
         "tslib": "^2.3.1",
         "wait-port": "^0.2.9"
@@ -31605,8 +31607,8 @@
       "requires": {
         "@dotcom-tool-kit/error": "^2.0.1",
         "@dotcom-tool-kit/state": "^2.0.1",
-        "@dotcom-tool-kit/types": "^2.9.0",
-        "@dotcom-tool-kit/vault": "^2.0.13",
+        "@dotcom-tool-kit/types": "^2.9.1",
+        "@dotcom-tool-kit/vault": "^2.0.14",
         "@types/nodemon": "^1.19.1",
         "get-port": "^5.1.1",
         "tslib": "^2.3.1"
@@ -31626,7 +31628,7 @@
         "@dotcom-tool-kit/error": "^2.0.1",
         "@dotcom-tool-kit/package-json-hook": "^3.0.0",
         "@dotcom-tool-kit/state": "^2.0.1",
-        "@dotcom-tool-kit/types": "^2.9.0",
+        "@dotcom-tool-kit/types": "^2.9.1",
         "@types/libnpmpublish": "^4.0.1",
         "@types/pacote": "^11.1.3",
         "@types/tar": "^6.1.1",
@@ -31743,7 +31745,7 @@
     "@dotcom-tool-kit/options": {
       "version": "file:lib/options",
       "requires": {
-        "@dotcom-tool-kit/types": "^2.9.0",
+        "@dotcom-tool-kit/types": "^2.9.1",
         "tslib": "^2.3.1"
       },
       "dependencies": {
@@ -31757,7 +31759,7 @@
     "@dotcom-tool-kit/pa11y": {
       "version": "file:plugins/pa11y",
       "requires": {
-        "@dotcom-tool-kit/types": "^2.9.0",
+        "@dotcom-tool-kit/types": "^2.9.1",
         "@types/pa11y": "^5.3.4",
         "pa11y-ci": "^3.0.1",
         "tslib": "^2.3.1"
@@ -31794,7 +31796,7 @@
         "@dotcom-tool-kit/error": "^2.0.1",
         "@dotcom-tool-kit/logger": "^2.2.1",
         "@dotcom-tool-kit/package-json-hook": "^3.0.0",
-        "@dotcom-tool-kit/types": "^2.9.0",
+        "@dotcom-tool-kit/types": "^2.9.1",
         "@jest/globals": "^27.4.6",
         "fast-glob": "^3.2.7",
         "hook-std": "^2.0.0",
@@ -31839,7 +31841,7 @@
       "version": "file:plugins/secret-squirrel",
       "requires": {
         "@dotcom-tool-kit/logger": "^2.2.1",
-        "@dotcom-tool-kit/types": "^2.9.0",
+        "@dotcom-tool-kit/types": "^2.9.1",
         "tslib": "^2.3.1"
       },
       "dependencies": {
@@ -31907,7 +31909,7 @@
       "version": "file:plugins/typescript",
       "requires": {
         "@dotcom-tool-kit/logger": "^2.2.1",
-        "@dotcom-tool-kit/types": "^2.9.0",
+        "@dotcom-tool-kit/types": "^2.9.1",
         "@jest/globals": "^29.3.1",
         "typescript": "^4.9.4",
         "winston": "^3.8.2"
@@ -32072,7 +32074,7 @@
         "@aws-sdk/types": "^3.13.1",
         "@dotcom-tool-kit/error": "^2.0.1",
         "@dotcom-tool-kit/logger": "^2.2.1",
-        "@dotcom-tool-kit/types": "^2.9.0",
+        "@dotcom-tool-kit/types": "^2.9.1",
         "@jest/globals": "^27.4.6",
         "@types/glob": "^7.1.3",
         "@types/jest": "^27.4.0",
@@ -32094,8 +32096,8 @@
       "version": "file:lib/vault",
       "requires": {
         "@dotcom-tool-kit/error": "^2.0.1",
-        "@dotcom-tool-kit/options": "^2.0.13",
-        "@dotcom-tool-kit/types": "^2.9.0",
+        "@dotcom-tool-kit/options": "^2.0.14",
+        "@dotcom-tool-kit/types": "^2.9.1",
         "@financial-times/n-fetch": "^1.0.0-beta.7",
         "@types/jest": "^27.0.2",
         "fs": "0.0.1-security",
@@ -32148,7 +32150,7 @@
       "requires": {
         "@dotcom-tool-kit/error": "^2.0.1",
         "@dotcom-tool-kit/logger": "^2.2.1",
-        "@dotcom-tool-kit/types": "^2.9.0",
+        "@dotcom-tool-kit/types": "^2.9.1",
         "@jest/globals": "^27.4.6",
         "ts-node": "^10.0.0",
         "tslib": "^2.3.1",
@@ -37606,22 +37608,22 @@
     "dotcom-tool-kit": {
       "version": "file:core/cli",
       "requires": {
-        "@dotcom-tool-kit/babel": "^2.0.13",
-        "@dotcom-tool-kit/backend-heroku-app": "^1.0.1",
-        "@dotcom-tool-kit/circleci": "^4.0.0",
-        "@dotcom-tool-kit/circleci-deploy": "^2.0.0",
+        "@dotcom-tool-kit/babel": "^2.0.14",
+        "@dotcom-tool-kit/backend-heroku-app": "^1.0.2",
+        "@dotcom-tool-kit/circleci": "^4.0.1",
+        "@dotcom-tool-kit/circleci-deploy": "^2.0.1",
         "@dotcom-tool-kit/error": "^2.0.1",
-        "@dotcom-tool-kit/eslint": "^2.3.0",
-        "@dotcom-tool-kit/frontend-app": "^2.2.1",
-        "@dotcom-tool-kit/heroku": "^2.1.4",
+        "@dotcom-tool-kit/eslint": "^2.3.1",
+        "@dotcom-tool-kit/frontend-app": "^2.2.2",
+        "@dotcom-tool-kit/heroku": "^2.1.5",
         "@dotcom-tool-kit/logger": "^2.2.1",
-        "@dotcom-tool-kit/mocha": "^2.3.0",
-        "@dotcom-tool-kit/n-test": "^2.1.8",
-        "@dotcom-tool-kit/npm": "^2.0.14",
-        "@dotcom-tool-kit/options": "^2.0.13",
-        "@dotcom-tool-kit/types": "^2.9.0",
+        "@dotcom-tool-kit/mocha": "^2.3.1",
+        "@dotcom-tool-kit/n-test": "^2.1.9",
+        "@dotcom-tool-kit/npm": "^2.0.15",
+        "@dotcom-tool-kit/options": "^2.0.14",
+        "@dotcom-tool-kit/types": "^2.9.1",
         "@dotcom-tool-kit/wait-for-ok": "^2.0.1",
-        "@dotcom-tool-kit/webpack": "^2.1.12",
+        "@dotcom-tool-kit/webpack": "^2.1.13",
         "@jest/globals": "^27.4.6",
         "@types/lodash": "^4.14.185",
         "@types/node": "^12.20.24",

--- a/plugins/frontend-app/.toolkitrc.yml
+++ b/plugins/frontend-app/.toolkitrc.yml
@@ -1,6 +1,7 @@
 plugins:
   - '@dotcom-tool-kit/webpack'
   - '@dotcom-tool-kit/backend-heroku-app'
+  - '@dotcom-tool-kit/upload-assets-to-s3'
 
 hooks:
   'run:local':

--- a/plugins/frontend-app/package.json
+++ b/plugins/frontend-app/package.json
@@ -8,6 +8,7 @@
   "license": "ISC",
   "dependencies": {
     "@dotcom-tool-kit/backend-heroku-app": "^1.0.2",
+    "@dotcom-tool-kit/upload-assets-to-s3": "^2.1.1",
     "@dotcom-tool-kit/webpack": "^2.1.13"
   },
   "repository": {


### PR DESCRIPTION
We include webpack in the frontend-app bootstrap plugin to compile frontend assets. We should include upload-assets-to-s3 so those assets are deloyed in production to the asset s3 bucket.

# Checklist:

- [x] My branch has been rebased onto the latest commit on main (don't merge main into your branch)
- [x] My commit messages are [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/), for example: `feat(circleci): add support for nightly workflows`, `fix: set Heroku app name for staging apps too`
