### PR TITLE
CPP-1372: Use env_var_name type for defining system-code for change-api orb

### DIFF
--- a/orb/src/jobs/deploy-production.yml
+++ b/orb/src/jobs/deploy-production.yml
@@ -6,11 +6,10 @@ parameters:
     default: ''
     type: string
   system-code:
-    default: $CIRCLE_PROJECT_REPONAME
+    type: env_var_name
+    default: CIRCLE_PROJECT_REPONAME
     description: >-
-      The systemcode of the system being changed. Defaults to the repository
-      name.
-    type: string
+      The environment variable containing the system-code of the system being changed.
   environment:
     default: production
     description: The environment in which the system is being changed.
@@ -33,5 +32,5 @@ steps:
       name: Deploy to production
       command: npx dotcom-tool-kit deploy:production
   - change-api/change-log:
-      environment: production
-      system-code: <<parameters.system-code>>
+      environment: << parameters.environment >>
+      system-code: << parameters.system-code >>

--- a/orb/src/jobs/heroku-promote.yml
+++ b/orb/src/jobs/heroku-promote.yml
@@ -2,12 +2,11 @@ parameters:
   executor:
     default: default
     type: executor
-  systemCode:
-    default: $CIRCLE_PROJECT_REPONAME
+  system-code:
+    type: env_var_name
+    default: CIRCLE_PROJECT_REPONAME
     description: >-
-      The systemcode of the system being changed. Defaults to the repository
-      name.
-    type: string
+      The environment variable containing the system-code of the system being changed.
   environment:
     default: production
     description: The environment in which the system is being changed.
@@ -21,5 +20,5 @@ steps:
       name: Deploy to production
       command: npx dotcom-tool-kit deploy:production
   - change-api/change-log:
-      environment: production
-      system-code: <<parameters.systemCode>>
+      environment: << parameters.environment >>
+      system-code: << parameters.system-code >>


### PR DESCRIPTION
Since using change-api@1.0.1, it no longer evaluates our system-code parameter as the value of the environment variable $CIRCLE_PROJECT_REPONAME. Instead it sends the string "CIRCLE_PROJECT_REPONAME" which fails the call to the change api (see slack thread linked below). According to the CircleCI docs (linked below), there is a parameter type of `env_var_name` which you provide a string of the environment variable name. This should pass the value of the $CIRCLE_PROJECT_REPONAME to the change-api call.

Relevant slack thread:
https://financialtimes.slack.com/archives/C02HH3JAQ5V/p1681485994978449?thread_ts=1681483126.496729&cid=C02HH3JAQ5V

CircleCI doc:
https://circleci.com/docs/reusing-config/#environment-variable-name

# Checklist:

- [x] My branch has been rebased onto the latest commit on main (don't merge main into your branch)
- [x] My commit messages are [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/), for example: `feat(circleci): add support for nightly workflows`, `fix: set Heroku app name for staging apps too`
