### PR TITLE
Clear config cache for migration script after updating options

### DIFF
--- a/core/create/src/prompts/conflicts.ts
+++ b/core/create/src/prompts/conflicts.ts
@@ -1,30 +1,20 @@
 import * as ToolkitErrorModule from '@dotcom-tool-kit/error'
 import { rootLogger as winstonLogger, styles } from '@dotcom-tool-kit/logger'
 import type { RCFile } from '@dotcom-tool-kit/types'
-import type { cosmiconfig } from 'cosmiconfig'
 import type { ValidConfig } from 'dotcom-tool-kit/lib/config'
 import type installHooksType from 'dotcom-tool-kit/lib/install'
 import { promises as fs } from 'fs'
 import importCwd from 'import-cwd'
-import YAML from 'yaml'
 import type Logger from 'komatsu'
 import ordinal from 'ordinal'
 import prompt from 'prompts'
-import { catchToolKitErrorsInLogger } from '../logger'
+import YAML from 'yaml'
 
 interface ConflictsParams {
   error: ToolkitErrorModule.ToolKitConflictError
   logger: Logger
   toolKitConfig: RCFile
   configPath: string
-}
-
-function clearConfigCache() {
-  // we need to import explorer from the app itself instead of npx as this is
-  // the object used by installHooks()
-  return (importCwd('dotcom-tool-kit/lib/rc-file') as {
-    explorer: ReturnType<typeof cosmiconfig>
-  }).explorer.clearSearchCache()
 }
 
 export function installHooks(logger: typeof winstonLogger): Promise<ValidConfig> {
@@ -87,16 +77,6 @@ sound alright?`
       fs.writeFile(configPath, configFile),
       `recreating ${styles.filepath('.toolkitrc.yml')}`
     )
-    // Clear config cache now that config has been updated
-    clearConfigCache()
-
-    await catchToolKitErrorsInLogger(
-      logger,
-      installHooks(winstonLogger),
-      'installing Tool Kit hooks again',
-      false
-    )
-
     return false
   }
   return true


### PR DESCRIPTION
# Description

We need to do this otherwise `cosmiconfig` will return us the old, cached options when we want to do our first install. This has only been causing us obvious issues since the migration to zod because the validation complains about the options that weren't defined when originally loading the config, but it would likely have caused subtle bugs in the installation process previously too.

# Checklist:

- [x] My branch has been rebased onto the latest commit on main (don't merge main into your branch)
- [x] My commit messages are [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/), for example: `feat(circleci): add support for nightly workflows`, `fix: set Heroku app name for staging apps too`
