### PR TITLE
CPP-1293: add husky as a dependency to @dotcom-tool-kit/husky-npm plugin

### DIFF
--- a/plugins/husky-npm/package.json
+++ b/plugins/husky-npm/package.json
@@ -11,10 +11,10 @@
   "license": "ISC",
   "dependencies": {
     "@dotcom-tool-kit/package-json-hook": "^3.0.0",
-    "tslib": "^2.3.1"
+    "tslib": "^2.3.1",
+    "husky": "^4.3.8"
   },
   "peerDependencies": {
-    "husky": "4.x",
     "dotcom-tool-kit": "^2.6.0"
   },
   "repository": {


### PR DESCRIPTION
When a repo installs to @dotcom-tool-kit/husky-npm we expect husky to be bundled so that our pre-commit hook can execute. However it turns out that when husky is defined as a peer dependency, although it does get installed, its executable is not defined in the root node_modules/.bin folder. This means that the `husky-run` executable cannot be found by the git pre-commit hook.

The plugin should depend on husky. This matches the way it worked for n-gage.

# Checklist:

- [x] My branch has been rebased onto the latest commit on main (don't merge main into your branch)
- [x] My commit messages are [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/), for example: `feat(circleci): add support for nightly workflows`, `fix: set Heroku app name for staging apps too`
