### PR TITLE
CPP-1248 Use standard tsconfig base for Node 16

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -22,6 +22,7 @@
         "@commitlint/cli": "^16.1.0",
         "@commitlint/config-conventional": "^16.0.0",
         "@financial-times/eslint-config-next": "^6.0.0",
+        "@tsconfig/node16": "^1.0.3",
         "@types/jest": "^27.4.0",
         "@types/node": "^16.18.23",
         "@typescript-eslint/eslint-plugin": "^5.57.0",
@@ -10080,9 +10081,10 @@
       "license": "MIT"
     },
     "node_modules/@tsconfig/node16": {
-      "version": "1.0.2",
-      "devOptional": true,
-      "license": "MIT"
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node16/-/node16-1.0.3.tgz",
+      "integrity": "sha512-yOlFc+7UtL/89t2ZhjPvvB/DeAr3r+Dq58IgzsFkOAvVC6NMJXmCGjbptdXdR9qsX7pKcTL+s87FtYREi2dEEQ==",
+      "devOptional": true
     },
     "node_modules/@types/babel__core": {
       "version": "7.1.19",
@@ -39280,7 +39282,9 @@
       "devOptional": true
     },
     "@tsconfig/node16": {
-      "version": "1.0.2",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node16/-/node16-1.0.3.tgz",
+      "integrity": "sha512-yOlFc+7UtL/89t2ZhjPvvB/DeAr3r+Dq58IgzsFkOAvVC6NMJXmCGjbptdXdR9qsX7pKcTL+s87FtYREi2dEEQ==",
       "devOptional": true
     },
     "@types/babel__core": {

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "@commitlint/cli": "^16.1.0",
     "@commitlint/config-conventional": "^16.0.0",
     "@financial-times/eslint-config-next": "^6.0.0",
+    "@tsconfig/node16": "^1.0.3",
     "@types/jest": "^27.4.0",
     "@types/node": "^16.18.23",
     "@typescript-eslint/eslint-plugin": "^5.57.0",

--- a/tsconfig.settings.json
+++ b/tsconfig.settings.json
@@ -1,14 +1,9 @@
 {
+  "extends": "@tsconfig/node16/tsconfig.json",
   "compilerOptions": {
     "composite": true,
     "declaration": true,
     "declarationMap": true,
-    "importHelpers": true,
-    "module": "commonjs",
-    "strict": true,
-    "target": "ES2019",
-    "types": ["node"],
-    "lib": ["ES2019"],
-    "esModuleInterop": true
+    "importHelpers": true
   }
 }


### PR DESCRIPTION
# Description

This sets the `target` and `library` compiler options so that we aren't polyfilling any ECMAScript constructs that Node 16 supports natively, and the latest Node 16 library functions are type checked properly. It will be easier to remember to update this base configuration once we move to Node 18 than updating the options directly. These base options are defined [here](https://github.com/tsconfig/bases/blob/821d9aa0b2e075949b6764c1e4556f83ab7554a9/bases/node16.json).

It also sets some useful recommended default options, including some that we were already using which I've now removed as they're redundant.

# Checklist:

- [x] My branch has been rebased onto the latest commit on main (don't merge main into your branch)
- [x] My commit messages are [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/), for example: `feat(circleci): add support for nightly workflows`, `fix: set Heroku app name for staging apps too`
