### PR TITLE
Make vault options optional

### DIFF
--- a/lib/types/src/schema/vault.ts
+++ b/lib/types/src/schema/vault.ts
@@ -1,9 +1,15 @@
 import { z } from 'zod'
 
-export const VaultSchema = z.object({
-  team: z.string(),
-  app: z.string()
-})
+// In theory, these fields should be required as Vault won't work without them,
+// but not every app that pulls in the Vault plugin actually needs to use
+// Vault, e.g., an app that uses the `nodemon` plugin with the `useVault`
+// option set to false.
+export const VaultSchema = z
+  .object({
+    team: z.string(),
+    app: z.string()
+  })
+  .partial()
 export type VaultOptions = z.infer<typeof VaultSchema>
 
 export const Schema = VaultSchema


### PR DESCRIPTION
# Description

In theory, these fields should be required as Vault won't work without them, but not every app that pulls in the Vault plugin actually needs to use Vault, e.g., an app that uses the `nodemon` plugin with the `useVault` option set to false. In the future we could investigate alternative approach which could conditionally require the options in some circumstances but I'm not sure how that would look.

This was inspired by but does not fix https://github.com/Financial-Times/cp-content-pipeline/pull/328. Other plugins, like `@dotcom-tool-kit/heroku` also have required options, but don't have any options that would mean they should be ignored in certain circumstances.

# Checklist:

- [x] My branch has been rebased onto the latest commit on main (don't merge main into your branch)
- [x] My commit messages are [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/), for example: `feat(circleci): add support for nightly workflows`, `fix: set Heroku app name for staging apps too`
