### PR TITLE
fix(serverless): update @dotcom-tool-kit/types

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -29373,7 +29373,7 @@
       "dependencies": {
         "@dotcom-tool-kit/error": "^2.0.1",
         "@dotcom-tool-kit/state": "^2.0.1",
-        "@dotcom-tool-kit/types": "^2.8.0",
+        "@dotcom-tool-kit/types": "^2.9.2",
         "@dotcom-tool-kit/vault": "^2.0.12",
         "get-port": "^5.1.1",
         "tslib": "^2.3.1",
@@ -35032,7 +35032,7 @@
       "requires": {
         "@dotcom-tool-kit/error": "^2.0.1",
         "@dotcom-tool-kit/state": "^2.0.1",
-        "@dotcom-tool-kit/types": "^2.8.0",
+        "@dotcom-tool-kit/types": "2.9.2",
         "@dotcom-tool-kit/vault": "^2.0.12",
         "get-port": "^5.1.1",
         "tslib": "^2.3.1",
@@ -38618,7 +38618,7 @@
     "ansi-escapes": {
       "version": "4.3.2",
       "requires": {
-        "type-fest": "^0.21.3"
+        "type-fest": "3.6.0"
       }
     },
     "ansi-regex": {
@@ -39209,7 +39209,7 @@
         "chalk": "^4.1.0",
         "cli-boxes": "^2.2.1",
         "string-width": "^4.2.2",
-        "type-fest": "^0.20.2",
+        "type-fest": "3.6.0",
         "widest-line": "^3.1.0",
         "wrap-ansi": "^7.0.0"
       },
@@ -44493,7 +44493,7 @@
         "graceful-fs": "^4.1.15",
         "parse-json": "^5.0.0",
         "strip-bom": "^4.0.0",
-        "type-fest": "^0.6.0"
+        "type-fest": "3.6.0"
       }
     },
     "loader-runner": {
@@ -46192,7 +46192,7 @@
       "peer": true,
       "requires": {
         "mimic-fn": "^4.0.0",
-        "type-fest": "^3.0.0"
+        "type-fest": "3.6.0"
       },
       "dependencies": {
         "mimic-fn": {
@@ -47286,7 +47286,7 @@
         "@types/normalize-package-data": "^2.4.0",
         "normalize-package-data": "^2.5.0",
         "parse-json": "^5.0.0",
-        "type-fest": "^0.6.0"
+        "type-fest": "3.6.0"
       },
       "dependencies": {
         "hosted-git-info": {
@@ -47956,7 +47956,7 @@
     "serialize-error": {
       "version": "5.0.0",
       "requires": {
-        "type-fest": "^0.8.0"
+        "type-fest": "3.6.0"
       }
     },
     "serialize-javascript": {
@@ -48374,7 +48374,7 @@
             "chalk": "^5.0.1",
             "cli-boxes": "^3.0.0",
             "string-width": "^5.1.2",
-            "type-fest": "^2.13.0",
+            "type-fest": "3.6.0",
             "widest-line": "^4.0.1",
             "wrap-ansi": "^8.0.1"
           }
@@ -50887,7 +50887,7 @@
       "dev": true,
       "requires": {
         "sort-keys": "^2.0.0",
-        "type-fest": "^0.4.1",
+        "type-fest": "3.6.0",
         "write-json-file": "^3.2.0"
       }
     },

--- a/plugins/serverless/package.json
+++ b/plugins/serverless/package.json
@@ -27,7 +27,7 @@
   "dependencies": {
     "@dotcom-tool-kit/error": "^2.0.1",
     "@dotcom-tool-kit/state": "^2.0.1",
-    "@dotcom-tool-kit/types": "^2.8.0",
+    "@dotcom-tool-kit/types": "^2.9.2",
     "@dotcom-tool-kit/vault": "^2.0.12",
     "get-port": "^5.1.1",
     "tslib": "^2.3.1",


### PR DESCRIPTION
# Description

Ran `cd plugins/serverless && npm install @dotcom-tool-kit/types@latest` to fix the build error for the latest changes in #372.

# Checklist:

- [x] My branch has been rebased onto the latest commit on main (don't merge main into your branch)
- [x] My commit messages are [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/), for example: `feat(circleci): add support for nightly workflows`, `fix: set Heroku app name for staging apps too`
