### PR TITLE
fix(circleci): update majorOrbVersion to new published major version

### DIFF
--- a/plugins/circleci/src/circleci-config.ts
+++ b/plugins/circleci/src/circleci-config.ts
@@ -13,7 +13,7 @@ import path from 'path'
 import type { PartialDeep } from 'type-fest'
 import YAML from 'yaml'
 
-const majorOrbVersion = '3'
+const majorOrbVersion = '4'
 
 export type CircleCIState = CircleConfig
 /**


### PR DESCRIPTION
# Description

After dropping support for Node 14 in this repo (#409), our orb was also bumped to a new major version. This PR updates the CircleCI plugin to use the new major orb version.

# Checklist:

- [x] My branch has been rebased onto the latest commit on main (don't merge main into your branch)
- [x] My commit messages are [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/), for example: `feat(circleci): add support for nightly workflows`, `fix: set Heroku app name for staging apps too`
