### PR TITLE
Fix zod validation issues with the create package

### DIFF
--- a/core/cli/src/messages.ts
+++ b/core/cli/src/messages.ts
@@ -102,7 +102,8 @@ ${invalidOptions
   .map(([plugin, error]) => fromZodError(error, { prefix: `- ${s.plugin(plugin)} has the issue(s)` }).message)
   .join('\n')}
 
-Please update the options so that they are the expected types. You can refer to the README for the plugin for examples and descriptions of the options used.`
+Please update the options so that they are the expected types. You can refer to the README for the plugin for examples and descriptions of the options used.
+`
 
 export const formatUnusedOptions = (
   unusedOptions: string[],

--- a/core/create/src/logger.ts
+++ b/core/create/src/logger.ts
@@ -3,7 +3,7 @@ import importCwd from 'import-cwd'
 import type { Spinner } from 'komatsu'
 import Komatsu from 'komatsu'
 
-export type LoggerError = Error & {
+export type LoggerError = (Error | ToolkitErrorModule.ToolKitError) & {
   logged?: boolean
 }
 
@@ -98,9 +98,13 @@ export async function runTasksWithLogger<T, U>(
     if (allowConflicts && hasToolKitConflicts(error)) {
       logger.log(id, { status: 'done', message: 'finished installing hooks, but found conflicts' })
     } else {
+      let message = labels.fail
+      if ('details' in loggerError) {
+        message += ' –\n' + loggerError.details
+      }
       logger.log(id, {
         status: 'fail',
-        message: labels.fail,
+        message,
         error: loggerError.logged ? undefined : loggerError
       })
     }

--- a/core/create/src/logger.ts
+++ b/core/create/src/logger.ts
@@ -1,57 +1,9 @@
 import * as ToolkitErrorModule from '@dotcom-tool-kit/error'
 import importCwd from 'import-cwd'
-import type { Spinner } from 'komatsu'
-import Komatsu from 'komatsu'
+import Logger from 'komatsu'
 
 export type LoggerError = (Error | ToolkitErrorModule.ToolKitError) & {
   logged?: boolean
-}
-
-export type labels = {
-  waiting: string
-  pending: string
-  done: string
-  fail: string
-}
-
-// TODO backport this to Komatsu mainline?
-export class Logger extends Komatsu {
-  stop(): void {
-    if (
-      !Array.from(this.spinners.values()).some(
-        (spinner: Spinner | { status: 'not-started' }) => spinner.status === 'not-started'
-      )
-    )
-      super.stop()
-  }
-
-  renderSymbol(spinner: Spinner | { status: 'not-started' }): string {
-    if (spinner.status === 'not-started') {
-      return '-'
-    }
-
-    return super.renderSymbol(spinner)
-  }
-
-  async logPromiseWait<T>(wait: Promise<T>, labels: labels): Promise<{ interim: T; id: string }> {
-    const id = Math.floor(parseInt(`zzzzzz`, 36) * Math.random())
-      .toString(36)
-      .padStart(6, '0')
-
-    this.log(id, { message: labels.waiting, status: 'not-started' })
-
-    let interim
-    try {
-      interim = await wait
-    } catch (error) {
-      const loggerError = error as LoggerError
-      // should have been logged by logPromise
-      loggerError.logged = true
-      throw error
-    }
-
-    return { interim, id }
-  }
 }
 
 export function hasToolKitConflicts(error: unknown): boolean {
@@ -69,26 +21,29 @@ export function hasToolKitConflicts(error: unknown): boolean {
   }
 }
 
-export async function runTasksWithLogger<T, U>(
+// helper function to include ToolKitError details in logs when available and,
+// optionally, don't print errors when we get Tool Kit conflicts if we're
+// expecting them
+export async function catchToolKitErrorsInLogger<T>(
   logger: Logger,
-  wait: Promise<T>,
-  run: (interim: T) => Promise<U>,
+  run: Promise<T>,
   label: string,
   allowConflicts: boolean
-): Promise<U> {
-  const labels: labels = {
-    waiting: `not ${label} yet`,
+): Promise<T> {
+  const labels = {
     pending: label,
     done: `finished ${label}`,
     fail: `error with ${label}`
   }
 
-  const { interim, id } = await logger.logPromiseWait(wait, labels)
+  const id = Math.floor(parseInt(`zzzzzz`, 36) * Math.random())
+    .toString(36)
+    .padStart(6, '0')
 
   try {
     logger.log(id, { message: labels.pending })
 
-    const result = await run(interim)
+    const result = await run
     logger.log(id, { status: 'done', message: labels.done })
     return result
   } catch (error) {

--- a/core/create/src/prompts/options.ts
+++ b/core/create/src/prompts/options.ts
@@ -30,128 +30,138 @@ async function optionsPromptForPlugin(
       ? ` (leave blank to use default value ${styles.code(JSON.stringify(optionDefault))})`
       : ''
 
-    // the Def type returned by ._def is different for each different Zod
-    // schema, but all of the schemas we're checking for here will have a
-    // .typeName field on their Def that gives a string representation of
-    // their type. this is preferred to using instanceof to check for the
-    // type as this method should work when different versions of zod are
-    // installed.
-    const typeName = optionType._def.typeName as z.ZodFirstPartyTypeKind
-    switch (typeName) {
-      case 'ZodString':
-        const { stringOption } = await prompt(
-          {
-            name: 'stringOption',
-            type: 'text',
-            message: `Set a value for '${styles.option(optionName)}'` + defaultSuffix
-          },
-          { onCancel }
-        )
-        if (stringOption !== '') {
-          toolKitConfig.options[plugin][optionName] = stringOption
-        }
-        break
-      case 'ZodBoolean':
-        const { boolOption } = await prompt(
-          {
-            name: 'boolOption',
-            type: 'confirm',
-            message: `Would you like to enable option '${styles.option(optionName)}'?` + defaultSuffix
-          },
-          { onCancel }
-        )
-        if (boolOption !== '') {
-          toolKitConfig.options[plugin][optionName] = boolOption
-        }
-        break
-      case 'ZodNumber':
-        const { numberOption } = await prompt(
-          {
-            name: 'numberOption',
-            type: 'text',
-            message: `Set a numerical value for '${styles.option(optionName)}'` + defaultSuffix
-          },
-          { onCancel }
-        )
-        if (numberOption !== '') {
-          toolKitConfig.options[plugin][optionName] = Number.parseFloat(numberOption)
-        }
-        break
-      case 'ZodArray':
-        const elementType = (optionType as z.ZodArray<z.ZodTypeAny>).element
-        switch (elementType._def.typeName as z.ZodFirstPartyTypeKind) {
-          case 'ZodString':
-            const { stringArrayOption }: { stringArrayOption: string | undefined } = await prompt(
-              {
-                name: 'stringArrayOption',
-                type: 'text',
-                message:
-                  `Set a list of values for '${styles.option(optionName)}' (delimited by commas)` +
-                  defaultSuffix
-              },
-              { onCancel }
-            )
-            if (stringArrayOption !== '' && stringArrayOption !== undefined) {
-              toolKitConfig.options[plugin][optionName] = stringArrayOption.split(',').map((s) => s.trim())
-            }
-            break
-          case 'ZodNumber':
-            const { numberArrayOption }: { numberArrayOption: string | undefined } = await prompt(
-              {
-                name: 'numberArrayOption',
-                type: 'text',
-                message:
-                  `Set a list of values for '${styles.option(optionName)}' (delimited by commas)` +
-                  defaultSuffix
-              },
-              { onCancel }
-            )
-            if (numberArrayOption !== '' && numberArrayOption !== undefined) {
-              toolKitConfig.options[plugin][optionName] = numberArrayOption
-                .split(',')
-                .map((s) => Number.parseFloat(s.trim()))
-            }
-            break
-          case 'ZodEnum':
-            const { option } = await prompt(
-              {
-                name: 'option',
-                type: 'multiselect',
-                choices: (elementType as z.ZodEnum<any>).options.map((choice: string) => ({
-                  title: choice,
-                  value: choice
-                })),
-                message: `Select options for '${styles.option(optionName)}'` + defaultSuffix
-              },
-              { onCancel }
-            )
-            if (option !== '') {
-              toolKitConfig.options[plugin][optionName] = option
-            }
-            break
-        }
-        break
-      case 'ZodEnum':
-        const { option } = await prompt(
-          {
-            name: 'option',
-            type: 'select',
-            choices: (optionType as z.ZodEnum<any>).options.map((choice: string) => ({
-              title: choice,
-              value: choice
-            })),
-            message: `Select an option for '${styles.option(optionName)}'` + defaultSuffix
-          },
-          { onCancel }
-        )
-        if (option !== '') {
-          toolKitConfig.options[plugin][optionName] = option
-        }
-        break
-      default:
-        winstonLogger.verbose(`skipping prompting for unrecognised option type ${typeName} for ${optionName}`)
-        break
+    const typeSwitch = async (optionType: z.ZodTypeAny) => {
+      // the Def type returned by ._def is different for each different Zod
+      // schema, but all of the schemas we're checking for here will have a
+      // .typeName field on their Def that gives a string representation of
+      // their type. this is preferred to using instanceof to check for the
+      // type as this method should work when different versions of zod are
+      // installed.
+      const typeName = optionType._def.typeName as z.ZodFirstPartyTypeKind
+      switch (typeName) {
+        case 'ZodString':
+          const { stringOption } = await prompt(
+            {
+              name: 'stringOption',
+              type: 'text',
+              message: `Set a value for '${styles.option(optionName)}'` + defaultSuffix
+            },
+            { onCancel }
+          )
+          if (stringOption !== '') {
+            toolKitConfig.options[plugin][optionName] = stringOption
+          }
+          break
+        case 'ZodBoolean':
+          const { boolOption } = await prompt(
+            {
+              name: 'boolOption',
+              type: 'confirm',
+              message: `Would you like to enable option '${styles.option(optionName)}'?` + defaultSuffix
+            },
+            { onCancel }
+          )
+          if (boolOption !== '') {
+            toolKitConfig.options[plugin][optionName] = boolOption
+          }
+          break
+        case 'ZodNumber':
+          const { numberOption } = await prompt(
+            {
+              name: 'numberOption',
+              type: 'text',
+              message: `Set a numerical value for '${styles.option(optionName)}'` + defaultSuffix
+            },
+            { onCancel }
+          )
+          if (numberOption !== '') {
+            toolKitConfig.options[plugin][optionName] = Number.parseFloat(numberOption)
+          }
+          break
+        case 'ZodArray':
+          const elementType = (optionType as z.ZodArray<z.ZodTypeAny>).element
+          switch (elementType._def.typeName as z.ZodFirstPartyTypeKind) {
+            case 'ZodString':
+              const { stringArrayOption }: { stringArrayOption: string | undefined } = await prompt(
+                {
+                  name: 'stringArrayOption',
+                  type: 'text',
+                  message:
+                    `Set a list of values for '${styles.option(optionName)}' (delimited by commas)` +
+                    defaultSuffix
+                },
+                { onCancel }
+              )
+              if (stringArrayOption !== '' && stringArrayOption !== undefined) {
+                toolKitConfig.options[plugin][optionName] = stringArrayOption.split(',').map((s) => s.trim())
+              }
+              break
+            case 'ZodNumber':
+              const { numberArrayOption }: { numberArrayOption: string | undefined } = await prompt(
+                {
+                  name: 'numberArrayOption',
+                  type: 'text',
+                  message:
+                    `Set a list of values for '${styles.option(optionName)}' (delimited by commas)` +
+                    defaultSuffix
+                },
+                { onCancel }
+              )
+              if (numberArrayOption !== '' && numberArrayOption !== undefined) {
+                toolKitConfig.options[plugin][optionName] = numberArrayOption
+                  .split(',')
+                  .map((s) => Number.parseFloat(s.trim()))
+              }
+              break
+            case 'ZodEnum':
+              const { option } = await prompt(
+                {
+                  name: 'option',
+                  type: 'multiselect',
+                  choices: (elementType as z.ZodEnum<any>).options.map((choice: string) => ({
+                    title: choice,
+                    value: choice
+                  })),
+                  message: `Select options for '${styles.option(optionName)}'` + defaultSuffix
+                },
+                { onCancel }
+              )
+              if (option !== '') {
+                toolKitConfig.options[plugin][optionName] = option
+              }
+              break
+          }
+          break
+        case 'ZodEnum':
+          const { option } = await prompt(
+            {
+              name: 'option',
+              type: 'select',
+              choices: (optionType as z.ZodEnum<any>).options.map((choice: string) => ({
+                title: choice,
+                value: choice
+              })),
+              message: `Select an option for '${styles.option(optionName)}'` + defaultSuffix
+            },
+            { onCancel }
+          )
+          if (option !== '') {
+            toolKitConfig.options[plugin][optionName] = option
+          }
+          break
+        case 'ZodUnion':
+          // only suggest the first choice of a union
+          await typeSwitch((optionType as z.ZodUnion<z.ZodUnionOptions>).options[0])
+          break
+        default:
+          winstonLogger.verbose(
+            `skipping prompting for unrecognised option type ${typeName} for ${optionName}`
+          )
+          break
+      }
     }
+
+    await typeSwitch(optionType)
 
     if (pluginCancelled) {
       return true

--- a/core/create/src/prompts/options.ts
+++ b/core/create/src/prompts/options.ts
@@ -1,13 +1,13 @@
 import { rootLogger as winstonLogger, styles } from '@dotcom-tool-kit/logger'
 import type { RCFile } from '@dotcom-tool-kit/types'
 import type { PromptGenerators } from '@dotcom-tool-kit/types/src/schema'
-import type { ValidConfig } from 'dotcom-tool-kit/lib/config'
+import type { RawConfig } from 'dotcom-tool-kit/lib/config'
 import { promises as fs } from 'fs'
 import * as yaml from 'js-yaml'
+import type Logger from 'komatsu'
 import partition from 'lodash/partition'
 import prompt from 'prompts'
 import { z } from 'zod'
-import type { Logger } from '../logger'
 
 interface OptionSettings {
   name: string
@@ -173,7 +173,7 @@ async function optionsPromptForPlugin(
 
 export interface OptionsParams {
   logger: Logger
-  config: ValidConfig
+  config: RawConfig
   toolKitConfig: RCFile
   configPath: string
 }

--- a/core/create/src/prompts/options.ts
+++ b/core/create/src/prompts/options.ts
@@ -12,7 +12,7 @@ import { z } from 'zod'
 interface OptionSettings {
   name: string
   type: z.ZodTypeAny
-  default?: any
+  default?: unknown
 }
 
 async function optionsPromptForPlugin(
@@ -118,10 +118,12 @@ async function optionsPromptForPlugin(
                 {
                   name: 'option',
                   type: 'multiselect',
-                  choices: (elementType as z.ZodEnum<any>).options.map((choice: string) => ({
-                    title: choice,
-                    value: choice
-                  })),
+                  choices: (elementType as z.ZodEnum<[string, ...string[]]>).options.map(
+                    (choice: string) => ({
+                      title: choice,
+                      value: choice
+                    })
+                  ),
                   message: `Select options for '${styles.option(optionName)}'` + defaultSuffix
                 },
                 { onCancel }
@@ -137,7 +139,7 @@ async function optionsPromptForPlugin(
             {
               name: 'option',
               type: 'select',
-              choices: (optionType as z.ZodEnum<any>).options.map((choice: string) => ({
+              choices: (optionType as z.ZodEnum<[string, ...string[]]>).options.map((choice: string) => ({
                 title: choice,
                 value: choice
               })),
@@ -223,6 +225,9 @@ export default async ({ logger, config, toolKitConfig, configPath }: OptionsPara
       }
       if (!cancelled && generators) {
         for (const [optionName, generator] of Object.entries(generators)) {
+          // the object is partial because not all options for a plugin will
+          // have generators, but all values in the record will be defined
+          // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
           toolKitConfig.options[plugin][optionName] = await generator!(
             winstonLogger.child({ plugin }),
             prompt,


### PR DESCRIPTION
# Description

As part of #368, I knew I'd have to add support for zod's union types to the `create` package so that it could handle unions of types when prompting the user to enter options as part of a migration (it now does this by prompting for the first type in the list of union types). However, when I was testing this change I found that the create script would fail when creating a new Tool Kit config using a standard preset like `backend-heroku-app`. It would throw errors about the `heroku` and `vault` plugins having missing options (or in fact it would just say there were problems with the installation – I've added logging for the `ToolKitError` in this PR too). This is because we do an install of Tool Kit before we prompt the user for any options to set so that we can get the configuration it loads to use as a list of plugins that we need to ask options for. I've now rewritten this logic to only run an install after the options have been set so that the validation passes as expected.

Since `create` is working again I can now test its support for union types and confirm that works too. I've also taken the opportunity to tidy up some of the code in the package.

# Checklist:

- [x] My branch has been rebased onto the latest commit on main (don't merge main into your branch)
- [x] My commit messages are [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/), for example: `feat(circleci): add support for nightly workflows`, `fix: set Heroku app name for staging apps too`
