### PR TITLE
chore: bump to latest version of n-test to get versions back aligned

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4507,9 +4507,9 @@
       }
     },
     "node_modules/@financial-times/n-test": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/@financial-times/n-test/-/n-test-4.1.0.tgz",
-      "integrity": "sha512-OizHtCb6P29AszUA+xWibjmN1faVcxKBED3X5kq9TCYMEMuBF5zxHQOhwXil4g4EdDseXsSe+9m5YZFXjEhOxg==",
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/@financial-times/n-test/-/n-test-5.0.1.tgz",
+      "integrity": "sha512-KZV1RUZ0rxK4gaxHE8BsZ6kd6znO3SlQY4t+BtuM0r622AP2ocMQYEktp1+Wr+H2dE/PT8T3clplAgpsy/5Jyg==",
       "hasInstallScript": true,
       "dependencies": {
         "chalk": "^2.3.0",
@@ -27212,7 +27212,7 @@
         "@dotcom-tool-kit/logger": "^2.2.1",
         "@dotcom-tool-kit/state": "^2.0.1",
         "@dotcom-tool-kit/types": "^2.9.2",
-        "@financial-times/n-test": "^4.1.0",
+        "@financial-times/n-test": "^5.0.1",
         "tslib": "^2.3.1"
       },
       "devDependencies": {
@@ -31461,7 +31461,7 @@
         "@dotcom-tool-kit/logger": "^2.2.1",
         "@dotcom-tool-kit/state": "^2.0.1",
         "@dotcom-tool-kit/types": "^2.9.2",
-        "@financial-times/n-test": "^4.1.0",
+        "@financial-times/n-test": "^5.0.1",
         "@jest/globals": "^27.4.6",
         "@types/jest": "^27.4.0",
         "tslib": "^2.3.1",
@@ -32209,9 +32209,9 @@
       }
     },
     "@financial-times/n-test": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/@financial-times/n-test/-/n-test-4.1.0.tgz",
-      "integrity": "sha512-OizHtCb6P29AszUA+xWibjmN1faVcxKBED3X5kq9TCYMEMuBF5zxHQOhwXil4g4EdDseXsSe+9m5YZFXjEhOxg==",
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/@financial-times/n-test/-/n-test-5.0.1.tgz",
+      "integrity": "sha512-KZV1RUZ0rxK4gaxHE8BsZ6kd6znO3SlQY4t+BtuM0r622AP2ocMQYEktp1+Wr+H2dE/PT8T3clplAgpsy/5Jyg==",
       "requires": {
         "chalk": "^2.3.0",
         "commander": "^3.0.0",

--- a/plugins/n-test/package.json
+++ b/plugins/n-test/package.json
@@ -13,7 +13,7 @@
     "@dotcom-tool-kit/logger": "^2.2.1",
     "@dotcom-tool-kit/state": "^2.0.1",
     "@dotcom-tool-kit/types": "^2.9.2",
-    "@financial-times/n-test": "^4.1.0",
+    "@financial-times/n-test": "^5.0.1",
     "tslib": "^2.3.1"
   },
   "repository": {


### PR DESCRIPTION
see https://github.com/Financial-Times/dotcom-tool-kit/pull/381. This is required to unblock failing builds on next-article.

This is not a breaking change

# Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. 

# Checklist:

- [ ] My branch has been rebased onto the latest commit on main (don't merge main into your branch)
- [ ] My commit messages are [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/), for example: `feat(circleci): add support for nightly workflows`, `fix: set Heroku app name for staging apps too`
