### PR TITLE
CPP-1057 Add a serverless preset plugin

### DIFF
--- a/core/create/src/prompts/main.ts
+++ b/core/create/src/prompts/main.ts
@@ -24,7 +24,8 @@ export default async ({
         message: `What kind of app is ${styles.app(packageJson.getField('name'))}?`,
         choices: [
           { title: 'A user-facing (frontend) app', value: 'frontend-app' },
-          { title: 'A service (backend) app', value: 'backend-heroku-app' },
+          { title: 'A Heroku backend app', value: 'backend-heroku-app' },
+          { title: 'A Serverless backend app', value: 'backend-serverless-app' },
           { title: 'An npm component', value: 'component' }
         ]
       },

--- a/orb/src/jobs/deploy-production.yml
+++ b/orb/src/jobs/deploy-production.yml
@@ -2,7 +2,10 @@ parameters:
   executor:
     default: default
     type: executor
-  systemCode:
+  aws-account-id:
+    default: ''
+    type: string
+  system-code:
     default: $CIRCLE_PROJECT_REPONAME
     description: >-
       The systemcode of the system being changed. Defaults to the repository
@@ -17,9 +20,18 @@ executor: << parameters.executor >>
 
 steps:
   - attach-workspace
+  - when:
+      condition:
+        and:
+          - << parameters.aws-account-id >>
+          - << parameters.system-code >>
+      steps:
+        - serverless-assume-role:
+            aws-account-id: << parameters.aws-account-id >>
+            system-code: << parameters.system-code >>
   - run:
       name: Deploy to production
       command: npx dotcom-tool-kit deploy:production
   - change-api/change-log:
       environment: production
-      system-code: <<parameters.systemCode>>
+      system-code: <<parameters.system-code>>

--- a/package-lock.json
+++ b/package-lock.json
@@ -28523,9 +28523,6 @@
         "@dotcom-tool-kit/circleci": "^4.0.3",
         "tslib": "^2.3.1"
       },
-      "devDependencies": {
-        "type-fest": "^3.6.0"
-      },
       "peerDependencies": {
         "dotcom-tool-kit": "^2.6.0"
       }
@@ -33588,8 +33585,7 @@
       "version": "file:plugins/circleci-deploy",
       "requires": {
         "@dotcom-tool-kit/circleci": "^4.0.3",
-        "tslib": "^2.3.1",
-        "type-fest": "^3.6.0"
+        "tslib": "^2.3.1"
       },
       "dependencies": {
         "tslib": {
@@ -38620,7 +38616,7 @@
     "ansi-escapes": {
       "version": "4.3.2",
       "requires": {
-        "type-fest": "3.6.0"
+        "type-fest": "^0.21.3"
       }
     },
     "ansi-regex": {
@@ -39211,7 +39207,7 @@
         "chalk": "^4.1.0",
         "cli-boxes": "^2.2.1",
         "string-width": "^4.2.2",
-        "type-fest": "3.6.0",
+        "type-fest": "^0.20.2",
         "widest-line": "^3.1.0",
         "wrap-ansi": "^7.0.0"
       },
@@ -44497,7 +44493,7 @@
         "graceful-fs": "^4.1.15",
         "parse-json": "^5.0.0",
         "strip-bom": "^4.0.0",
-        "type-fest": "3.6.0"
+        "type-fest": "^0.6.0"
       }
     },
     "loader-runner": {
@@ -46198,7 +46194,7 @@
       "peer": true,
       "requires": {
         "mimic-fn": "^4.0.0",
-        "type-fest": "3.6.0"
+        "type-fest": "^3.0.0"
       },
       "dependencies": {
         "mimic-fn": {
@@ -47292,7 +47288,7 @@
         "@types/normalize-package-data": "^2.4.0",
         "normalize-package-data": "^2.5.0",
         "parse-json": "^5.0.0",
-        "type-fest": "3.6.0"
+        "type-fest": "^0.6.0"
       },
       "dependencies": {
         "hosted-git-info": {
@@ -47962,7 +47958,7 @@
     "serialize-error": {
       "version": "5.0.0",
       "requires": {
-        "type-fest": "3.6.0"
+        "type-fest": "^0.8.0"
       }
     },
     "serialize-javascript": {
@@ -48380,7 +48376,7 @@
             "chalk": "^5.0.1",
             "cli-boxes": "^3.0.0",
             "string-width": "^5.1.2",
-            "type-fest": "3.6.0",
+            "type-fest": "^2.13.0",
             "widest-line": "^4.0.1",
             "wrap-ansi": "^8.0.1"
           }
@@ -50893,7 +50889,7 @@
       "dev": true,
       "requires": {
         "sort-keys": "^2.0.0",
-        "type-fest": "3.6.0",
+        "type-fest": "^0.4.1",
         "write-json-file": "^3.2.0"
       }
     },

--- a/package-lock.json
+++ b/package-lock.json
@@ -28543,6 +28543,9 @@
         "@dotcom-tool-kit/circleci": "^4.0.3",
         "tslib": "^2.3.1"
       },
+      "devDependencies": {
+        "winston": "^3.5.1"
+      },
       "peerDependencies": {
         "dotcom-tool-kit": "^2.6.0"
       }
@@ -33616,7 +33619,8 @@
       "version": "file:plugins/circleci-deploy",
       "requires": {
         "@dotcom-tool-kit/circleci": "^4.0.3",
-        "tslib": "^2.3.1"
+        "tslib": "^2.3.1",
+        "winston": "^3.5.1"
       },
       "dependencies": {
         "tslib": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -6022,6 +6022,10 @@
       "resolved": "plugins/backend-heroku-app",
       "link": true
     },
+    "node_modules/@dotcom-tool-kit/backend-serverless-app": {
+      "resolved": "plugins/backend-serverless-app",
+      "link": true
+    },
     "node_modules/@dotcom-tool-kit/circleci": {
       "resolved": "plugins/circleci",
       "link": true
@@ -28490,6 +28494,22 @@
         "dotcom-tool-kit": "^2.6.0"
       }
     },
+    "plugins/backend-serverless-app": {
+      "name": "@dotcom-tool-kit/backend-serverless-app",
+      "version": "0.1.0",
+      "license": "ISC",
+      "dependencies": {
+        "@dotcom-tool-kit/circleci-deploy": "^2.0.3",
+        "@dotcom-tool-kit/husky-npm": "^3.0.0",
+        "@dotcom-tool-kit/node": "^2.3.2",
+        "@dotcom-tool-kit/npm": "^2.0.16",
+        "@dotcom-tool-kit/secret-squirrel": "^1.0.14",
+        "@dotcom-tool-kit/serverless": "^0.1.0"
+      },
+      "peerDependencies": {
+        "dotcom-tool-kit": "2.x"
+      }
+    },
     "plugins/circleci": {
       "name": "@dotcom-tool-kit/circleci",
       "version": "4.0.3",
@@ -33544,6 +33564,17 @@
         "@dotcom-tool-kit/node": "^2.3.2",
         "@dotcom-tool-kit/npm": "^2.0.16",
         "@dotcom-tool-kit/secret-squirrel": "^1.0.14"
+      }
+    },
+    "@dotcom-tool-kit/backend-serverless-app": {
+      "version": "file:plugins/backend-serverless-app",
+      "requires": {
+        "@dotcom-tool-kit/circleci-deploy": "^2.0.3",
+        "@dotcom-tool-kit/husky-npm": "^3.0.0",
+        "@dotcom-tool-kit/node": "^2.3.2",
+        "@dotcom-tool-kit/npm": "^2.0.16",
+        "@dotcom-tool-kit/secret-squirrel": "^1.0.14",
+        "@dotcom-tool-kit/serverless": "^0.1.0"
       }
     },
     "@dotcom-tool-kit/circleci": {

--- a/plugins/backend-serverless-app/.toolkitrc.yml
+++ b/plugins/backend-serverless-app/.toolkitrc.yml
@@ -1,0 +1,12 @@
+plugins:
+  - '@dotcom-tool-kit/npm'
+  - '@dotcom-tool-kit/circleci-deploy'
+  - '@dotcom-tool-kit/serverless'
+  - '@dotcom-tool-kit/node'
+  - '@dotcom-tool-kit/husky-npm'
+  - '@dotcom-tool-kit/secret-squirrel'
+
+hooks:
+  'run:local': ServerlessRun
+  'deploy:review': ServerlessProvision
+  'deploy:production': ServerlessDeploy

--- a/plugins/backend-serverless-app/index.js
+++ b/plugins/backend-serverless-app/index.js
@@ -1,0 +1,1 @@
+exports.tasks = []

--- a/plugins/backend-serverless-app/package.json
+++ b/plugins/backend-serverless-app/package.json
@@ -1,0 +1,27 @@
+{
+  "name": "@dotcom-tool-kit/backend-serverless-app",
+  "version": "0.1.0",
+  "description": "",
+  "main": "lib",
+  "keywords": [],
+  "author": "FT.com Platforms Team <platforms-team.customer-products@ft.com>",
+  "license": "ISC",
+  "dependencies": {
+    "@dotcom-tool-kit/circleci-deploy": "^2.0.3",
+    "@dotcom-tool-kit/husky-npm": "^3.0.0",
+    "@dotcom-tool-kit/node": "^2.3.2",
+    "@dotcom-tool-kit/npm": "^2.0.16",
+    "@dotcom-tool-kit/secret-squirrel": "^1.0.14",
+    "@dotcom-tool-kit/serverless": "^0.1.0"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/financial-times/dotcom-tool-kit.git",
+    "directory": "plugins/backend-serverless-app"
+  },
+  "bugs": "https://github.com/financial-times/dotcom-tool-kit/issues",
+  "homepage": "https://github.com/financial-times/dotcom-tool-kit/tree/main/plugins/backend-serverless-app",
+  "peerDependencies": {
+    "dotcom-tool-kit": "2.x"
+  }
+}

--- a/plugins/backend-serverless-app/readme.md
+++ b/plugins/backend-serverless-app/readme.md
@@ -1,0 +1,27 @@
+# @dotcom-tool-kit/backend-serverless-app
+
+A bootstrap plugin that provides the minimum required Tool Kit plugins for a "backend" (aka an [API](https://github.com/Financial-Times/next/wiki/Naming-Conventions#apis)) that is deployed to AWS. The plugins are:
+
+- [`@dotcom-tool-kit/npm`](https://github.com/Financial-Times/dotcom-tool-kit/tree/main/plugins/npm)
+- [`@dotcom-tool-kit/circleci-deploy`](https://github.com/Financial-Times/dotcom-tool-kit/tree/main/plugins/circleci-deploy)
+- [`@dotcom-tool-kit/serverless`](https://github.com/Financial-Times/dotcom-tool-kit/tree/main/plugins/serverless)
+- [`@dotcom-tool-kit/node`](https://github.com/Financial-Times/dotcom-tool-kit/tree/main/plugins/node)
+- [`@dotcom-tool-kit/husky-npm`](https://github.com/Financial-Times/dotcom-tool-kit/tree/main/plugins/husky-npm)
+- [`@dotcom-tool-kit/secret-squirrel`](https://github.com/Financial-Times/dotcom-tool-kit/tree/main/plugins/secret-squirrel)
+
+This bootstrap plugin is also preconfigured to run the `ServerlessRun` task on the hook `run:local`, and binds the tasks defined by the `serverless` plugin to the hooks defined by `circleci-deploy`.
+
+## Installation
+
+With Tool Kit [already set up](https://github.com/financial-times/dotcom-tool-kit#installing-and-using-tool-kit), install this plugin as a dev dependency:
+
+```sh
+npm install --save-dev @dotcom-tool-kit/backend-serverless-app
+```
+
+And add it to your repo's `.toolkitrc.yml`:
+
+```yaml
+plugins:
+    - '@dotcom-tool-kit/backend-serverless-app'
+```

--- a/plugins/circleci-deploy/package.json
+++ b/plugins/circleci-deploy/package.json
@@ -29,8 +29,5 @@
   },
   "peerDependencies": {
     "dotcom-tool-kit": "^2.6.0"
-  },
-  "devDependencies": {
-    "type-fest": "^3.6.0"
   }
 }

--- a/plugins/circleci-deploy/package.json
+++ b/plugins/circleci-deploy/package.json
@@ -27,6 +27,9 @@
   "volta": {
     "extends": "../../package.json"
   },
+  "devDependencies": {
+    "winston": "^3.5.1"
+  },
   "peerDependencies": {
     "dotcom-tool-kit": "^2.6.0"
   }

--- a/plugins/circleci-deploy/src/index.ts
+++ b/plugins/circleci-deploy/src/index.ts
@@ -5,11 +5,21 @@ import CircleCiConfigHook, {
 } from '@dotcom-tool-kit/circleci/lib/circleci-config'
 import { TestCI } from '@dotcom-tool-kit/circleci/lib/index'
 import { getOptions } from '@dotcom-tool-kit/options'
+import type { Logger } from 'winston'
 
 // CircleCI config generator which will additionally optionally pass Serverless
 // options as parameters to the orb job to enable OIDC authentication
-const generateConfigWithServerlessOptions = (jobOptions: JobGeneratorOptions): CircleCIStatePartial => {
+const generateConfigWithServerlessOptions = (
+  logger: Logger,
+  jobOptions: JobGeneratorOptions
+): CircleCIStatePartial => {
   const serverlessOptions = getOptions('@dotcom-tool-kit/serverless')
+  const herokuOptions = getOptions('@dotcom-tool-kit/heroku')
+  if (serverlessOptions && herokuOptions) {
+    logger.warn(
+      'Tool Kit currently does not support managing Heroku and Serverless apps in the same project.'
+    )
+  }
   if (serverlessOptions?.awsAccountId && serverlessOptions?.systemCode) {
     jobOptions.additionalFields ??= {}
     jobOptions.additionalFields['aws-account-id'] = serverlessOptions.awsAccountId
@@ -23,7 +33,7 @@ export class DeployReview extends CircleCiConfigHook {
   // needs to be a getter so that we can lazily wait for the global options
   // object to be assigned before getting values from it
   get config(): CircleCIStatePartial {
-    return generateConfigWithServerlessOptions({
+    return generateConfigWithServerlessOptions(this.logger, {
       name: DeployReview.job,
       addToNightly: true,
       requires: ['tool-kit/setup', 'waiting-for-approval'],
@@ -75,7 +85,7 @@ export class TestStaging extends CypressCiHook {
 export class DeployProduction extends CircleCiConfigHook {
   static job = 'tool-kit/deploy-production'
   get config(): CircleCIStatePartial {
-    return generateConfigWithServerlessOptions({
+    return generateConfigWithServerlessOptions(this.logger, {
       name: DeployProduction.job,
       addToNightly: false,
       requires: [new TestStaging(this.logger).job, TestCI.job],

--- a/plugins/serverless/src/index.ts
+++ b/plugins/serverless/src/index.ts
@@ -1,4 +1,5 @@
+import ServerlessDeploy from './tasks/deploy'
 import ServerlessProvision from './tasks/provision'
 import ServerlessRun from './tasks/run'
 
-export const tasks = [ServerlessRun, ServerlessProvision]
+export const tasks = [ServerlessRun, ServerlessDeploy, ServerlessProvision]

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -22,6 +22,7 @@
     "plugins/babel": {},
     "plugins/backend-app": {},
     "plugins/backend-heroku-app": {},
+    "plugins/backend-serverless-app": {},
     "plugins/circleci": {},
     "plugins/circleci-deploy": {},
     "plugins/circleci-heroku": {},
@@ -44,6 +45,7 @@
     "plugins/pa11y": {},
     "plugins/prettier": {},
     "plugins/secret-squirrel": {},
+    "plugins/serverless": {},
     "plugins/typescript": {},
     "plugins/upload-assets-to-s3": {},
     "plugins/webpack": {}


### PR DESCRIPTION
# Description

This PR adds a new Tool Kit plugin that users can include to bundle the baseline recommended configuration for a Serverless project.

# Checklist:

- [x] My branch has been rebased onto the latest commit on main (don't merge main into your branch)
- [x] My commit messages are [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/), for example: `feat(circleci): add support for nightly workflows`, `fix: set Heroku app name for staging apps too`
