### PR TITLE
Fix installation error for unmanaged CircleCI configs

### DIFF
--- a/plugins/circleci/src/circleci-config.ts
+++ b/plugins/circleci/src/circleci-config.ts
@@ -269,12 +269,12 @@ If you would like a Tool Kit configured CircleCI config file to be generated for
       const { jobs, nightlyJobs } = getWorkflowJobs(config)
       const flatJobs = jobs?.map(getJobName) ?? []
       const flatNightlyJobs = nightlyJobs?.map(getJobName) ?? []
-      const missingJobs = Object.keys(state.workflows['tool-kit'].jobs).filter(
-        (job) => !flatJobs.includes(job)
-      )
-      const missingNightlyJobs = Object.keys(state.workflows.nightly.jobs).filter(
-        (job) => !flatNightlyJobs.includes(job)
-      )
+      const missingJobs = state.workflows['tool-kit'].jobs
+        .map(getJobName)
+        .filter((job) => !flatJobs.includes(job))
+      const missingNightlyJobs = state.workflows.nightly.jobs
+        .map(getJobName)
+        .filter((job) => !flatNightlyJobs.includes(job))
 
       const formatMissingHooks = (hooks: string[]): string => hooks.map(styles.hook).join(', ')
       throw new ToolKitError(


### PR DESCRIPTION
# Description

Quick PR as I noticed when experimenting with `cp-content-pipeline` that since the revamp to the CircleCI plugin, the installation error for CircleCI configurations that are unmanaged by Tool Kit (i.e., they don't have the generated comment at the top of the file) get an unhelpful error when the configuration is missing expected code, e.g.,

```
could not automatically install hooks:
───────────────────────────────────────────────────────────────────────────
- Please update your CircleCI config to include the 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10 job(s) in the tool-kit workflow and the 0, 1, 2, 3, 4 job(s) in the nightly workflow
```

This was because we were getting the keys of arrays which are, of course, numbers in JavaScript lol. There's only so much TypeScript can help us! This now correctly prints the names of any jobs that are missing.

This change highlights the fact we might want to consider how to handle unmanaged configurations since the revamp. The installation checks are a lot stricter now: we check whether the whole file has the expected config we've generated rather than just checking whether the Tool Kit jobs we want are there. This is much better for managed configurations, as it means we are better at catching when any part of the configuration is missing/wrong and needs to be updated (such as the version of an orb etc) but it makes the installation logic a lot less flexible for unmanaged configurations. We should re-evaluate how we want to validate unmanaged configurations (or if we want to validate them at all!) but that's out of the scope of this PR 😄

# Checklist:

- [x] My branch has been rebased onto the latest commit on main (don't merge main into your branch)
- [x] My commit messages are [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/), for example: `feat(circleci): add support for nightly workflows`, `fix: set Heroku app name for staging apps too`
