### PR TITLE
Revert #402 and update change-api-orb

### DIFF
--- a/orb/src/@orb.yml
+++ b/orb/src/@orb.yml
@@ -12,6 +12,6 @@ display:
 # If your orb requires other orbs, you can import them like this. Otherwise remove the "orbs" stanza.
 orbs:
   node: circleci/node@5.0.2
-  change-api: financial-times/change-api@1.0.1
+  change-api: financial-times/change-api@1.0.7
   aws-cli: circleci/aws-cli@3.1.4
   serverless-framework: circleci/serverless-framework@2.0.1

--- a/orb/src/jobs/deploy-production.yml
+++ b/orb/src/jobs/deploy-production.yml
@@ -6,10 +6,11 @@ parameters:
     default: ''
     type: string
   system-code:
-    type: env_var_name
-    default: CIRCLE_PROJECT_REPONAME
+    default: $CIRCLE_PROJECT_REPONAME
     description: >-
-      The environment variable containing the system-code of the system being changed.
+      The systemcode of the system being changed. Defaults to the repository
+      name.
+    type: string
   environment:
     default: production
     description: The environment in which the system is being changed.
@@ -32,5 +33,5 @@ steps:
       name: Deploy to production
       command: npx dotcom-tool-kit deploy:production
   - change-api/change-log:
-      environment: << parameters.environment >>
-      system-code: << parameters.system-code >>
+      environment: production
+      system-code: <<parameters.system-code>>

--- a/orb/src/jobs/deploy-production.yml
+++ b/orb/src/jobs/deploy-production.yml
@@ -8,7 +8,7 @@ parameters:
   system-code:
     default: $CIRCLE_PROJECT_REPONAME
     description: >-
-      The systemcode of the system being changed. Defaults to the repository
+      The system-code of the system being changed. Defaults to the repository
       name.
     type: string
   environment:
@@ -34,4 +34,4 @@ steps:
       command: npx dotcom-tool-kit deploy:production
   - change-api/change-log:
       environment: production
-      system-code: <<parameters.system-code>>
+      system-code: << parameters.system-code >>

--- a/orb/src/jobs/deploy-production.yml
+++ b/orb/src/jobs/deploy-production.yml
@@ -11,10 +11,6 @@ parameters:
       The system-code of the system being changed. Defaults to the repository
       name.
     type: string
-  environment:
-    default: production
-    description: The environment in which the system is being changed.
-    type: string
 
 executor: << parameters.executor >>
 

--- a/orb/src/jobs/heroku-promote.yml
+++ b/orb/src/jobs/heroku-promote.yml
@@ -2,10 +2,10 @@ parameters:
   executor:
     default: default
     type: executor
-  systemCode:
+  system-code:
     default: $CIRCLE_PROJECT_REPONAME
     description: >-
-      The systemcode of the system being changed. Defaults to the repository
+      The system-code of the system being changed. Defaults to the repository
       name.
     type: string
   environment:
@@ -22,4 +22,4 @@ steps:
       command: npx dotcom-tool-kit deploy:production
   - change-api/change-log:
       environment: production
-      system-code: <<parameters.systemCode>>
+      system-code: << parameters.system-code >>

--- a/orb/src/jobs/heroku-promote.yml
+++ b/orb/src/jobs/heroku-promote.yml
@@ -2,11 +2,12 @@ parameters:
   executor:
     default: default
     type: executor
-  system-code:
-    type: env_var_name
-    default: CIRCLE_PROJECT_REPONAME
+  systemCode:
+    default: $CIRCLE_PROJECT_REPONAME
     description: >-
-      The environment variable containing the system-code of the system being changed.
+      The systemcode of the system being changed. Defaults to the repository
+      name.
+    type: string
   environment:
     default: production
     description: The environment in which the system is being changed.
@@ -20,5 +21,5 @@ steps:
       name: Deploy to production
       command: npx dotcom-tool-kit deploy:production
   - change-api/change-log:
-      environment: << parameters.environment >>
-      system-code: << parameters.system-code >>
+      environment: production
+      system-code: <<parameters.systemCode>>

--- a/orb/src/jobs/heroku-promote.yml
+++ b/orb/src/jobs/heroku-promote.yml
@@ -8,10 +8,6 @@ parameters:
       The system-code of the system being changed. Defaults to the repository
       name.
     type: string
-  environment:
-    default: production
-    description: The environment in which the system is being changed.
-    type: string
 
 executor: << parameters.executor >>
 


### PR DESCRIPTION
Reverts Financial-Times/dotcom-tool-kit#402 and update to new Change API Orb which fixes the change-log job.