### PR TITLE
Drop support for Node 14

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -187,21 +187,21 @@ workflows:
           name: build-v<< matrix.node-version >>
           matrix:
             parameters:
-              node-version: [ '16.14', '14.19' ]
+              node-version: [ '16.14' ]
       - test:
           requires:
             - build-v<< matrix.node-version >>
           name: test-v<< matrix.node-version >>
           matrix:
             parameters:
-              node-version: [ '16.14', '14.19' ]
+              node-version: [ '16.14' ]
       - lint:
           requires:
             - build-v<< matrix.node-version >>
           name: lint-v<< matrix.node-version >>
           matrix:
             parameters:
-              node-version: [ '16.14', '14.19' ]
+              node-version: [ '16.14' ]
 
   release-please:
     when:
@@ -231,21 +231,21 @@ workflows:
           name: build-v<< matrix.node-version >>
           matrix:
             parameters:
-              node-version: [ '16.14', '14.19' ]
+              node-version: [ '16.14' ]
       - test:
           requires:
             - build-v<< matrix.node-version >>
           name: test-v<< matrix.node-version >>
           matrix:
             parameters:
-              node-version: [ '16.14', '14.19' ]
+              node-version: [ '16.14' ]
       - lint:
           requires:
             - build-v<< matrix.node-version >>
           name: lint-v<< matrix.node-version >>
           matrix:
             parameters:
-              node-version: [ '16.14', '14.19' ]
+              node-version: [ '16.14' ]
 
   build-test-publish:
     when:
@@ -260,7 +260,7 @@ workflows:
           name: build-v<< matrix.node-version >>
           matrix:
             parameters:
-              node-version: [ '16.14', '14.19' ]
+              node-version: [ '16.14' ]
       - test:
           filters:
             <<: *filters_release_build
@@ -269,7 +269,7 @@ workflows:
           name: test-v<< matrix.node-version >>
           matrix:
             parameters:
-              node-version: [ '16.14', '14.19' ]
+              node-version: [ '16.14' ]
       - lint:
           filters:
             <<: *filters_release_build
@@ -278,7 +278,7 @@ workflows:
           name: lint-v<< matrix.node-version >>
           matrix:
             parameters:
-              node-version: [ '16.14', '14.19' ]
+              node-version: [ '16.14' ]
       - publish:
           context: npm-publish-token
           filters:
@@ -300,7 +300,7 @@ workflows:
           name: build-v<< matrix.node-version >>
           matrix:
             parameters:
-              node-version: [ '16.14', '14.19' ]
+              node-version: [ '16.14' ]
       - test:
           filters:
             <<: *filters_prerelease_build
@@ -309,7 +309,7 @@ workflows:
           name: test-v<< matrix.node-version >>
           matrix:
             parameters:
-              node-version: [ '16.14', '14.19' ]
+              node-version: [ '16.14' ]
       - lint:
           filters:
             <<: *filters_prerelease_build
@@ -318,7 +318,7 @@ workflows:
           name: lint-v<< matrix.node-version >>
           matrix:
             parameters:
-              node-version: [ '16.14', '14.19' ]
+              node-version: [ '16.14' ]
       - prepublish:
           context: npm-publish-token
           filters:
@@ -342,7 +342,7 @@ workflows:
           name: build-v<< matrix.node-version >>
           matrix:
             parameters:
-              node-version: [ '16.14', '14.19' ]
+              node-version: [ '16.14' ]
       - test:
           requires:
             - build-v<< matrix.node-version >>
@@ -350,7 +350,7 @@ workflows:
           name: test-v<< matrix.node-version >>
           matrix:
             parameters:
-              node-version: [ '16.14', '14.19' ]
+              node-version: [ '16.14' ]
 
   # Prior to producing a development orb (which requires credentials) basic validation, linting, and even unit testing can be performed.
   # This workflow will run on every commit

--- a/core/cli/package.json
+++ b/core/cli/package.json
@@ -33,7 +33,7 @@
     "@dotcom-tool-kit/webpack": "^2.1.15",
     "@jest/globals": "^27.4.6",
     "@types/lodash": "^4.14.185",
-    "@types/node": "^12.20.24",
+    "@types/node": "^16.18.23",
     "chai": "^4.3.4",
     "globby": "^10.0.2",
     "ts-node": "^8.10.2",
@@ -54,7 +54,7 @@
     "zod-validation-error": "^0.3.0"
   },
   "engines": {
-    "node": ">=8.0.0"
+    "node": "16.x"
   },
   "files": [
     "/bin",

--- a/core/create/package.json
+++ b/core/create/package.json
@@ -47,7 +47,7 @@
   "devDependencies": {
     "@types/financial-times__package-json": "^1.9.0",
     "@types/lodash": "^4.14.185",
-    "@types/node": "^12.20.24",
+    "@types/node": "^16.18.23",
     "@types/node-fetch": "^2.6.2",
     "@types/pacote": "^11.1.3",
     "@types/prompts": "^2.0.14",

--- a/lib/wait-for-ok/package.json
+++ b/lib/wait-for-ok/package.json
@@ -21,7 +21,7 @@
   "bugs": "https://github.com/financial-times/dotcom-tool-kit/issues",
   "homepage": "https://github.com/financial-times/dotcom-tool-kit/tree/main/lib/wait-for-ok",
   "devDependencies": {
-    "@types/node": "^12.20.24",
+    "@types/node": "^16.18.23",
     "@types/node-fetch": "^2.5.10",
     "winston": "^3.5.1"
   },

--- a/package-lock.json
+++ b/package-lock.json
@@ -23,7 +23,7 @@
         "@commitlint/config-conventional": "^16.0.0",
         "@financial-times/eslint-config-next": "^6.0.0",
         "@types/jest": "^27.4.0",
-        "@types/node": "^12.20.24",
+        "@types/node": "^16.18.23",
         "@typescript-eslint/eslint-plugin": "^5.57.0",
         "@typescript-eslint/parser": "^5.57.0",
         "check-engines": "^1.5.0",
@@ -39,7 +39,7 @@
         "typescript": "~4.9.5"
       },
       "engines": {
-        "node": "14.x || 16.x",
+        "node": "16.x",
         "npm": "7.x || 8.x"
       }
     },
@@ -78,15 +78,21 @@
         "@dotcom-tool-kit/webpack": "^2.1.15",
         "@jest/globals": "^27.4.6",
         "@types/lodash": "^4.14.185",
-        "@types/node": "^12.20.24",
+        "@types/node": "^16.18.23",
         "chai": "^4.3.4",
         "globby": "^10.0.2",
         "ts-node": "^8.10.2",
         "winston": "^3.5.1"
       },
       "engines": {
-        "node": ">=8.0.0"
+        "node": "16.x"
       }
+    },
+    "core/cli/node_modules/@types/node": {
+      "version": "17.0.45",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-17.0.45.tgz",
+      "integrity": "sha512-w+tIMs3rq2afQdsPJlODhoUEKzFP1ayaoyl1CcnwtIlsVe7K7bA1NGm4s3PraqTLlXnbIN84zuBlxBWo1u9BLw==",
+      "dev": true
     },
     "core/cli/node_modules/globby": {
       "version": "10.0.2",
@@ -144,7 +150,7 @@
       "devDependencies": {
         "@types/financial-times__package-json": "^1.9.0",
         "@types/lodash": "^4.14.185",
-        "@types/node": "^12.20.24",
+        "@types/node": "^16.18.23",
         "@types/node-fetch": "^2.6.2",
         "@types/pacote": "^11.1.3",
         "@types/prompts": "^2.0.14",
@@ -961,6 +967,12 @@
         "node": ">=14.0.0"
       }
     },
+    "core/create/node_modules/@types/node": {
+      "version": "12.20.55",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-12.20.55.tgz",
+      "integrity": "sha512-J8xLz7q2OFulZ2cyGTLE1TbbZcjpno7FaN6zdJNrgAdrJ+DZzh/uFR6YrTb4C+nXakvud8Q4+rbhoIWlYQbUFQ==",
+      "dev": true
+    },
     "core/create/node_modules/code-suggester": {
       "version": "4.3.1",
       "resolved": "https://registry.npmjs.org/code-suggester/-/code-suggester-4.3.1.tgz",
@@ -1203,10 +1215,16 @@
         "tslib": "^2.3.1"
       },
       "devDependencies": {
-        "@types/node": "^12.20.24",
+        "@types/node": "^16.18.23",
         "@types/node-fetch": "^2.5.10",
         "winston": "^3.5.1"
       }
+    },
+    "lib/wait-for-ok/node_modules/@types/node": {
+      "version": "12.20.55",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-12.20.55.tgz",
+      "integrity": "sha512-J8xLz7q2OFulZ2cyGTLE1TbbZcjpno7FaN6zdJNrgAdrJ+DZzh/uFR6YrTb4C+nXakvud8Q4+rbhoIWlYQbUFQ==",
+      "dev": true
     },
     "lib/wait-for-ok/node_modules/tslib": {
       "version": "2.4.1",
@@ -9515,8 +9533,9 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "12.20.50",
-      "license": "MIT"
+      "version": "16.18.23",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-16.18.23.tgz",
+      "integrity": "sha512-XAMpaw1s1+6zM+jn2tmw8MyaRDIJfXxqmIQIS0HfoGYPuf7dUWeiUKopwq13KFX9lEp1+THGtlaaYx39Nxr58g=="
     },
     "node_modules/@types/node-fetch": {
       "version": "2.6.2",
@@ -33707,7 +33726,7 @@
         "@quarterto/parse-makefile-rules": "^1.1.0",
         "@types/financial-times__package-json": "^1.9.0",
         "@types/lodash": "^4.14.185",
-        "@types/node": "^12.20.24",
+        "@types/node": "^16.18.23",
         "@types/node-fetch": "^2.6.2",
         "@types/pacote": "^11.1.3",
         "@types/prompts": "^2.0.14",
@@ -34377,6 +34396,11 @@
             "@aws-sdk/util-buffer-from": "3.295.0",
             "tslib": "^2.5.0"
           }
+        },
+        "@types/node": {
+          "version": "https://registry.npmjs.org/@types/node/-/node-12.20.55.tgz",
+          "integrity": "sha512-J8xLz7q2OFulZ2cyGTLE1TbbZcjpno7FaN6zdJNrgAdrJ+DZzh/uFR6YrTb4C+nXakvud8Q4+rbhoIWlYQbUFQ==",
+          "dev": true
         },
         "code-suggester": {
           "version": "4.3.1",
@@ -35348,13 +35372,18 @@
     "@dotcom-tool-kit/wait-for-ok": {
       "version": "file:lib/wait-for-ok",
       "requires": {
-        "@types/node": "^12.20.24",
+        "@types/node": "^16.18.23",
         "@types/node-fetch": "^2.5.10",
         "node-fetch": "^2.6.8",
         "tslib": "^2.3.1",
         "winston": "^3.5.1"
       },
       "dependencies": {
+        "@types/node": {
+          "version": "https://registry.npmjs.org/@types/node/-/node-12.20.55.tgz",
+          "integrity": "sha512-J8xLz7q2OFulZ2cyGTLE1TbbZcjpno7FaN6zdJNrgAdrJ+DZzh/uFR6YrTb4C+nXakvud8Q4+rbhoIWlYQbUFQ==",
+          "dev": true
+        },
         "tslib": {
           "version": "2.4.1",
           "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
@@ -38064,7 +38093,9 @@
       "dev": true
     },
     "@types/node": {
-      "version": "12.20.50"
+      "version": "16.18.23",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-16.18.23.tgz",
+      "integrity": "sha512-XAMpaw1s1+6zM+jn2tmw8MyaRDIJfXxqmIQIS0HfoGYPuf7dUWeiUKopwq13KFX9lEp1+THGtlaaYx39Nxr58g=="
     },
     "@types/node-fetch": {
       "version": "2.6.2",
@@ -38660,7 +38691,7 @@
     "ansi-escapes": {
       "version": "4.3.2",
       "requires": {
-        "type-fest": "3.6.0"
+        "type-fest": "^0.21.3"
       }
     },
     "ansi-regex": {
@@ -39251,7 +39282,7 @@
         "chalk": "^4.1.0",
         "cli-boxes": "^2.2.1",
         "string-width": "^4.2.2",
-        "type-fest": "3.6.0",
+        "type-fest": "^0.20.2",
         "widest-line": "^3.1.0",
         "wrap-ansi": "^7.0.0"
       },
@@ -40999,7 +41030,7 @@
         "@dotcom-tool-kit/webpack": "^2.1.15",
         "@jest/globals": "^27.4.6",
         "@types/lodash": "^4.14.185",
-        "@types/node": "^12.20.24",
+        "@types/node": "^16.18.23",
         "chai": "^4.3.4",
         "cosmiconfig": "^7.0.0",
         "globby": "^10.0.2",
@@ -41013,6 +41044,11 @@
         "zod-validation-error": "^0.3.0"
       },
       "dependencies": {
+        "@types/node": {
+          "version": "https://registry.npmjs.org/@types/node/-/node-17.0.45.tgz",
+          "integrity": "sha512-w+tIMs3rq2afQdsPJlODhoUEKzFP1ayaoyl1CcnwtIlsVe7K7bA1NGm4s3PraqTLlXnbIN84zuBlxBWo1u9BLw==",
+          "dev": true
+        },
         "globby": {
           "version": "10.0.2",
           "dev": true,
@@ -44570,7 +44606,7 @@
         "graceful-fs": "^4.1.15",
         "parse-json": "^5.0.0",
         "strip-bom": "^4.0.0",
-        "type-fest": "3.6.0"
+        "type-fest": "^0.6.0"
       }
     },
     "loader-runner": {
@@ -46271,7 +46307,7 @@
       "peer": true,
       "requires": {
         "mimic-fn": "^4.0.0",
-        "type-fest": "3.6.0"
+        "type-fest": "^3.0.0"
       },
       "dependencies": {
         "mimic-fn": {
@@ -47365,7 +47401,7 @@
         "@types/normalize-package-data": "^2.4.0",
         "normalize-package-data": "^2.5.0",
         "parse-json": "^5.0.0",
-        "type-fest": "3.6.0"
+        "type-fest": "^0.6.0"
       },
       "dependencies": {
         "hosted-git-info": {
@@ -48037,7 +48073,7 @@
     "serialize-error": {
       "version": "5.0.0",
       "requires": {
-        "type-fest": "3.6.0"
+        "type-fest": "^0.8.0"
       }
     },
     "serialize-javascript": {
@@ -48455,7 +48491,7 @@
             "chalk": "^5.0.1",
             "cli-boxes": "^3.0.0",
             "string-width": "^5.1.2",
-            "type-fest": "3.6.0",
+            "type-fest": "^2.13.0",
             "widest-line": "^4.0.1",
             "wrap-ansi": "^8.0.1"
           }
@@ -50970,7 +51006,7 @@
       "dev": true,
       "requires": {
         "sort-keys": "^2.0.0",
-        "type-fest": "3.6.0",
+        "type-fest": "^0.4.1",
         "write-json-file": "^3.2.0"
       }
     },

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "@commitlint/config-conventional": "^16.0.0",
     "@financial-times/eslint-config-next": "^6.0.0",
     "@types/jest": "^27.4.0",
-    "@types/node": "^12.20.24",
+    "@types/node": "^16.18.23",
     "@typescript-eslint/eslint-plugin": "^5.57.0",
     "@typescript-eslint/parser": "^5.57.0",
     "check-engines": "^1.5.0",
@@ -60,7 +60,7 @@
     "npm": "8.5.4"
   },
   "engines": {
-    "node": "14.x || 16.x",
+    "node": "16.x",
     "npm": "7.x || 8.x"
   },
   "overrides": {


### PR DESCRIPTION
# Description

Drops support for Node 14. This doesn't involve any changes to the code, but it marks the end of our support for Node 14 and potentially the beginning of us writing code that is not compatible with the older runtime.

# Checklist:

- [x] My branch has been rebased onto the latest commit on main (don't merge main into your branch)
- [x] My commit messages are [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/), for example: `feat(circleci): add support for nightly workflows`, `fix: set Heroku app name for staging apps too`
