### PR TITLE
Force color output for mocha logs

### DIFF
--- a/plugins/mocha/src/tasks/mocha.ts
+++ b/plugins/mocha/src/tasks/mocha.ts
@@ -12,7 +12,7 @@ export default class Mocha extends Task<typeof MochaSchema> {
   async run(): Promise<void> {
     const files = await promisify(glob)(this.options.files)
 
-    const args = [this.options.configPath ? `--config=${this.options.configPath}` : '', ...files]
+    const args = ['--color', this.options.configPath ? `--config=${this.options.configPath}` : '', ...files]
     this.logger.info(`running mocha ${args.join(' ')}`)
     const child = fork(mochaCLIPath, args, { silent: true })
     hookFork(this.logger, 'mocha', child)


### PR DESCRIPTION
# Description

As with many CLI tools, mocha supports ANSI colours for its test reporting but disables them if it's not connected to a TTY (i.e., if it's not an interactive session, such as when it's run in a CI or if it's being piped to another script). It doesn't detect a TTY in our case as we're piping its stdout and stderr through our winston logging infrastructure rather than outputting to the user's terminal directly. In order to get colourful output then, let's force it via mocha's [`--color`](https://mochajs.org/#-color-c-colors) option.

# Checklist:

- [x] My branch has been rebased onto the latest commit on main (don't merge main into your branch)
- [x] My commit messages are [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/), for example: `feat(circleci): add support for nightly workflows`, `fix: set Heroku app name for staging apps too`
