### PR TITLE
Load Tool Kit configuration via a user's local dotcom-tool-kit package

### DIFF
--- a/core/create/src/index.ts
+++ b/core/create/src/index.ts
@@ -3,8 +3,9 @@ import { rootLogger as winstonLogger, styles } from '@dotcom-tool-kit/logger'
 import type { RCFile } from '@dotcom-tool-kit/types'
 import loadPackageJson from '@financial-times/package-json'
 import { exec as _exec } from 'child_process'
-import { loadConfig } from 'dotcom-tool-kit/lib/config'
+import type { loadConfig as loadConfigType } from 'dotcom-tool-kit/lib/config'
 import { promises as fs } from 'fs'
+import importCwd from 'import-cwd'
 import * as yaml from 'js-yaml'
 import Logger from 'komatsu'
 import pacote from 'pacote'
@@ -126,6 +127,10 @@ async function main() {
   // Carry out the proposed changes: install + uninstall packages, add config
   // files, etc.
   await executeMigration(deleteConfig, addEslintConfig, configFile)
+  // Use user's version of Tool Kit that we've just installed for them to load
+  // the config to avoid any incompatibilities with a version that create might
+  // use
+  const { loadConfig } = importCwd('dotcom-tool-kit/lib/config') as { loadConfig: typeof loadConfigType }
   const config = await loadConfig(winstonLogger, { validate: false })
   // Give the user a chance to set any configurable options for the plugins
   // they've installed.


### PR DESCRIPTION
# Description

This was causing a crash as `dotcom-tool-kit` is only a dev dependency of the `create` package. Rather than promoting it to a full dependency to use `loadConfig`, I remembered that [in other places in the package](https://github.com/Financial-Times/dotcom-tool-kit/blob/453ebf57ecbfaff8266f6dffbea1523247fb4aaf/core/create/src/prompts/conflicts.ts#L31-L33) we use the version of `dotcom-tool-kit` that we install into the user's own project as part of the migration to avoid `instanceof` incompatibilities. It makes sense to keep doing the same thing here to avoid accidentally bumping into further incompatibilities in future code changes.

# Checklist:

- [x] My branch has been rebased onto the latest commit on main (don't merge main into your branch)
- [x] My commit messages are [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/), for example: `feat(circleci): add support for nightly workflows`, `fix: set Heroku app name for staging apps too`
