### PR TITLE
CPP-1372: use circleci context to deploy orb

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -369,6 +369,7 @@ workflows:
           source-dir: orb/src
       # Publish development version(s) of the orb.
       - orb-tools/publish-dev:
+          context: circleci-orb-publishing
           orb-name: financial-times/dotcom-tool-kit
           requires:
             - orb-tools/lint
@@ -392,6 +393,7 @@ workflows:
           filters:
             <<: *filters_orbs_release_build
       - orb-tools/publish:
+          context: circleci-orb-publishing
           attach-workspace: true
           # Strip leading 'orb-v' from git tag
           orb-ref: financial-times/dotcom-tool-kit@${CIRCLE_TAG:5}


### PR DESCRIPTION
# Description

[Code Management have created us a CircleCI context](https://financialtimes.slack.com/archives/C02ST9MNV0S/p1681727613774559?thread_ts=1681725871.981079&cid=C02ST9MNV0S) that contains a `CIRCLE_TOKEN` that has permanent permissions to publish our dotcom-tool-kit Orb. This PR implements this new context. I have also made a copy of the old `CIRCLE_TOKEN` in vault called `CIRCLE_TOKEN_COPY` and deleted the original. If this works as expected, I will delete the copy.

# Checklist:

- [x] My branch has been rebased onto the latest commit on main (don't merge main into your branch)
- [x] My commit messages are [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/), for example: `feat(circleci): add support for nightly workflows`, `fix: set Heroku app name for staging apps too`
