### PR TITLE
Allow prettier/eslint files options to be simple strings as well as arrays

### DIFF
--- a/lib/types/src/schema/eslint.ts
+++ b/lib/types/src/schema/eslint.ts
@@ -1,7 +1,7 @@
 import { z } from 'zod'
 
 export const ESLintSchema = z.object({
-  files: z.string().array().default(['**/*.js']),
+  files: z.string().array().or(z.string()).default(['**/*.js']),
   config: z.record(z.unknown()).optional(), // @deprecated: use options instead
   options: z.record(z.unknown()).optional()
 })

--- a/lib/types/src/schema/prettier.ts
+++ b/lib/types/src/schema/prettier.ts
@@ -1,7 +1,7 @@
 import { z } from 'zod'
 
 export const PrettierSchema = z.object({
-  files: z.string().array().default(['**/*.{js,jsx,ts,tsx}']),
+  files: z.string().array().or(z.string()).default(['**/*.{js,jsx,ts,tsx}']),
   configFile: z.string().optional(),
   ignoreFile: z.string().default('.prettierignore'),
   configOptions: z.record(z.unknown()).default({


### PR DESCRIPTION
# Description

Originally, these files options just accepted strings, but they were modified to accept arrays of strings too whilst we were adding lint-staged support so that that plugin could pass in an array of globs. We allowed single strings to still be set as options in order to preserve backwards compatibility, but when writing the original schemas for the migration script the option was encoded as a string array because we planned to deprecate a single string option eventually so it made sense for the migration script to only offer new users to create a list of file globs. However, this became a problem when we translated that schema into a zod schema that would also be used to validate the options a user has set, as that original schema did not allow single strings. This inadvertently created a breaking change when moving to zod.

To work around this breaking change, let's tell zod that either a string or an array of strings is valid. We can roll this back in a future major version if we wish.

The `create` plugin needs to be updated to support the introduction of the `ZodUnion` type we're using here, but whilst testing that change I noticed that the migration script is failing after the zod update for other reasons so I'm not able to test that change. I'll make a separate PR to fix the migration script instead.

# Checklist:

- [x] My branch has been rebased onto the latest commit on main (don't merge main into your branch)
- [x] My commit messages are [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/), for example: `feat(circleci): add support for nightly workflows`, `fix: set Heroku app name for staging apps too`
