### PR TITLE
CPP-1285 Improve Heroku errors

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -40,20 +40,20 @@
         "typescript": "~4.9.5"
       },
       "engines": {
-        "node": "16.x",
-        "npm": "7.x || 8.x"
+        "node": "16.x || 18.x",
+        "npm": "7.x || 8.x || 9.x"
       }
     },
     "core/cli": {
       "name": "dotcom-tool-kit",
-      "version": "3.0.0",
+      "version": "3.1.0",
       "license": "MIT",
       "dependencies": {
-        "@dotcom-tool-kit/error": "^3.0.0",
-        "@dotcom-tool-kit/logger": "^3.0.0",
-        "@dotcom-tool-kit/options": "^3.0.0",
-        "@dotcom-tool-kit/types": "^3.0.0",
-        "@dotcom-tool-kit/wait-for-ok": "^3.0.0",
+        "@dotcom-tool-kit/error": "^3.1.0",
+        "@dotcom-tool-kit/logger": "^3.1.0",
+        "@dotcom-tool-kit/options": "^3.1.0",
+        "@dotcom-tool-kit/types": "^3.1.0",
+        "@dotcom-tool-kit/wait-for-ok": "^3.1.0",
         "cosmiconfig": "^7.0.0",
         "lodash": "^4.17.21",
         "minimist": "^1.2.5",
@@ -66,17 +66,17 @@
         "dotcom-tool-kit": "bin/run"
       },
       "devDependencies": {
-        "@dotcom-tool-kit/babel": "^3.0.0",
-        "@dotcom-tool-kit/backend-heroku-app": "^2.0.0",
-        "@dotcom-tool-kit/circleci": "^5.0.0",
-        "@dotcom-tool-kit/circleci-deploy": "^3.0.0",
-        "@dotcom-tool-kit/eslint": "^3.0.0",
-        "@dotcom-tool-kit/frontend-app": "^3.0.0",
-        "@dotcom-tool-kit/heroku": "^3.0.0",
-        "@dotcom-tool-kit/mocha": "^3.0.0",
-        "@dotcom-tool-kit/n-test": "^3.0.0",
-        "@dotcom-tool-kit/npm": "^3.0.0",
-        "@dotcom-tool-kit/webpack": "^3.0.0",
+        "@dotcom-tool-kit/babel": "^3.1.0",
+        "@dotcom-tool-kit/backend-heroku-app": "^2.1.0",
+        "@dotcom-tool-kit/circleci": "^5.1.0",
+        "@dotcom-tool-kit/circleci-deploy": "^3.1.0",
+        "@dotcom-tool-kit/eslint": "^3.1.0",
+        "@dotcom-tool-kit/frontend-app": "^3.1.0",
+        "@dotcom-tool-kit/heroku": "^3.1.0",
+        "@dotcom-tool-kit/mocha": "^3.1.0",
+        "@dotcom-tool-kit/n-test": "^3.1.0",
+        "@dotcom-tool-kit/npm": "^3.1.0",
+        "@dotcom-tool-kit/webpack": "^3.1.0",
         "@jest/globals": "^27.4.6",
         "@types/lodash": "^4.14.185",
         "@types/node": "^16.18.23",
@@ -86,7 +86,8 @@
         "winston": "^3.5.1"
       },
       "engines": {
-        "node": "16.x"
+        "node": "16.x || 18.x",
+        "npm": "7.x || 8.x || 9.x"
       }
     },
     "core/cli/node_modules/@types/node": {
@@ -120,15 +121,15 @@
     },
     "core/create": {
       "name": "@dotcom-tool-kit/create",
-      "version": "3.0.0",
+      "version": "3.1.0",
       "license": "ISC",
       "dependencies": {
         "@aws-sdk/client-iam": "^3.282.0",
         "@aws-sdk/client-sts": "^3.282.0",
-        "@dotcom-tool-kit/error": "^3.0.0",
-        "@dotcom-tool-kit/logger": "^3.0.0",
-        "@dotcom-tool-kit/types": "^3.0.0",
-        "@dotcom-tool-kit/vault": "^3.0.0",
+        "@dotcom-tool-kit/error": "^3.1.0",
+        "@dotcom-tool-kit/logger": "^3.1.0",
+        "@dotcom-tool-kit/types": "^3.1.0",
+        "@dotcom-tool-kit/vault": "^3.1.0",
         "@financial-times/package-json": "^3.0.0",
         "@octokit/rest": "^19.0.5",
         "@quarterto/parse-makefile-rules": "^1.1.0",
@@ -156,7 +157,11 @@
         "@types/pacote": "^11.1.3",
         "@types/prompts": "^2.0.14",
         "cosmiconfig": "^7.0.1",
-        "dotcom-tool-kit": "^3.0.0"
+        "dotcom-tool-kit": "^3.1.0"
+      },
+      "engines": {
+        "node": "16.x || 18.x",
+        "npm": "7.x || 8.x || 9.x"
       }
     },
     "core/create/node_modules/@aws-sdk/abort-controller": {
@@ -1075,6 +1080,10 @@
         "@dotcom-tool-kit/upload-assets-to-s3": "^2.0.0",
         "dotcom-tool-kit": "^2.0.0",
         "nodemon": "^2.0.15"
+      },
+      "engines": {
+        "node": "16.x || 18.x",
+        "npm": "7.x || 8.x || 9.x"
       }
     },
     "core/sandbox/node_modules/@dotcom-tool-kit/backend-heroku-app": {
@@ -1819,10 +1828,14 @@
     },
     "lib/error": {
       "name": "@dotcom-tool-kit/error",
-      "version": "3.0.0",
+      "version": "3.1.0",
       "license": "ISC",
       "dependencies": {
         "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": "16.x || 18.x",
+        "npm": "7.x || 8.x || 9.x"
       }
     },
     "lib/error/node_modules/tslib": {
@@ -1832,10 +1845,10 @@
     },
     "lib/logger": {
       "name": "@dotcom-tool-kit/logger",
-      "version": "3.0.0",
+      "version": "3.1.0",
       "license": "ISC",
       "dependencies": {
-        "@dotcom-tool-kit/error": "^3.0.0",
+        "@dotcom-tool-kit/error": "^3.1.0",
         "ansi-colors": "^4.1.1",
         "ansi-regex": "^5.0.1",
         "triple-beam": "^1.3.0",
@@ -1845,6 +1858,10 @@
       },
       "devDependencies": {
         "@types/triple-beam": "^1.3.2"
+      },
+      "engines": {
+        "node": "16.x || 18.x",
+        "npm": "7.x || 8.x || 9.x"
       }
     },
     "lib/logger/node_modules/tslib": {
@@ -1854,11 +1871,15 @@
     },
     "lib/options": {
       "name": "@dotcom-tool-kit/options",
-      "version": "3.0.0",
+      "version": "3.1.0",
       "license": "ISC",
       "dependencies": {
-        "@dotcom-tool-kit/types": "^3.0.0",
+        "@dotcom-tool-kit/types": "^3.1.0",
         "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": "16.x || 18.x",
+        "npm": "7.x || 8.x || 9.x"
       }
     },
     "lib/options/node_modules/tslib": {
@@ -1868,7 +1889,7 @@
     },
     "lib/package-json-hook": {
       "name": "@dotcom-tool-kit/package-json-hook",
-      "version": "4.0.0",
+      "version": "4.1.0",
       "license": "ISC",
       "dependencies": {
         "@financial-times/package-json": "^3.0.0",
@@ -1879,6 +1900,10 @@
         "@jest/globals": "^27.4.6",
         "@types/lodash": "^4.14.185",
         "winston": "^3.5.1"
+      },
+      "engines": {
+        "node": "16.x || 18.x",
+        "npm": "7.x || 8.x || 9.x"
       }
     },
     "lib/package-json-hook/node_modules/tslib": {
@@ -1888,10 +1913,14 @@
     },
     "lib/state": {
       "name": "@dotcom-tool-kit/state",
-      "version": "3.0.0",
+      "version": "3.1.0",
       "license": "ISC",
       "dependencies": {
         "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": "16.x || 18.x",
+        "npm": "7.x || 8.x || 9.x"
       }
     },
     "lib/state/node_modules/tslib": {
@@ -1901,11 +1930,11 @@
     },
     "lib/types": {
       "name": "@dotcom-tool-kit/types",
-      "version": "3.0.0",
+      "version": "3.1.0",
       "license": "ISC",
       "dependencies": {
-        "@dotcom-tool-kit/error": "^3.0.0",
-        "@dotcom-tool-kit/logger": "^3.0.0",
+        "@dotcom-tool-kit/error": "^3.1.0",
+        "@dotcom-tool-kit/logger": "^3.1.0",
         "semver": "^7.3.7",
         "tslib": "^2.3.1",
         "zod": "^3.20.2"
@@ -1915,6 +1944,10 @@
         "@types/prompts": "^2.0.14",
         "@types/semver": "^7.3.9",
         "winston": "^3.5.1"
+      },
+      "engines": {
+        "node": "16.x || 18.x",
+        "npm": "7.x || 8.x || 9.x"
       }
     },
     "lib/types/node_modules/tslib": {
@@ -1924,12 +1957,12 @@
     },
     "lib/vault": {
       "name": "@dotcom-tool-kit/vault",
-      "version": "3.0.0",
+      "version": "3.1.0",
       "license": "ISC",
       "dependencies": {
-        "@dotcom-tool-kit/error": "^3.0.0",
-        "@dotcom-tool-kit/options": "^3.0.0",
-        "@dotcom-tool-kit/types": "^3.0.0",
+        "@dotcom-tool-kit/error": "^3.1.0",
+        "@dotcom-tool-kit/options": "^3.1.0",
+        "@dotcom-tool-kit/types": "^3.1.0",
         "@financial-times/n-fetch": "^1.0.0-beta.12",
         "fs": "0.0.1-security",
         "os": "^0.1.2",
@@ -1940,6 +1973,10 @@
       "devDependencies": {
         "@types/jest": "^27.0.2",
         "winston": "^3.5.1"
+      },
+      "engines": {
+        "node": "16.x || 18.x",
+        "npm": "7.x || 8.x || 9.x"
       }
     },
     "lib/vault/node_modules/tslib": {
@@ -1949,7 +1986,7 @@
     },
     "lib/wait-for-ok": {
       "name": "@dotcom-tool-kit/wait-for-ok",
-      "version": "3.0.0",
+      "version": "3.1.0",
       "license": "ISC",
       "dependencies": {
         "node-fetch": "^2.6.8",
@@ -1959,6 +1996,10 @@
         "@types/node": "^16.18.23",
         "@types/node-fetch": "^2.5.10",
         "winston": "^3.5.1"
+      },
+      "engines": {
+        "node": "16.x || 18.x",
+        "npm": "7.x || 8.x || 9.x"
       }
     },
     "lib/wait-for-ok/node_modules/@types/node": {
@@ -29228,12 +29269,12 @@
     },
     "plugins/babel": {
       "name": "@dotcom-tool-kit/babel",
-      "version": "3.0.0",
+      "version": "3.1.0",
       "license": "MIT",
       "dependencies": {
-        "@dotcom-tool-kit/error": "^3.0.0",
-        "@dotcom-tool-kit/logger": "^3.0.0",
-        "@dotcom-tool-kit/types": "^3.0.0",
+        "@dotcom-tool-kit/error": "^3.1.0",
+        "@dotcom-tool-kit/logger": "^3.1.0",
+        "@dotcom-tool-kit/types": "^3.1.0",
         "fast-glob": "^3.2.11",
         "tslib": "^2.3.1"
       },
@@ -29241,6 +29282,10 @@
         "@babel/preset-env": "^7.16.11",
         "@jest/globals": "^27.4.6",
         "winston": "^3.5.1"
+      },
+      "engines": {
+        "node": "16.x || 18.x",
+        "npm": "7.x || 8.x || 9.x"
       },
       "peerDependencies": {
         "@babel/core": "7.x",
@@ -29254,10 +29299,14 @@
     },
     "plugins/backend-app": {
       "name": "@dotcom-tool-kit/backend-app",
-      "version": "3.0.0",
+      "version": "3.1.0",
       "license": "ISC",
       "dependencies": {
-        "@dotcom-tool-kit/backend-heroku-app": "^2.0.0"
+        "@dotcom-tool-kit/backend-heroku-app": "^2.1.0"
+      },
+      "engines": {
+        "node": "16.x || 18.x",
+        "npm": "7.x || 8.x || 9.x"
       },
       "peerDependencies": {
         "dotcom-tool-kit": "3.x"
@@ -29265,15 +29314,19 @@
     },
     "plugins/backend-heroku-app": {
       "name": "@dotcom-tool-kit/backend-heroku-app",
-      "version": "2.0.0",
+      "version": "2.1.0",
       "license": "ISC",
       "dependencies": {
-        "@dotcom-tool-kit/circleci-deploy": "^3.0.0",
-        "@dotcom-tool-kit/heroku": "^3.0.0",
-        "@dotcom-tool-kit/husky-npm": "^4.0.0",
-        "@dotcom-tool-kit/node": "^3.0.0",
-        "@dotcom-tool-kit/npm": "^3.0.0",
-        "@dotcom-tool-kit/secret-squirrel": "^2.0.0"
+        "@dotcom-tool-kit/circleci-deploy": "^3.1.0",
+        "@dotcom-tool-kit/heroku": "^3.1.0",
+        "@dotcom-tool-kit/husky-npm": "^4.1.0",
+        "@dotcom-tool-kit/node": "^3.1.0",
+        "@dotcom-tool-kit/npm": "^3.1.0",
+        "@dotcom-tool-kit/secret-squirrel": "^2.1.0"
+      },
+      "engines": {
+        "node": "16.x || 18.x",
+        "npm": "7.x || 8.x || 9.x"
       },
       "peerDependencies": {
         "dotcom-tool-kit": "3.x"
@@ -29281,15 +29334,19 @@
     },
     "plugins/backend-serverless-app": {
       "name": "@dotcom-tool-kit/backend-serverless-app",
-      "version": "2.0.0",
+      "version": "2.1.0",
       "license": "ISC",
       "dependencies": {
-        "@dotcom-tool-kit/circleci-deploy": "^3.0.0",
-        "@dotcom-tool-kit/husky-npm": "^4.0.0",
-        "@dotcom-tool-kit/node": "^3.0.0",
-        "@dotcom-tool-kit/npm": "^3.0.0",
-        "@dotcom-tool-kit/secret-squirrel": "^2.0.0",
-        "@dotcom-tool-kit/serverless": "^2.0.0"
+        "@dotcom-tool-kit/circleci-deploy": "^3.1.0",
+        "@dotcom-tool-kit/husky-npm": "^4.1.0",
+        "@dotcom-tool-kit/node": "^3.1.0",
+        "@dotcom-tool-kit/npm": "^3.1.0",
+        "@dotcom-tool-kit/secret-squirrel": "^2.1.0",
+        "@dotcom-tool-kit/serverless": "^2.1.0"
+      },
+      "engines": {
+        "node": "16.x || 18.x",
+        "npm": "7.x || 8.x || 9.x"
       },
       "peerDependencies": {
         "dotcom-tool-kit": "3.x"
@@ -29297,13 +29354,13 @@
     },
     "plugins/circleci": {
       "name": "@dotcom-tool-kit/circleci",
-      "version": "5.0.0",
+      "version": "5.1.0",
       "license": "ISC",
       "dependencies": {
-        "@dotcom-tool-kit/error": "^3.0.0",
-        "@dotcom-tool-kit/logger": "^3.0.0",
-        "@dotcom-tool-kit/state": "^3.0.0",
-        "@dotcom-tool-kit/types": "^3.0.0",
+        "@dotcom-tool-kit/error": "^3.1.0",
+        "@dotcom-tool-kit/logger": "^3.1.0",
+        "@dotcom-tool-kit/state": "^3.1.0",
+        "@dotcom-tool-kit/types": "^3.1.0",
         "lodash": "^4.17.21",
         "tslib": "^2.3.1",
         "type-fest": "^3.5.4",
@@ -29316,20 +29373,28 @@
         "@types/lodash": "^4.14.185",
         "winston": "^3.5.1"
       },
+      "engines": {
+        "node": "16.x || 18.x",
+        "npm": "7.x || 8.x || 9.x"
+      },
       "peerDependencies": {
         "dotcom-tool-kit": "3.x"
       }
     },
     "plugins/circleci-deploy": {
       "name": "@dotcom-tool-kit/circleci-deploy",
-      "version": "3.0.0",
+      "version": "3.1.0",
       "license": "ISC",
       "dependencies": {
-        "@dotcom-tool-kit/circleci": "^5.0.0",
+        "@dotcom-tool-kit/circleci": "^5.1.0",
         "tslib": "^2.3.1"
       },
       "devDependencies": {
         "winston": "^3.5.1"
+      },
+      "engines": {
+        "node": "16.x || 18.x",
+        "npm": "7.x || 8.x || 9.x"
       },
       "peerDependencies": {
         "dotcom-tool-kit": "3.x"
@@ -29342,12 +29407,16 @@
     },
     "plugins/circleci-heroku": {
       "name": "@dotcom-tool-kit/circleci-heroku",
-      "version": "3.0.0",
+      "version": "3.1.0",
       "license": "ISC",
       "dependencies": {
-        "@dotcom-tool-kit/circleci-deploy": "^3.0.0",
-        "@dotcom-tool-kit/heroku": "^3.0.0",
+        "@dotcom-tool-kit/circleci-deploy": "^3.1.0",
+        "@dotcom-tool-kit/heroku": "^3.1.0",
         "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": "16.x || 18.x",
+        "npm": "7.x || 8.x || 9.x"
       },
       "peerDependencies": {
         "dotcom-tool-kit": "3.x"
@@ -29360,13 +29429,17 @@
     },
     "plugins/circleci-npm": {
       "name": "@dotcom-tool-kit/circleci-npm",
-      "version": "5.0.0",
+      "version": "5.1.0",
       "license": "ISC",
       "dependencies": {
-        "@dotcom-tool-kit/circleci": "^5.0.0",
-        "@dotcom-tool-kit/npm": "^3.0.0",
-        "@dotcom-tool-kit/types": "^3.0.0",
+        "@dotcom-tool-kit/circleci": "^5.1.0",
+        "@dotcom-tool-kit/npm": "^3.1.0",
+        "@dotcom-tool-kit/types": "^3.1.0",
         "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": "16.x || 18.x",
+        "npm": "7.x || 8.x || 9.x"
       },
       "peerDependencies": {
         "dotcom-tool-kit": "3.x"
@@ -29403,13 +29476,17 @@
     },
     "plugins/component": {
       "name": "@dotcom-tool-kit/component",
-      "version": "3.0.0",
+      "version": "3.1.0",
       "license": "ISC",
       "dependencies": {
-        "@dotcom-tool-kit/circleci-npm": "^5.0.0",
-        "@dotcom-tool-kit/husky-npm": "^4.0.0",
-        "@dotcom-tool-kit/npm": "^3.0.0",
-        "@dotcom-tool-kit/secret-squirrel": "^2.0.0"
+        "@dotcom-tool-kit/circleci-npm": "^5.1.0",
+        "@dotcom-tool-kit/husky-npm": "^4.1.0",
+        "@dotcom-tool-kit/npm": "^3.1.0",
+        "@dotcom-tool-kit/secret-squirrel": "^2.1.0"
+      },
+      "engines": {
+        "node": "16.x || 18.x",
+        "npm": "7.x || 8.x || 9.x"
       },
       "peerDependencies": {
         "dotcom-tool-kit": "3.x"
@@ -29417,20 +29494,24 @@
     },
     "plugins/cypress": {
       "name": "@dotcom-tool-kit/cypress",
-      "version": "3.0.0",
+      "version": "3.1.0",
       "license": "ISC",
+      "engines": {
+        "node": "16.x || 18.x",
+        "npm": "7.x || 8.x || 9.x"
+      },
       "peerDependencies": {
         "dotcom-tool-kit": "3.x"
       }
     },
     "plugins/eslint": {
       "name": "@dotcom-tool-kit/eslint",
-      "version": "3.0.0",
+      "version": "3.1.0",
       "license": "ISC",
       "dependencies": {
-        "@dotcom-tool-kit/error": "^3.0.0",
-        "@dotcom-tool-kit/logger": "^3.0.0",
-        "@dotcom-tool-kit/types": "^3.0.0",
+        "@dotcom-tool-kit/error": "^3.1.0",
+        "@dotcom-tool-kit/logger": "^3.1.0",
+        "@dotcom-tool-kit/types": "^3.1.0",
         "tslib": "^2.3.1"
       },
       "devDependencies": {
@@ -29438,6 +29519,10 @@
         "@types/eslint": "^7.2.13",
         "eslint": "^8.15.0",
         "winston": "^3.5.1"
+      },
+      "engines": {
+        "node": "16.x || 18.x",
+        "npm": "7.x || 8.x || 9.x"
       },
       "peerDependencies": {
         "dotcom-tool-kit": "3.x",
@@ -29643,12 +29728,16 @@
     },
     "plugins/frontend-app": {
       "name": "@dotcom-tool-kit/frontend-app",
-      "version": "3.0.0",
+      "version": "3.1.0",
       "license": "ISC",
       "dependencies": {
-        "@dotcom-tool-kit/backend-heroku-app": "^2.0.0",
-        "@dotcom-tool-kit/upload-assets-to-s3": "^3.0.0",
-        "@dotcom-tool-kit/webpack": "^3.0.0"
+        "@dotcom-tool-kit/backend-heroku-app": "^2.1.0",
+        "@dotcom-tool-kit/upload-assets-to-s3": "^3.1.0",
+        "@dotcom-tool-kit/webpack": "^3.1.0"
+      },
+      "engines": {
+        "node": "16.x || 18.x",
+        "npm": "7.x || 8.x || 9.x"
       },
       "peerDependencies": {
         "dotcom-tool-kit": "3.x"
@@ -29656,17 +29745,17 @@
     },
     "plugins/heroku": {
       "name": "@dotcom-tool-kit/heroku",
-      "version": "3.0.0",
+      "version": "3.1.0",
       "license": "ISC",
       "dependencies": {
-        "@dotcom-tool-kit/error": "^3.0.0",
-        "@dotcom-tool-kit/logger": "^3.0.0",
-        "@dotcom-tool-kit/npm": "^3.0.0",
-        "@dotcom-tool-kit/package-json-hook": "^4.0.0",
-        "@dotcom-tool-kit/state": "^3.0.0",
-        "@dotcom-tool-kit/types": "^3.0.0",
-        "@dotcom-tool-kit/vault": "^3.0.0",
-        "@dotcom-tool-kit/wait-for-ok": "^3.0.0",
+        "@dotcom-tool-kit/error": "^3.1.0",
+        "@dotcom-tool-kit/logger": "^3.1.0",
+        "@dotcom-tool-kit/npm": "^3.1.0",
+        "@dotcom-tool-kit/package-json-hook": "^4.1.0",
+        "@dotcom-tool-kit/state": "^3.1.0",
+        "@dotcom-tool-kit/types": "^3.1.0",
+        "@dotcom-tool-kit/vault": "^3.1.0",
+        "@dotcom-tool-kit/wait-for-ok": "^3.1.0",
         "@octokit/request": "^5.6.0",
         "@octokit/request-error": "^2.1.0",
         "heroku-client": "^3.1.0",
@@ -29679,6 +29768,10 @@
         "@types/p-retry": "^3.0.1",
         "winston": "^3.5.1"
       },
+      "engines": {
+        "node": "16.x || 18.x",
+        "npm": "7.x || 8.x || 9.x"
+      },
       "peerDependencies": {
         "dotcom-tool-kit": "3.x"
       }
@@ -29690,11 +29783,15 @@
     },
     "plugins/husky-npm": {
       "name": "@dotcom-tool-kit/husky-npm",
-      "version": "4.0.0",
+      "version": "4.1.0",
       "license": "ISC",
       "dependencies": {
-        "@dotcom-tool-kit/package-json-hook": "^4.0.0",
+        "@dotcom-tool-kit/package-json-hook": "^4.1.0",
         "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": "16.x || 18.x",
+        "npm": "7.x || 8.x || 9.x"
       },
       "peerDependencies": {
         "dotcom-tool-kit": "3.x",
@@ -29708,16 +29805,20 @@
     },
     "plugins/jest": {
       "name": "@dotcom-tool-kit/jest",
-      "version": "3.0.0",
+      "version": "3.1.0",
       "license": "ISC",
       "dependencies": {
-        "@dotcom-tool-kit/logger": "^3.0.0",
-        "@dotcom-tool-kit/types": "^3.0.0",
+        "@dotcom-tool-kit/logger": "^3.1.0",
+        "@dotcom-tool-kit/types": "^3.1.0",
         "tslib": "^2.3.1"
       },
       "devDependencies": {
         "@jest/globals": "^27.4.6",
         "winston": "^3.5.1"
+      },
+      "engines": {
+        "node": "16.x || 18.x",
+        "npm": "7.x || 8.x || 9.x"
       },
       "peerDependencies": {
         "dotcom-tool-kit": "3.x",
@@ -29731,14 +29832,18 @@
     },
     "plugins/lint-staged": {
       "name": "@dotcom-tool-kit/lint-staged",
-      "version": "4.0.0",
+      "version": "4.1.0",
       "license": "ISC",
       "dependencies": {
-        "@dotcom-tool-kit/logger": "^3.0.0",
-        "@dotcom-tool-kit/package-json-hook": "^4.0.0",
-        "@dotcom-tool-kit/types": "^3.0.0",
+        "@dotcom-tool-kit/logger": "^3.1.0",
+        "@dotcom-tool-kit/package-json-hook": "^4.1.0",
+        "@dotcom-tool-kit/types": "^3.1.0",
         "lint-staged": "^11.2.3",
         "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": "16.x || 18.x",
+        "npm": "7.x || 8.x || 9.x"
       },
       "peerDependencies": {
         "dotcom-tool-kit": "3.x"
@@ -29746,13 +29851,17 @@
     },
     "plugins/lint-staged-npm": {
       "name": "@dotcom-tool-kit/lint-staged-npm",
-      "version": "3.0.0",
+      "version": "3.1.0",
       "license": "ISC",
       "dependencies": {
-        "@dotcom-tool-kit/husky-npm": "^4.0.0",
-        "@dotcom-tool-kit/lint-staged": "^4.0.0",
-        "@dotcom-tool-kit/options": "^3.0.0",
+        "@dotcom-tool-kit/husky-npm": "^4.1.0",
+        "@dotcom-tool-kit/lint-staged": "^4.1.0",
+        "@dotcom-tool-kit/options": "^3.1.0",
         "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": "16.x || 18.x",
+        "npm": "7.x || 8.x || 9.x"
       },
       "peerDependencies": {
         "dotcom-tool-kit": "3.x"
@@ -29820,12 +29929,12 @@
     },
     "plugins/mocha": {
       "name": "@dotcom-tool-kit/mocha",
-      "version": "3.0.0",
+      "version": "3.1.0",
       "license": "ISC",
       "dependencies": {
-        "@dotcom-tool-kit/error": "^3.0.0",
-        "@dotcom-tool-kit/logger": "^3.0.0",
-        "@dotcom-tool-kit/types": "^3.0.0",
+        "@dotcom-tool-kit/error": "^3.1.0",
+        "@dotcom-tool-kit/logger": "^3.1.0",
+        "@dotcom-tool-kit/types": "^3.1.0",
         "glob": "^7.1.7",
         "tslib": "^2.3.1"
       },
@@ -29834,6 +29943,10 @@
         "@types/glob": "^7.1.3",
         "@types/mocha": "^8.2.2",
         "winston": "^3.5.1"
+      },
+      "engines": {
+        "node": "16.x || 18.x",
+        "npm": "7.x || 8.x || 9.x"
       },
       "peerDependencies": {
         "dotcom-tool-kit": "3.x",
@@ -29847,12 +29960,12 @@
     },
     "plugins/n-test": {
       "name": "@dotcom-tool-kit/n-test",
-      "version": "3.0.0",
+      "version": "3.1.0",
       "license": "ISC",
       "dependencies": {
-        "@dotcom-tool-kit/logger": "^3.0.0",
-        "@dotcom-tool-kit/state": "^3.0.0",
-        "@dotcom-tool-kit/types": "^3.0.0",
+        "@dotcom-tool-kit/logger": "^3.1.0",
+        "@dotcom-tool-kit/state": "^3.1.0",
+        "@dotcom-tool-kit/types": "^3.1.0",
         "@financial-times/n-test": "^5.0.1",
         "tslib": "^2.3.1"
       },
@@ -29860,6 +29973,10 @@
         "@jest/globals": "^27.4.6",
         "@types/jest": "^27.4.0",
         "winston": "^3.5.1"
+      },
+      "engines": {
+        "node": "16.x || 18.x",
+        "npm": "7.x || 8.x || 9.x"
       },
       "peerDependencies": {
         "dotcom-tool-kit": "3.x"
@@ -29872,16 +29989,20 @@
     },
     "plugins/next-router": {
       "name": "@dotcom-tool-kit/next-router",
-      "version": "3.0.0",
+      "version": "3.1.0",
       "license": "ISC",
       "dependencies": {
-        "@dotcom-tool-kit/error": "^3.0.0",
-        "@dotcom-tool-kit/logger": "^3.0.0",
-        "@dotcom-tool-kit/state": "^3.0.0",
-        "@dotcom-tool-kit/types": "^3.0.0",
-        "@dotcom-tool-kit/vault": "^3.0.0",
+        "@dotcom-tool-kit/error": "^3.1.0",
+        "@dotcom-tool-kit/logger": "^3.1.0",
+        "@dotcom-tool-kit/state": "^3.1.0",
+        "@dotcom-tool-kit/types": "^3.1.0",
+        "@dotcom-tool-kit/vault": "^3.1.0",
         "ft-next-router": "^1.0.0",
         "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": "16.x || 18.x",
+        "npm": "7.x || 8.x || 9.x"
       },
       "peerDependencies": {
         "dotcom-tool-kit": "3.x"
@@ -29894,16 +30015,20 @@
     },
     "plugins/node": {
       "name": "@dotcom-tool-kit/node",
-      "version": "3.0.0",
+      "version": "3.1.0",
       "license": "ISC",
       "dependencies": {
-        "@dotcom-tool-kit/error": "^3.0.0",
-        "@dotcom-tool-kit/state": "^3.0.0",
-        "@dotcom-tool-kit/types": "^3.0.0",
-        "@dotcom-tool-kit/vault": "^3.0.0",
+        "@dotcom-tool-kit/error": "^3.1.0",
+        "@dotcom-tool-kit/state": "^3.1.0",
+        "@dotcom-tool-kit/types": "^3.1.0",
+        "@dotcom-tool-kit/vault": "^3.1.0",
         "get-port": "^5.1.1",
         "tslib": "^2.3.1",
         "wait-port": "^0.2.9"
+      },
+      "engines": {
+        "node": "16.x || 18.x",
+        "npm": "7.x || 8.x || 9.x"
       },
       "peerDependencies": {
         "dotcom-tool-kit": "3.x"
@@ -29916,18 +30041,22 @@
     },
     "plugins/nodemon": {
       "name": "@dotcom-tool-kit/nodemon",
-      "version": "3.0.0",
+      "version": "3.1.0",
       "license": "ISC",
       "dependencies": {
-        "@dotcom-tool-kit/error": "^3.0.0",
-        "@dotcom-tool-kit/state": "^3.0.0",
-        "@dotcom-tool-kit/types": "^3.0.0",
-        "@dotcom-tool-kit/vault": "^3.0.0",
+        "@dotcom-tool-kit/error": "^3.1.0",
+        "@dotcom-tool-kit/state": "^3.1.0",
+        "@dotcom-tool-kit/types": "^3.1.0",
+        "@dotcom-tool-kit/vault": "^3.1.0",
         "get-port": "^5.1.1",
         "tslib": "^2.3.1"
       },
       "devDependencies": {
         "@types/nodemon": "^1.19.1"
+      },
+      "engines": {
+        "node": "16.x || 18.x",
+        "npm": "7.x || 8.x || 9.x"
       },
       "peerDependencies": {
         "dotcom-tool-kit": "3.x",
@@ -29941,14 +30070,14 @@
     },
     "plugins/npm": {
       "name": "@dotcom-tool-kit/npm",
-      "version": "3.0.0",
+      "version": "3.1.0",
       "license": "ISC",
       "dependencies": {
         "@actions/exec": "^1.1.0",
-        "@dotcom-tool-kit/error": "^3.0.0",
-        "@dotcom-tool-kit/package-json-hook": "^4.0.0",
-        "@dotcom-tool-kit/state": "^3.0.0",
-        "@dotcom-tool-kit/types": "^3.0.0",
+        "@dotcom-tool-kit/error": "^3.1.0",
+        "@dotcom-tool-kit/package-json-hook": "^4.1.0",
+        "@dotcom-tool-kit/state": "^3.1.0",
+        "@dotcom-tool-kit/types": "^3.1.0",
         "libnpmpack": "^3.1.0",
         "libnpmpublish": "^5.0.1",
         "pacote": "^12.0.3",
@@ -29960,6 +30089,10 @@
         "@types/pacote": "^11.1.3",
         "@types/tar": "^6.1.1",
         "winston": "^3.5.1"
+      },
+      "engines": {
+        "node": "16.x || 18.x",
+        "npm": "7.x || 8.x || 9.x"
       },
       "peerDependencies": {
         "dotcom-tool-kit": "3.x"
@@ -30105,15 +30238,19 @@
     },
     "plugins/pa11y": {
       "name": "@dotcom-tool-kit/pa11y",
-      "version": "0.4.0",
+      "version": "0.4.1",
       "license": "ISC",
       "dependencies": {
-        "@dotcom-tool-kit/types": "^3.0.0",
+        "@dotcom-tool-kit/types": "^3.1.0",
         "pa11y-ci": "^3.0.1",
         "tslib": "^2.3.1"
       },
       "devDependencies": {
         "@types/pa11y": "^5.3.4"
+      },
+      "engines": {
+        "node": "16.x || 18.x",
+        "npm": "7.x || 8.x || 9.x"
       },
       "peerDependencies": {
         "dotcom-tool-kit": "3.x"
@@ -30126,13 +30263,13 @@
     },
     "plugins/prettier": {
       "name": "@dotcom-tool-kit/prettier",
-      "version": "3.0.0",
+      "version": "3.1.0",
       "license": "ISC",
       "dependencies": {
-        "@dotcom-tool-kit/error": "^3.0.0",
-        "@dotcom-tool-kit/logger": "^3.0.0",
-        "@dotcom-tool-kit/package-json-hook": "^4.0.0",
-        "@dotcom-tool-kit/types": "^3.0.0",
+        "@dotcom-tool-kit/error": "^3.1.0",
+        "@dotcom-tool-kit/logger": "^3.1.0",
+        "@dotcom-tool-kit/package-json-hook": "^4.1.0",
+        "@dotcom-tool-kit/types": "^3.1.0",
         "fast-glob": "^3.2.7",
         "hook-std": "^2.0.0",
         "prettier": "^2.2.1",
@@ -30143,6 +30280,10 @@
         "jest": "^27.4.7",
         "ts-jest": "^27.1.3",
         "winston": "^3.5.1"
+      },
+      "engines": {
+        "node": "16.x || 18.x",
+        "npm": "7.x || 8.x || 9.x"
       },
       "peerDependencies": {
         "dotcom-tool-kit": "3.x"
@@ -30155,12 +30296,16 @@
     },
     "plugins/secret-squirrel": {
       "name": "@dotcom-tool-kit/secret-squirrel",
-      "version": "2.0.0",
+      "version": "2.1.0",
       "license": "ISC",
       "dependencies": {
-        "@dotcom-tool-kit/logger": "^3.0.0",
-        "@dotcom-tool-kit/types": "^3.0.0",
+        "@dotcom-tool-kit/logger": "^3.1.0",
+        "@dotcom-tool-kit/types": "^3.1.0",
         "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": "16.x || 18.x",
+        "npm": "7.x || 8.x || 9.x"
       },
       "peerDependencies": {
         "@financial-times/secret-squirrel": "2.x",
@@ -30174,16 +30319,20 @@
     },
     "plugins/serverless": {
       "name": "@dotcom-tool-kit/serverless",
-      "version": "2.0.0",
+      "version": "2.1.0",
       "license": "ISC",
       "dependencies": {
-        "@dotcom-tool-kit/error": "^3.0.0",
-        "@dotcom-tool-kit/state": "^3.0.0",
-        "@dotcom-tool-kit/types": "^3.0.0",
-        "@dotcom-tool-kit/vault": "^3.0.0",
+        "@dotcom-tool-kit/error": "^3.1.0",
+        "@dotcom-tool-kit/state": "^3.1.0",
+        "@dotcom-tool-kit/types": "^3.1.0",
+        "@dotcom-tool-kit/vault": "^3.1.0",
         "get-port": "^5.1.1",
         "tslib": "^2.3.1",
         "wait-port": "^0.2.9"
+      },
+      "engines": {
+        "node": "16.x || 18.x",
+        "npm": "7.x || 8.x || 9.x"
       },
       "peerDependencies": {
         "dotcom-tool-kit": "3.x",
@@ -30197,16 +30346,20 @@
     },
     "plugins/typescript": {
       "name": "@dotcom-tool-kit/typescript",
-      "version": "2.0.0",
+      "version": "2.1.0",
       "license": "ISC",
       "dependencies": {
-        "@dotcom-tool-kit/logger": "^3.0.0",
-        "@dotcom-tool-kit/types": "^3.0.0"
+        "@dotcom-tool-kit/logger": "^3.1.0",
+        "@dotcom-tool-kit/types": "^3.1.0"
       },
       "devDependencies": {
         "@jest/globals": "^29.3.1",
         "typescript": "^4.9.4",
         "winston": "^3.8.2"
+      },
+      "engines": {
+        "node": "16.x || 18.x",
+        "npm": "7.x || 8.x || 9.x"
       },
       "peerDependencies": {
         "dotcom-tool-kit": "3.x",
@@ -30401,13 +30554,13 @@
     },
     "plugins/upload-assets-to-s3": {
       "name": "@dotcom-tool-kit/upload-assets-to-s3",
-      "version": "3.0.0",
+      "version": "3.1.0",
       "license": "ISC",
       "dependencies": {
         "@aws-sdk/client-s3": "^3.256.0",
-        "@dotcom-tool-kit/error": "^3.0.0",
-        "@dotcom-tool-kit/logger": "^3.0.0",
-        "@dotcom-tool-kit/types": "^3.0.0",
+        "@dotcom-tool-kit/error": "^3.1.0",
+        "@dotcom-tool-kit/logger": "^3.1.0",
+        "@dotcom-tool-kit/types": "^3.1.0",
         "glob": "^7.1.6",
         "mime": "^2.5.2",
         "tslib": "^2.3.1"
@@ -30420,6 +30573,10 @@
         "@types/mime": "^2.0.3",
         "winston": "^3.5.1"
       },
+      "engines": {
+        "node": "16.x || 18.x",
+        "npm": "7.x || 8.x || 9.x"
+      },
       "peerDependencies": {
         "dotcom-tool-kit": "3.x"
       }
@@ -30431,12 +30588,12 @@
     },
     "plugins/webpack": {
       "name": "@dotcom-tool-kit/webpack",
-      "version": "3.0.0",
+      "version": "3.1.0",
       "license": "MIT",
       "dependencies": {
-        "@dotcom-tool-kit/error": "^3.0.0",
-        "@dotcom-tool-kit/logger": "^3.0.0",
-        "@dotcom-tool-kit/types": "^3.0.0",
+        "@dotcom-tool-kit/error": "^3.1.0",
+        "@dotcom-tool-kit/logger": "^3.1.0",
+        "@dotcom-tool-kit/types": "^3.1.0",
         "tslib": "^2.3.1",
         "webpack-cli": "^4.6.0"
       },
@@ -30445,6 +30602,10 @@
         "ts-node": "^10.0.0",
         "webpack": "^4.42.1",
         "winston": "^3.5.1"
+      },
+      "engines": {
+        "node": "16.x || 18.x",
+        "npm": "7.x || 8.x || 9.x"
       },
       "peerDependencies": {
         "dotcom-tool-kit": "3.x",
@@ -34320,9 +34481,9 @@
       "version": "file:plugins/babel",
       "requires": {
         "@babel/preset-env": "^7.16.11",
-        "@dotcom-tool-kit/error": "^3.0.0",
-        "@dotcom-tool-kit/logger": "^3.0.0",
-        "@dotcom-tool-kit/types": "^3.0.0",
+        "@dotcom-tool-kit/error": "^3.1.0",
+        "@dotcom-tool-kit/logger": "^3.1.0",
+        "@dotcom-tool-kit/types": "^3.1.0",
         "@jest/globals": "^27.4.6",
         "fast-glob": "^3.2.11",
         "tslib": "^2.3.1",
@@ -34339,38 +34500,38 @@
     "@dotcom-tool-kit/backend-app": {
       "version": "file:plugins/backend-app",
       "requires": {
-        "@dotcom-tool-kit/backend-heroku-app": "^2.0.0"
+        "@dotcom-tool-kit/backend-heroku-app": "^2.1.0"
       }
     },
     "@dotcom-tool-kit/backend-heroku-app": {
       "version": "file:plugins/backend-heroku-app",
       "requires": {
-        "@dotcom-tool-kit/circleci-deploy": "^3.0.0",
-        "@dotcom-tool-kit/heroku": "^3.0.0",
-        "@dotcom-tool-kit/husky-npm": "^4.0.0",
-        "@dotcom-tool-kit/node": "^3.0.0",
-        "@dotcom-tool-kit/npm": "^3.0.0",
-        "@dotcom-tool-kit/secret-squirrel": "^2.0.0"
+        "@dotcom-tool-kit/circleci-deploy": "^3.1.0",
+        "@dotcom-tool-kit/heroku": "^3.1.0",
+        "@dotcom-tool-kit/husky-npm": "^4.1.0",
+        "@dotcom-tool-kit/node": "^3.1.0",
+        "@dotcom-tool-kit/npm": "^3.1.0",
+        "@dotcom-tool-kit/secret-squirrel": "^2.1.0"
       }
     },
     "@dotcom-tool-kit/backend-serverless-app": {
       "version": "file:plugins/backend-serverless-app",
       "requires": {
-        "@dotcom-tool-kit/circleci-deploy": "^3.0.0",
-        "@dotcom-tool-kit/husky-npm": "^4.0.0",
-        "@dotcom-tool-kit/node": "^3.0.0",
-        "@dotcom-tool-kit/npm": "^3.0.0",
-        "@dotcom-tool-kit/secret-squirrel": "^2.0.0",
-        "@dotcom-tool-kit/serverless": "^2.0.0"
+        "@dotcom-tool-kit/circleci-deploy": "^3.1.0",
+        "@dotcom-tool-kit/husky-npm": "^4.1.0",
+        "@dotcom-tool-kit/node": "^3.1.0",
+        "@dotcom-tool-kit/npm": "^3.1.0",
+        "@dotcom-tool-kit/secret-squirrel": "^2.1.0",
+        "@dotcom-tool-kit/serverless": "^2.1.0"
       }
     },
     "@dotcom-tool-kit/circleci": {
       "version": "file:plugins/circleci",
       "requires": {
-        "@dotcom-tool-kit/error": "^3.0.0",
-        "@dotcom-tool-kit/logger": "^3.0.0",
-        "@dotcom-tool-kit/state": "^3.0.0",
-        "@dotcom-tool-kit/types": "^3.0.0",
+        "@dotcom-tool-kit/error": "^3.1.0",
+        "@dotcom-tool-kit/logger": "^3.1.0",
+        "@dotcom-tool-kit/state": "^3.1.0",
+        "@dotcom-tool-kit/types": "^3.1.0",
         "@jest/globals": "^27.4.6",
         "@types/jest": "^27.4.0",
         "@types/js-yaml": "^4.0.3",
@@ -34402,7 +34563,7 @@
     "@dotcom-tool-kit/circleci-deploy": {
       "version": "file:plugins/circleci-deploy",
       "requires": {
-        "@dotcom-tool-kit/circleci": "^5.0.0",
+        "@dotcom-tool-kit/circleci": "^5.1.0",
         "tslib": "^2.3.1",
         "winston": "^3.5.1"
       },
@@ -34417,8 +34578,8 @@
     "@dotcom-tool-kit/circleci-heroku": {
       "version": "file:plugins/circleci-heroku",
       "requires": {
-        "@dotcom-tool-kit/circleci-deploy": "^3.0.0",
-        "@dotcom-tool-kit/heroku": "^3.0.0",
+        "@dotcom-tool-kit/circleci-deploy": "^3.1.0",
+        "@dotcom-tool-kit/heroku": "^3.1.0",
         "tslib": "^2.3.1"
       },
       "dependencies": {
@@ -34432,9 +34593,9 @@
     "@dotcom-tool-kit/circleci-npm": {
       "version": "file:plugins/circleci-npm",
       "requires": {
-        "@dotcom-tool-kit/circleci": "^5.0.0",
-        "@dotcom-tool-kit/npm": "^3.0.0",
-        "@dotcom-tool-kit/types": "^3.0.0",
+        "@dotcom-tool-kit/circleci": "^5.1.0",
+        "@dotcom-tool-kit/npm": "^3.1.0",
+        "@dotcom-tool-kit/types": "^3.1.0",
         "tslib": "^2.3.1"
       },
       "dependencies": {
@@ -34448,10 +34609,10 @@
     "@dotcom-tool-kit/component": {
       "version": "file:plugins/component",
       "requires": {
-        "@dotcom-tool-kit/circleci-npm": "^5.0.0",
-        "@dotcom-tool-kit/husky-npm": "^4.0.0",
-        "@dotcom-tool-kit/npm": "^3.0.0",
-        "@dotcom-tool-kit/secret-squirrel": "^2.0.0"
+        "@dotcom-tool-kit/circleci-npm": "^5.1.0",
+        "@dotcom-tool-kit/husky-npm": "^4.1.0",
+        "@dotcom-tool-kit/npm": "^3.1.0",
+        "@dotcom-tool-kit/secret-squirrel": "^2.1.0"
       }
     },
     "@dotcom-tool-kit/create": {
@@ -34459,10 +34620,10 @@
       "requires": {
         "@aws-sdk/client-iam": "^3.282.0",
         "@aws-sdk/client-sts": "^3.282.0",
-        "@dotcom-tool-kit/error": "^3.0.0",
-        "@dotcom-tool-kit/logger": "^3.0.0",
-        "@dotcom-tool-kit/types": "^3.0.0",
-        "@dotcom-tool-kit/vault": "^3.0.0",
+        "@dotcom-tool-kit/error": "^3.1.0",
+        "@dotcom-tool-kit/logger": "^3.1.0",
+        "@dotcom-tool-kit/types": "^3.1.0",
+        "@dotcom-tool-kit/vault": "^3.1.0",
         "@financial-times/package-json": "^3.0.0",
         "@octokit/rest": "^19.0.5",
         "@quarterto/parse-makefile-rules": "^1.1.0",
@@ -34475,7 +34636,7 @@
         "cli-highlight": "^2.1.11",
         "code-suggester": "^4.3.0",
         "cosmiconfig": "^7.0.1",
-        "dotcom-tool-kit": "^3.0.0",
+        "dotcom-tool-kit": "^3.1.0",
         "import-cwd": "^3.0.0",
         "komatsu": "^1.3.0",
         "lodash": "^4.17.21",
@@ -35222,9 +35383,9 @@
     "@dotcom-tool-kit/eslint": {
       "version": "file:plugins/eslint",
       "requires": {
-        "@dotcom-tool-kit/error": "^3.0.0",
-        "@dotcom-tool-kit/logger": "^3.0.0",
-        "@dotcom-tool-kit/types": "^3.0.0",
+        "@dotcom-tool-kit/error": "^3.1.0",
+        "@dotcom-tool-kit/logger": "^3.1.0",
+        "@dotcom-tool-kit/types": "^3.1.0",
         "@jest/globals": "^27.4.6",
         "@types/eslint": "^7.2.13",
         "eslint": "^8.15.0",
@@ -35370,22 +35531,22 @@
     "@dotcom-tool-kit/frontend-app": {
       "version": "file:plugins/frontend-app",
       "requires": {
-        "@dotcom-tool-kit/backend-heroku-app": "^2.0.0",
-        "@dotcom-tool-kit/upload-assets-to-s3": "^3.0.0",
-        "@dotcom-tool-kit/webpack": "^3.0.0"
+        "@dotcom-tool-kit/backend-heroku-app": "^2.1.0",
+        "@dotcom-tool-kit/upload-assets-to-s3": "^3.1.0",
+        "@dotcom-tool-kit/webpack": "^3.1.0"
       }
     },
     "@dotcom-tool-kit/heroku": {
       "version": "file:plugins/heroku",
       "requires": {
-        "@dotcom-tool-kit/error": "^3.0.0",
-        "@dotcom-tool-kit/logger": "^3.0.0",
-        "@dotcom-tool-kit/npm": "^3.0.0",
-        "@dotcom-tool-kit/package-json-hook": "^4.0.0",
-        "@dotcom-tool-kit/state": "^3.0.0",
-        "@dotcom-tool-kit/types": "^3.0.0",
-        "@dotcom-tool-kit/vault": "^3.0.0",
-        "@dotcom-tool-kit/wait-for-ok": "^3.0.0",
+        "@dotcom-tool-kit/error": "^3.1.0",
+        "@dotcom-tool-kit/logger": "^3.1.0",
+        "@dotcom-tool-kit/npm": "^3.1.0",
+        "@dotcom-tool-kit/package-json-hook": "^4.1.0",
+        "@dotcom-tool-kit/state": "^3.1.0",
+        "@dotcom-tool-kit/types": "^3.1.0",
+        "@dotcom-tool-kit/vault": "^3.1.0",
+        "@dotcom-tool-kit/wait-for-ok": "^3.1.0",
         "@octokit/request": "^5.6.0",
         "@octokit/request-error": "^2.1.0",
         "@types/financial-times__package-json": "^1.9.0",
@@ -35407,7 +35568,7 @@
     "@dotcom-tool-kit/husky-npm": {
       "version": "file:plugins/husky-npm",
       "requires": {
-        "@dotcom-tool-kit/package-json-hook": "^4.0.0",
+        "@dotcom-tool-kit/package-json-hook": "^4.1.0",
         "tslib": "^2.3.1"
       },
       "dependencies": {
@@ -35421,8 +35582,8 @@
     "@dotcom-tool-kit/jest": {
       "version": "file:plugins/jest",
       "requires": {
-        "@dotcom-tool-kit/logger": "^3.0.0",
-        "@dotcom-tool-kit/types": "^3.0.0",
+        "@dotcom-tool-kit/logger": "^3.1.0",
+        "@dotcom-tool-kit/types": "^3.1.0",
         "@jest/globals": "^27.4.6",
         "tslib": "^2.3.1",
         "winston": "^3.5.1"
@@ -35438,9 +35599,9 @@
     "@dotcom-tool-kit/lint-staged": {
       "version": "file:plugins/lint-staged",
       "requires": {
-        "@dotcom-tool-kit/logger": "^3.0.0",
-        "@dotcom-tool-kit/package-json-hook": "^4.0.0",
-        "@dotcom-tool-kit/types": "^3.0.0",
+        "@dotcom-tool-kit/logger": "^3.1.0",
+        "@dotcom-tool-kit/package-json-hook": "^4.1.0",
+        "@dotcom-tool-kit/types": "^3.1.0",
         "lint-staged": "^11.2.3",
         "tslib": "^2.3.1"
       },
@@ -35486,9 +35647,9 @@
     "@dotcom-tool-kit/lint-staged-npm": {
       "version": "file:plugins/lint-staged-npm",
       "requires": {
-        "@dotcom-tool-kit/husky-npm": "^4.0.0",
-        "@dotcom-tool-kit/lint-staged": "^4.0.0",
-        "@dotcom-tool-kit/options": "^3.0.0",
+        "@dotcom-tool-kit/husky-npm": "^4.1.0",
+        "@dotcom-tool-kit/lint-staged": "^4.1.0",
+        "@dotcom-tool-kit/options": "^3.1.0",
         "tslib": "^2.3.1"
       },
       "dependencies": {
@@ -35502,7 +35663,7 @@
     "@dotcom-tool-kit/logger": {
       "version": "file:lib/logger",
       "requires": {
-        "@dotcom-tool-kit/error": "^3.0.0",
+        "@dotcom-tool-kit/error": "^3.1.0",
         "@types/triple-beam": "^1.3.2",
         "ansi-colors": "^4.1.1",
         "ansi-regex": "^5.0.1",
@@ -35522,9 +35683,9 @@
     "@dotcom-tool-kit/mocha": {
       "version": "file:plugins/mocha",
       "requires": {
-        "@dotcom-tool-kit/error": "^3.0.0",
-        "@dotcom-tool-kit/logger": "^3.0.0",
-        "@dotcom-tool-kit/types": "^3.0.0",
+        "@dotcom-tool-kit/error": "^3.1.0",
+        "@dotcom-tool-kit/logger": "^3.1.0",
+        "@dotcom-tool-kit/types": "^3.1.0",
         "@jest/globals": "^27.4.6",
         "@types/glob": "^7.1.3",
         "@types/mocha": "^8.2.2",
@@ -35543,9 +35704,9 @@
     "@dotcom-tool-kit/n-test": {
       "version": "file:plugins/n-test",
       "requires": {
-        "@dotcom-tool-kit/logger": "^3.0.0",
-        "@dotcom-tool-kit/state": "^3.0.0",
-        "@dotcom-tool-kit/types": "^3.0.0",
+        "@dotcom-tool-kit/logger": "^3.1.0",
+        "@dotcom-tool-kit/state": "^3.1.0",
+        "@dotcom-tool-kit/types": "^3.1.0",
         "@financial-times/n-test": "^5.0.1",
         "@jest/globals": "^27.4.6",
         "@types/jest": "^27.4.0",
@@ -35563,11 +35724,11 @@
     "@dotcom-tool-kit/next-router": {
       "version": "file:plugins/next-router",
       "requires": {
-        "@dotcom-tool-kit/error": "^3.0.0",
-        "@dotcom-tool-kit/logger": "^3.0.0",
-        "@dotcom-tool-kit/state": "^3.0.0",
-        "@dotcom-tool-kit/types": "^3.0.0",
-        "@dotcom-tool-kit/vault": "^3.0.0",
+        "@dotcom-tool-kit/error": "^3.1.0",
+        "@dotcom-tool-kit/logger": "^3.1.0",
+        "@dotcom-tool-kit/state": "^3.1.0",
+        "@dotcom-tool-kit/types": "^3.1.0",
+        "@dotcom-tool-kit/vault": "^3.1.0",
         "ft-next-router": "^1.0.0",
         "tslib": "^2.3.1"
       },
@@ -35582,10 +35743,10 @@
     "@dotcom-tool-kit/node": {
       "version": "file:plugins/node",
       "requires": {
-        "@dotcom-tool-kit/error": "^3.0.0",
-        "@dotcom-tool-kit/state": "^3.0.0",
-        "@dotcom-tool-kit/types": "^3.0.0",
-        "@dotcom-tool-kit/vault": "^3.0.0",
+        "@dotcom-tool-kit/error": "^3.1.0",
+        "@dotcom-tool-kit/state": "^3.1.0",
+        "@dotcom-tool-kit/types": "^3.1.0",
+        "@dotcom-tool-kit/vault": "^3.1.0",
         "get-port": "^5.1.1",
         "tslib": "^2.3.1",
         "wait-port": "^0.2.9"
@@ -35601,10 +35762,10 @@
     "@dotcom-tool-kit/nodemon": {
       "version": "file:plugins/nodemon",
       "requires": {
-        "@dotcom-tool-kit/error": "^3.0.0",
-        "@dotcom-tool-kit/state": "^3.0.0",
-        "@dotcom-tool-kit/types": "^3.0.0",
-        "@dotcom-tool-kit/vault": "^3.0.0",
+        "@dotcom-tool-kit/error": "^3.1.0",
+        "@dotcom-tool-kit/state": "^3.1.0",
+        "@dotcom-tool-kit/types": "^3.1.0",
+        "@dotcom-tool-kit/vault": "^3.1.0",
         "@types/nodemon": "^1.19.1",
         "get-port": "^5.1.1",
         "tslib": "^2.3.1"
@@ -35621,10 +35782,10 @@
       "version": "file:plugins/npm",
       "requires": {
         "@actions/exec": "^1.1.0",
-        "@dotcom-tool-kit/error": "^3.0.0",
-        "@dotcom-tool-kit/package-json-hook": "^4.0.0",
-        "@dotcom-tool-kit/state": "^3.0.0",
-        "@dotcom-tool-kit/types": "^3.0.0",
+        "@dotcom-tool-kit/error": "^3.1.0",
+        "@dotcom-tool-kit/package-json-hook": "^4.1.0",
+        "@dotcom-tool-kit/state": "^3.1.0",
+        "@dotcom-tool-kit/types": "^3.1.0",
         "@types/libnpmpublish": "^4.0.1",
         "@types/pacote": "^11.1.3",
         "@types/tar": "^6.1.1",
@@ -35741,7 +35902,7 @@
     "@dotcom-tool-kit/options": {
       "version": "file:lib/options",
       "requires": {
-        "@dotcom-tool-kit/types": "^3.0.0",
+        "@dotcom-tool-kit/types": "^3.1.0",
         "tslib": "^2.3.1"
       },
       "dependencies": {
@@ -35755,7 +35916,7 @@
     "@dotcom-tool-kit/pa11y": {
       "version": "file:plugins/pa11y",
       "requires": {
-        "@dotcom-tool-kit/types": "^3.0.0",
+        "@dotcom-tool-kit/types": "^3.1.0",
         "@types/pa11y": "^5.3.4",
         "pa11y-ci": "^3.0.1",
         "tslib": "^2.3.1"
@@ -35789,10 +35950,10 @@
     "@dotcom-tool-kit/prettier": {
       "version": "file:plugins/prettier",
       "requires": {
-        "@dotcom-tool-kit/error": "^3.0.0",
-        "@dotcom-tool-kit/logger": "^3.0.0",
-        "@dotcom-tool-kit/package-json-hook": "^4.0.0",
-        "@dotcom-tool-kit/types": "^3.0.0",
+        "@dotcom-tool-kit/error": "^3.1.0",
+        "@dotcom-tool-kit/logger": "^3.1.0",
+        "@dotcom-tool-kit/package-json-hook": "^4.1.0",
+        "@dotcom-tool-kit/types": "^3.1.0",
         "@jest/globals": "^27.4.6",
         "fast-glob": "^3.2.7",
         "hook-std": "^2.0.0",
@@ -36451,8 +36612,8 @@
     "@dotcom-tool-kit/secret-squirrel": {
       "version": "file:plugins/secret-squirrel",
       "requires": {
-        "@dotcom-tool-kit/logger": "^3.0.0",
-        "@dotcom-tool-kit/types": "^3.0.0",
+        "@dotcom-tool-kit/logger": "^3.1.0",
+        "@dotcom-tool-kit/types": "^3.1.0",
         "tslib": "^2.3.1"
       },
       "dependencies": {
@@ -36466,10 +36627,10 @@
     "@dotcom-tool-kit/serverless": {
       "version": "file:plugins/serverless",
       "requires": {
-        "@dotcom-tool-kit/error": "^3.0.0",
-        "@dotcom-tool-kit/state": "^3.0.0",
-        "@dotcom-tool-kit/types": "^3.0.0",
-        "@dotcom-tool-kit/vault": "^3.0.0",
+        "@dotcom-tool-kit/error": "^3.1.0",
+        "@dotcom-tool-kit/state": "^3.1.0",
+        "@dotcom-tool-kit/types": "^3.1.0",
+        "@dotcom-tool-kit/vault": "^3.1.0",
         "get-port": "^5.1.1",
         "tslib": "^2.3.1",
         "wait-port": "^0.2.9"
@@ -36498,8 +36659,8 @@
     "@dotcom-tool-kit/types": {
       "version": "file:lib/types",
       "requires": {
-        "@dotcom-tool-kit/error": "^3.0.0",
-        "@dotcom-tool-kit/logger": "^3.0.0",
+        "@dotcom-tool-kit/error": "^3.1.0",
+        "@dotcom-tool-kit/logger": "^3.1.0",
         "@jest/globals": "^27.4.6",
         "@types/prompts": "^2.0.14",
         "@types/semver": "^7.3.9",
@@ -36519,8 +36680,8 @@
     "@dotcom-tool-kit/typescript": {
       "version": "file:plugins/typescript",
       "requires": {
-        "@dotcom-tool-kit/logger": "^3.0.0",
-        "@dotcom-tool-kit/types": "^3.0.0",
+        "@dotcom-tool-kit/logger": "^3.1.0",
+        "@dotcom-tool-kit/types": "^3.1.0",
         "@jest/globals": "^29.3.1",
         "typescript": "^4.9.4",
         "winston": "^3.8.2"
@@ -36683,9 +36844,9 @@
       "requires": {
         "@aws-sdk/client-s3": "^3.256.0",
         "@aws-sdk/types": "^3.13.1",
-        "@dotcom-tool-kit/error": "^3.0.0",
-        "@dotcom-tool-kit/logger": "^3.0.0",
-        "@dotcom-tool-kit/types": "^3.0.0",
+        "@dotcom-tool-kit/error": "^3.1.0",
+        "@dotcom-tool-kit/logger": "^3.1.0",
+        "@dotcom-tool-kit/types": "^3.1.0",
         "@jest/globals": "^27.4.6",
         "@types/glob": "^7.1.3",
         "@types/jest": "^27.4.0",
@@ -36706,9 +36867,9 @@
     "@dotcom-tool-kit/vault": {
       "version": "file:lib/vault",
       "requires": {
-        "@dotcom-tool-kit/error": "^3.0.0",
-        "@dotcom-tool-kit/options": "^3.0.0",
-        "@dotcom-tool-kit/types": "^3.0.0",
+        "@dotcom-tool-kit/error": "^3.1.0",
+        "@dotcom-tool-kit/options": "^3.1.0",
+        "@dotcom-tool-kit/types": "^3.1.0",
         "@financial-times/n-fetch": "^1.0.0-beta.12",
         "@types/jest": "^27.0.2",
         "fs": "0.0.1-security",
@@ -36751,9 +36912,9 @@
     "@dotcom-tool-kit/webpack": {
       "version": "file:plugins/webpack",
       "requires": {
-        "@dotcom-tool-kit/error": "^3.0.0",
-        "@dotcom-tool-kit/logger": "^3.0.0",
-        "@dotcom-tool-kit/types": "^3.0.0",
+        "@dotcom-tool-kit/error": "^3.1.0",
+        "@dotcom-tool-kit/logger": "^3.1.0",
+        "@dotcom-tool-kit/types": "^3.1.0",
         "@jest/globals": "^27.4.6",
         "ts-node": "^10.0.0",
         "tslib": "^2.3.1",
@@ -40050,7 +40211,7 @@
     "ansi-escapes": {
       "version": "4.3.2",
       "requires": {
-        "type-fest": "^0.21.3"
+        "type-fest": "3.6.0"
       }
     },
     "ansi-regex": {
@@ -40641,7 +40802,7 @@
         "chalk": "^4.1.0",
         "cli-boxes": "^2.2.1",
         "string-width": "^4.2.2",
-        "type-fest": "^0.20.2",
+        "type-fest": "3.6.0",
         "widest-line": "^3.1.0",
         "wrap-ansi": "^7.0.0"
       },
@@ -42371,22 +42532,22 @@
     "dotcom-tool-kit": {
       "version": "file:core/cli",
       "requires": {
-        "@dotcom-tool-kit/babel": "^3.0.0",
-        "@dotcom-tool-kit/backend-heroku-app": "^2.0.0",
-        "@dotcom-tool-kit/circleci": "^5.0.0",
-        "@dotcom-tool-kit/circleci-deploy": "^3.0.0",
-        "@dotcom-tool-kit/error": "^3.0.0",
-        "@dotcom-tool-kit/eslint": "^3.0.0",
-        "@dotcom-tool-kit/frontend-app": "^3.0.0",
-        "@dotcom-tool-kit/heroku": "^3.0.0",
-        "@dotcom-tool-kit/logger": "^3.0.0",
-        "@dotcom-tool-kit/mocha": "^3.0.0",
-        "@dotcom-tool-kit/n-test": "^3.0.0",
-        "@dotcom-tool-kit/npm": "^3.0.0",
-        "@dotcom-tool-kit/options": "^3.0.0",
-        "@dotcom-tool-kit/types": "^3.0.0",
-        "@dotcom-tool-kit/wait-for-ok": "^3.0.0",
-        "@dotcom-tool-kit/webpack": "^3.0.0",
+        "@dotcom-tool-kit/babel": "^3.1.0",
+        "@dotcom-tool-kit/backend-heroku-app": "^2.1.0",
+        "@dotcom-tool-kit/circleci": "^5.1.0",
+        "@dotcom-tool-kit/circleci-deploy": "^3.1.0",
+        "@dotcom-tool-kit/error": "^3.1.0",
+        "@dotcom-tool-kit/eslint": "^3.1.0",
+        "@dotcom-tool-kit/frontend-app": "^3.1.0",
+        "@dotcom-tool-kit/heroku": "^3.1.0",
+        "@dotcom-tool-kit/logger": "^3.1.0",
+        "@dotcom-tool-kit/mocha": "^3.1.0",
+        "@dotcom-tool-kit/n-test": "^3.1.0",
+        "@dotcom-tool-kit/npm": "^3.1.0",
+        "@dotcom-tool-kit/options": "^3.1.0",
+        "@dotcom-tool-kit/types": "^3.1.0",
+        "@dotcom-tool-kit/wait-for-ok": "^3.1.0",
+        "@dotcom-tool-kit/webpack": "^3.1.0",
         "@jest/globals": "^27.4.6",
         "@types/lodash": "^4.14.185",
         "@types/node": "^16.18.23",
@@ -45965,7 +46126,7 @@
         "graceful-fs": "^4.1.15",
         "parse-json": "^5.0.0",
         "strip-bom": "^4.0.0",
-        "type-fest": "^0.6.0"
+        "type-fest": "3.6.0"
       }
     },
     "loader-runner": {
@@ -47666,7 +47827,7 @@
       "peer": true,
       "requires": {
         "mimic-fn": "^4.0.0",
-        "type-fest": "^3.0.0"
+        "type-fest": "3.6.0"
       },
       "dependencies": {
         "mimic-fn": {
@@ -48760,7 +48921,7 @@
         "@types/normalize-package-data": "^2.4.0",
         "normalize-package-data": "^2.5.0",
         "parse-json": "^5.0.0",
-        "type-fest": "^0.6.0"
+        "type-fest": "3.6.0"
       },
       "dependencies": {
         "hosted-git-info": {
@@ -49432,7 +49593,7 @@
     "serialize-error": {
       "version": "5.0.0",
       "requires": {
-        "type-fest": "^0.8.0"
+        "type-fest": "3.6.0"
       }
     },
     "serialize-javascript": {
@@ -49850,7 +50011,7 @@
             "chalk": "^5.0.1",
             "cli-boxes": "^3.0.0",
             "string-width": "^5.1.2",
-            "type-fest": "^2.13.0",
+            "type-fest": "3.6.0",
             "widest-line": "^4.0.1",
             "wrap-ansi": "^8.0.1"
           }
@@ -52365,7 +52526,7 @@
       "dev": true,
       "requires": {
         "sort-keys": "^2.0.0",
-        "type-fest": "^0.4.1",
+        "type-fest": "3.6.0",
         "write-json-file": "^3.2.0"
       }
     },

--- a/plugins/heroku/src/createBuild.ts
+++ b/plugins/heroku/src/createBuild.ts
@@ -1,27 +1,23 @@
 import type { Logger } from 'winston'
-import heroku from './herokuClient'
-import { ToolKitError } from '@dotcom-tool-kit/error'
+import heroku, { extractHerokuError } from './herokuClient'
 import type { HerokuApiResBuild } from 'heroku-client'
 import { getRepoDetails } from './githubApi'
 
 async function createBuild(logger: Logger, appName: string): Promise<HerokuApiResBuild> {
-	try {
-		logger.info(`getting latest tarball path for ${appName}...`)
-		const { branch, source_blob } = await getRepoDetails(logger)
-		logger.info(`creating new build for ${appName} from ${branch}...`)
-		const buildInfo: HerokuApiResBuild = await heroku.post(`/apps/${appName}/builds`, {
-			body: {
-				source_blob: {...source_blob, checksum: null}
-			  }
-		})
-		return buildInfo
-	} catch(err) {
-		const error = new ToolKitError('Unable to create build from latest tarball')
-		if (err instanceof Error) {
-			error.details = err.message
-		  }
-		throw error
-	}
+  logger.info(`getting latest tarball path for ${appName}...`)
+  const { branch, source_blob } = await getRepoDetails(logger)
+  logger.info(`creating new build for ${appName} from ${branch}...`)
+  const buildInfo = await heroku
+    .post<HerokuApiResBuild>(`/apps/${appName}/builds`, {
+      body: {
+        source_blob: {
+          ...source_blob,
+          checksum: null
+        }
+      }
+    })
+    .catch(extractHerokuError(`creating new build for app ${appName}`))
+  return buildInfo
 }
 
 export { createBuild }

--- a/plugins/heroku/src/declarations.d.ts
+++ b/plugins/heroku/src/declarations.d.ts
@@ -89,6 +89,11 @@ declare module 'heroku-client' {
     }
   }
 
+  export interface HerokuError extends Error {
+    statusCode: number
+    body: unknown
+  }
+
   export default class Heroku {
     constructor(options: HerokuClassOptions)
     get<T>(path: string, options?: HerokuApiReqOptions): Promise<T>

--- a/plugins/heroku/src/declarations.d.ts
+++ b/plugins/heroku/src/declarations.d.ts
@@ -89,9 +89,15 @@ declare module 'heroku-client' {
     }
   }
 
+  export type HerokuErrorBody = {
+    id: string
+    message: string
+    url?: string
+  }
+
   export interface HerokuError extends Error {
     statusCode: number
-    body: unknown
+    body: HerokuErrorBody
   }
 
   export default class Heroku {

--- a/plugins/heroku/src/getHerokuStagingApp.ts
+++ b/plugins/heroku/src/getHerokuStagingApp.ts
@@ -1,6 +1,6 @@
 import { readState, writeState } from '@dotcom-tool-kit/state'
 import { ToolKitError } from '@dotcom-tool-kit/error'
-import heroku from './herokuClient'
+import heroku, { extractHerokuError } from './herokuClient'
 import type { HerokuApiResGetStaging } from 'heroku-client'
 
 async function getHerokuStagingApp(): Promise<string> {
@@ -11,17 +11,12 @@ async function getHerokuStagingApp(): Promise<string> {
   }
 
   const appId = stagingState.appIds[0]
-  
-  try {
-    const { name: appName }: HerokuApiResGetStaging = await heroku.get(`/apps/${appId}`)
-    writeState('staging', { appName })
-    return appName
-  } catch (err) {
-		const error = new ToolKitError('Unable to find latest app or write it to state')
-		if (err instanceof Error) {
-			error.details = err.message
-		  } 
-		throw error
-  }
+  const { name: appName } = await heroku
+    .get<HerokuApiResGetStaging>(`/apps/${appId}`)
+    .catch(extractHerokuError(`getting name for app ${appId}`))
+  writeState('staging', {
+    appName
+  })
+  return appName
 }
 export { getHerokuStagingApp }

--- a/plugins/heroku/src/getPipelineCouplings.ts
+++ b/plugins/heroku/src/getPipelineCouplings.ts
@@ -1,4 +1,4 @@
-import heroku from './herokuClient'
+import heroku, { extractHerokuError } from './herokuClient'
 import type { HerokuApiResGetPipeline, HerokuApiResGetPipelineApps } from 'heroku-client'
 import type { Logger } from 'winston'
 import { ToolKitError } from '@dotcom-tool-kit/error'
@@ -6,13 +6,15 @@ import { writeState } from '@dotcom-tool-kit/state'
 
 async function getPipelineCouplings(logger: Logger, pipelineName: string): Promise<void> {
   logger.verbose(`retrieving pipeline id for ${pipelineName}`)
-  const piplelineDetails: HerokuApiResGetPipeline = await heroku.get(`/pipelines/${pipelineName}`)
-
+  const piplelineDetails = await heroku
+    .get<HerokuApiResGetPipeline>(`/pipelines/${pipelineName}`)
+    .catch(extractHerokuError(`getting pipeline ID for pipeline ${pipelineName}`))
   logger.verbose(`getting product app ids for pipeline id: ${piplelineDetails.id}`)
-  const couplings: HerokuApiResGetPipelineApps[] = await heroku.get(
-    `/pipelines/${piplelineDetails.id}/pipeline-couplings`
-  )
-
+  const couplings = await heroku
+    .get<HerokuApiResGetPipelineApps[]>(`/pipelines/${piplelineDetails.id}/pipeline-couplings`)
+    .catch(
+      extractHerokuError(`getting pipeline couplings for pipeline ${piplelineDetails.id} (${pipelineName})`)
+    )
   const stages = ['production', 'staging'] as const
 
   stages.forEach((stage) => {
@@ -24,8 +26,9 @@ async function getPipelineCouplings(logger: Logger, pipelineName: string): Promi
     }
     const appIds = apps.map((app) => app.app.id)
     logger.verbose(`writing ${stage} app ids to state: ${appIds}`)
-
-    writeState(stage, { appIds })
+    writeState(stage, {
+      appIds
+    })
   })
 
   return

--- a/plugins/heroku/src/gtg.ts
+++ b/plugins/heroku/src/gtg.ts
@@ -1,4 +1,4 @@
-import heroku from './herokuClient'
+import heroku, { extractHerokuError } from './herokuClient'
 import type { HerokuApiResGetGtg } from 'heroku-client'
 import type { Logger } from 'winston'
 import { waitForOk } from '@dotcom-tool-kit/wait-for-ok'
@@ -6,14 +6,17 @@ import { State, writeState } from '@dotcom-tool-kit/state'
 
 async function gtg(logger: Logger, appIdName: string, environment: keyof State, id = true): Promise<void> {
   let appName = appIdName
-  //gtg called with id rather than name; get name from Heroku
+  // gtg called with id rather than name; get name from Heroku
   if (id) {
-    const appDetails: HerokuApiResGetGtg = await heroku.get(`/apps/${appIdName}`)
+    const appDetails = await heroku
+      .get<HerokuApiResGetGtg>(`/apps/${appIdName}`)
+      .catch(extractHerokuError(`getting app name for app ${appIdName}`))
     appName = appDetails.name
   }
-  //save name to state file
-  writeState(environment, { appName })
-
+  // save name to state file
+  writeState(environment, {
+    appName
+  })
   const url = `https://${appName}.herokuapp.com/__gtg`
 
   return waitForOk(logger, url)

--- a/plugins/heroku/src/herokuClient.ts
+++ b/plugins/heroku/src/herokuClient.ts
@@ -1,5 +1,27 @@
-import Heroku from 'heroku-client'
+import { ToolKitError } from '@dotcom-tool-kit/error'
+import { styles } from '@dotcom-tool-kit/logger'
+import Heroku, { HerokuError } from 'heroku-client'
 
 const HEROKU_AUTH_TOKEN = process.env.HEROKU_AUTH_TOKEN
 
 export default new Heroku({ token: HEROKU_AUTH_TOKEN })
+
+// the Heroku client doesn't give particularly useful error messages, so we require an additional context
+// string when handling errors coming from it
+export function extractHerokuError(context: string): (err: unknown) => never {
+  return (err) => {
+    if ((err as HerokuError).statusCode) {
+      const upstream = err as HerokuError
+      const error = new ToolKitError('there was an error calling the Heroku API')
+      error.details = `received the error ${styles.errorHighlight(upstream.message)} when ${context}`
+      if (upstream.body) {
+        error.details += `\n\nresponse from Heroku was:\n${styles.errorHighlight(upstream.body.message)}`
+        if (upstream.body.url) {
+          error.details += `\nfurther information available at ${styles.URL(upstream.body.url)}`
+        }
+      }
+      throw error
+    }
+    throw err
+  }
+}

--- a/plugins/heroku/src/promoteStagingToProduction.ts
+++ b/plugins/heroku/src/promoteStagingToProduction.ts
@@ -1,4 +1,4 @@
-import heroku from './herokuClient'
+import heroku, { extractHerokuError } from './herokuClient'
 import { ToolKitError } from '@dotcom-tool-kit/error'
 import { readState } from '@dotcom-tool-kit/state'
 import { gtg } from './gtg'
@@ -28,13 +28,7 @@ async function promoteStagingToProduction(
           slug
         }
       })
-      .catch((err) => {
-        const error = new ToolKitError(
-          `there was an error with setting the slug on your production app id: ${appId}`
-        )
-        error.details = err
-        throw error
-      })
+      .catch(extractHerokuError(`promoting app ID ${appId} to production`))
       .then((response) => gtg(logger, response.app.name, 'production', false))
   )
 

--- a/plugins/heroku/src/repeatedCheckForBuildSuccess.ts
+++ b/plugins/heroku/src/repeatedCheckForBuildSuccess.ts
@@ -1,15 +1,19 @@
 import pRetry from 'p-retry'
-import heroku from './herokuClient'
+import heroku, { extractHerokuError } from './herokuClient'
 import type { HerokuApiResBuild } from 'heroku-client'
 import type { Logger } from 'winston'
 
-const NUM_RETRIES = process.env.HEROKU_BUILD_NUM_RETRIES
-  ? parseInt(process.env.HEROKU_BUILD_NUM_RETRIES)
-  : 60
+const NUM_RETRIES = process.env.HEROKU_BUILD_NUM_RETRIES ? parseInt(process.env.HEROKU_BUILD_NUM_RETRIES) : 60
 
-async function repeatedCheckForBuildSuccess(logger: Logger, appName: string, buildId: string): Promise<string> {
+async function repeatedCheckForBuildSuccess(
+  logger: Logger,
+  appName: string,
+  buildId: string
+): Promise<string> {
   async function checkForSuccessStatus() {
-    const buildInfo: HerokuApiResBuild = await heroku.get(`/apps/${appName}/builds/${buildId}`)
+    const buildInfo = await heroku
+      .get<HerokuApiResBuild>(`/apps/${appName}/builds/${buildId}`)
+      .catch(extractHerokuError(`getting info for build ${buildId} for app ${appName}`))
     logger.debug(`build status: ${buildInfo.status}`)
     if (buildInfo.status !== 'succeeded' || buildInfo.slug === null) {
       throw new Error(`Build for app ${appName} not yet finished`)

--- a/plugins/heroku/src/setStagingSlug.ts
+++ b/plugins/heroku/src/setStagingSlug.ts
@@ -1,28 +1,32 @@
 import type { Logger } from 'winston'
-import heroku from './herokuClient'
+import heroku, { extractHerokuError } from './herokuClient'
 import { ToolKitError } from '@dotcom-tool-kit/error'
 import { HerokuApiResPost } from 'heroku-client'
 import { writeState } from '@dotcom-tool-kit/state'
 
 async function setStagingSlug(logger: Logger, appName: string, slug: string): Promise<void> {
-	try{
-		logger.info(`updating slug id ${slug} on ${appName}`)
-	  
-		const { slug: {id: slugId}} = await heroku.post<HerokuApiResPost>(`/apps/${appName}/releases`, {
-			body: {
-			slug
-			}
-		})
-		writeState('staging', {slugId})
-	} catch(err) {
-        const error = new ToolKitError(
-          `there was an error with setting the slug on ${appName}`
-        )
-		if (err instanceof Error) {
-			error.details = err.message
-		  }
-		throw error
-      }
+  try {
+    logger.info(`updating slug id ${slug} on ${appName}`)
+
+    const {
+      slug: { id: slugId }
+    } = await heroku
+      .post<HerokuApiResPost>(`/apps/${appName}/releases`, {
+        body: {
+          slug
+        }
+      })
+      .catch(extractHerokuError(`setting slug for app ${appName}`))
+    writeState('staging', {
+      slugId
+    })
+  } catch (err) {
+    const error = new ToolKitError(`there was an error with setting the slug on ${appName}`)
+    if (err instanceof Error) {
+      error.details = err.message
+    }
+    throw error
+  }
 }
 
 export { setStagingSlug }

--- a/plugins/heroku/src/tasks/production.ts
+++ b/plugins/heroku/src/tasks/production.ts
@@ -3,7 +3,7 @@ import { ToolKitError } from '@dotcom-tool-kit/error'
 import { readState } from '@dotcom-tool-kit/state'
 import { styles } from '@dotcom-tool-kit/logger'
 import { HerokuSchema } from '@dotcom-tool-kit/types/lib/schema/heroku'
-import type { HerokuApiResGetApp } from 'heroku-client'
+import type { HerokuApiResGetApp, HerokuError } from 'heroku-client'
 import heroku from '../herokuClient'
 import { scaleDyno } from '../scaleDyno'
 import { promoteStagingToProduction } from '../promoteStagingToProduction'
@@ -66,6 +66,10 @@ export default class HerokuProduction extends Task<typeof HerokuSchema> {
       const error = new ToolKitError("there's an error with your production app")
       if (err instanceof Error) {
         error.details = err.message
+        // Heroku errors include a body property that provide additional context for why a request failed
+        if ((err as HerokuError).body) {
+          error.details += '\n' + (err as HerokuError).body
+        }
       }
       throw error
     }

--- a/plugins/heroku/src/tasks/production.ts
+++ b/plugins/heroku/src/tasks/production.ts
@@ -3,8 +3,8 @@ import { ToolKitError } from '@dotcom-tool-kit/error'
 import { readState } from '@dotcom-tool-kit/state'
 import { styles } from '@dotcom-tool-kit/logger'
 import { HerokuSchema } from '@dotcom-tool-kit/types/lib/schema/heroku'
-import type { HerokuApiResGetApp, HerokuError } from 'heroku-client'
-import heroku from '../herokuClient'
+import type { HerokuApiResGetApp } from 'heroku-client'
+import heroku, { extractHerokuError } from '../herokuClient'
 import { scaleDyno } from '../scaleDyno'
 import { promoteStagingToProduction } from '../promoteStagingToProduction'
 
@@ -66,10 +66,6 @@ export default class HerokuProduction extends Task<typeof HerokuSchema> {
       const error = new ToolKitError("there's an error with your production app")
       if (err instanceof Error) {
         error.details = err.message
-        // Heroku errors include a body property that provide additional context for why a request failed
-        if ((err as HerokuError).body) {
-          error.details += '\n' + (err as HerokuError).body
-        }
       }
       throw error
     }
@@ -77,7 +73,9 @@ export default class HerokuProduction extends Task<typeof HerokuSchema> {
 
   async fetchIfAppHasDeployed(appId: string): Promise<boolean> {
     this.logger.verbose(`retrieving app info for ${appId}`)
-    const appInfo: HerokuApiResGetApp = await heroku.get(`/apps/${appId}`)
+    const appInfo = await heroku
+      .get<HerokuApiResGetApp>(`/apps/${appId}`)
+      .catch(extractHerokuError(`getting slug size for app ${appId}`))
     return appInfo.slugSize !== null
   }
 }

--- a/plugins/heroku/src/tasks/staging.ts
+++ b/plugins/heroku/src/tasks/staging.ts
@@ -1,3 +1,4 @@
+import type { HerokuError } from 'heroku-client'
 import { Task } from '@dotcom-tool-kit/types'
 import { ToolKitError } from '@dotcom-tool-kit/error'
 import { getHerokuStagingApp } from '../getHerokuStagingApp'
@@ -48,6 +49,9 @@ export default class HerokuStaging extends Task<typeof HerokuSchema> {
       const error = new ToolKitError(`there's an error with your staging app`)
       if (err instanceof Error) {
         error.details = err.message
+        if ((err as HerokuError).body) {
+          error.details += '\n' + (err as HerokuError).body
+        }
       }
       throw error
     }

--- a/plugins/heroku/src/tasks/staging.ts
+++ b/plugins/heroku/src/tasks/staging.ts
@@ -1,4 +1,3 @@
-import type { HerokuError } from 'heroku-client'
 import { Task } from '@dotcom-tool-kit/types'
 import { ToolKitError } from '@dotcom-tool-kit/error'
 import { getHerokuStagingApp } from '../getHerokuStagingApp'
@@ -49,9 +48,6 @@ export default class HerokuStaging extends Task<typeof HerokuSchema> {
       const error = new ToolKitError(`there's an error with your staging app`)
       if (err instanceof Error) {
         error.details = err.message
-        if ((err as HerokuError).body) {
-          error.details += '\n' + (err as HerokuError).body
-        }
       }
       throw error
     }

--- a/plugins/heroku/test/createBuild.test.ts
+++ b/plugins/heroku/test/createBuild.test.ts
@@ -4,59 +4,60 @@ import { getRepoDetails } from '../src/githubApi'
 import heroku from '../src/herokuClient'
 import winston, { Logger } from 'winston'
 
-
 const logger = (winston as unknown) as Logger
 
 const appName = 'test-app-name'
 
 const repo = {
-	branch: 'test-branch',
-	source_blob: {
-		url: 'test-url',
-		version: 'test-version'
-	}
+  branch: 'test-branch',
+  source_blob: {
+    url: 'test-url',
+    version: 'test-version'
+  }
 }
 
 const buildInfo = {
-	id: 'test-build-id',
-    status: 'notfinished',
-    slug: null
+  id: 'test-build-id',
+  status: 'notfinished',
+  slug: null
 }
 
 const mockHerokuPost = jest.spyOn(heroku, 'post')
 
 jest.mock('../src/githubApi', () => {
-	return {
-		getRepoDetails: jest.fn(() => (repo))
-  }})
+  return {
+    getRepoDetails: jest.fn(() => repo)
+  }
+})
 
 describe('setStagingSlug', () => {
+  it('retrieves repo details', async () => {
+    mockHerokuPost.mockImplementationOnce(async () => Promise.resolve(buildInfo))
+    await createBuild(logger, appName)
 
-	it('retrieves repo details', async () => {
-		mockHerokuPost.mockImplementationOnce(async () => Promise.resolve(buildInfo))
-		await createBuild(logger, appName)
+    expect(getRepoDetails).toBeCalledTimes(1)
+    expect(getRepoDetails).toBeCalledWith(logger)
+  })
 
-		expect(getRepoDetails).toBeCalledTimes(1)
-		expect(getRepoDetails).toBeCalledWith(logger)
-	})
+  it('creates a new build for the app', async () => {
+    mockHerokuPost.mockImplementationOnce(async () => Promise.resolve(buildInfo))
+    await createBuild(logger, appName)
 
-	it('creates a new build for the app', async () => {
-		mockHerokuPost.mockImplementationOnce(async () => Promise.resolve(buildInfo))
-		await createBuild(logger, appName)
+    expect(heroku.post).toBeCalledTimes(1)
+    expect(heroku.post).toBeCalledWith(`/apps/${appName}/builds`, {
+      body: { source_blob: { ...repo.source_blob, checksum: null } }
+    })
+  })
 
-		expect(heroku.post).toBeCalledTimes(1)
-		expect(heroku.post).toBeCalledWith(`/apps/${appName}/builds`, {body: {source_blob: {...repo.source_blob, checksum:null}}})
-	})
+  it('returns build info if successful', async () => {
+    mockHerokuPost.mockImplementationOnce(async () => Promise.resolve(buildInfo))
 
-	it('returns build info if successful', async () => {
-		mockHerokuPost.mockImplementationOnce(async () => Promise.resolve(buildInfo))
+    await expect(createBuild(logger, appName)).resolves.not.toThrow()
+  })
 
-		await expect(createBuild(logger, appName)).resolves.not.toThrow()
-	})
+  it('throws if unsuccessful', async () => {
+    mockHerokuPost.mockImplementationOnce(async () => Promise.reject())
 
-	it('throws if unsuccessful', async () => {
-		mockHerokuPost.mockImplementationOnce(async () => Promise.reject())
-
-		await expect(createBuild(logger, appName)).rejects.toThrow()
-	})
+    await expect(createBuild(logger, appName)).rejects.toThrow()
+  })
 })

--- a/plugins/heroku/test/getHerokuReviewApp.test.ts
+++ b/plugins/heroku/test/getHerokuReviewApp.test.ts
@@ -30,8 +30,11 @@ const reviewApps = [
 ]
 
 jest.mock('../src/herokuClient', () => {
+  const originalModule = jest.requireActual('../src/herokuClient') as object
   return {
-    get: jest.fn(() => reviewApps)
+    __esmodule: true,
+    ...originalModule,
+    get: jest.fn(async () => reviewApps)
   }
 })
 

--- a/plugins/heroku/test/getHerokuStagingApp.test.ts
+++ b/plugins/heroku/test/getHerokuStagingApp.test.ts
@@ -23,7 +23,7 @@ const mockHerokuGet = jest.spyOn(heroku, 'get')
 
 describe('getHerokuStagingApp', () => {
   it('retreives data from state', async () => {
-    mockHerokuGet.mockImplementationOnce(async () => Promise.resolve({name}))
+    mockHerokuGet.mockImplementationOnce(async () => Promise.resolve({ name }))
 
     await getHerokuStagingApp()
 
@@ -31,27 +31,27 @@ describe('getHerokuStagingApp', () => {
   })
 
   it('writes app name to state', async () => {
-    mockHerokuGet.mockImplementationOnce(async () => Promise.resolve({name}))
+    mockHerokuGet.mockImplementationOnce(async () => Promise.resolve({ name }))
     await getHerokuStagingApp()
 
     expect(writeState).toBeCalledWith('staging', { appName: 'staging-app-name' })
   })
 
   it('returns the app name', async () => {
-    mockHerokuGet.mockImplementationOnce(async () => Promise.resolve({name}))
+    mockHerokuGet.mockImplementationOnce(async () => Promise.resolve({ name }))
     const appName = await getHerokuStagingApp()
 
     expect(appName).toEqual(name)
   })
 
   it('does not throw when successful', async () => {
-    mockHerokuGet.mockImplementationOnce(async () => Promise.resolve({name}))
+    mockHerokuGet.mockImplementationOnce(async () => Promise.resolve({ name }))
     await expect(getHerokuStagingApp()).resolves.not.toThrow()
   })
 
   it('throws when unsuccessful', async () => {
     mockHerokuGet.mockImplementationOnce(async () => Promise.reject())
- 
+
     await expect(getHerokuStagingApp()).rejects.toThrow()
   })
 })

--- a/plugins/heroku/test/getPipelineCouplings.test.ts
+++ b/plugins/heroku/test/getPipelineCouplings.test.ts
@@ -36,8 +36,11 @@ const couplings = [
 const pipelineName = 'test-pipeline-name'
 
 jest.mock('../src/herokuClient', () => {
+  const originalModule = jest.requireActual('../src/herokuClient') as object
   return {
-    get: jest.fn((str: string) => {
+    __esmodule: true,
+    ...originalModule,
+    get: jest.fn(async (str: string) => {
       return str.includes('couplings') ? couplings : pipeline[str.replace('/pipelines/', '')]
     })
   }

--- a/plugins/heroku/test/gtg.test.ts
+++ b/plugins/heroku/test/gtg.test.ts
@@ -10,8 +10,11 @@ const logger = (winston as unknown) as Logger
 const appName = 'test-app-name'
 
 jest.mock('../src/herokuClient', () => {
+  const originalModule = jest.requireActual('../src/herokuClient') as object
   return {
-    get: jest.fn(() => ({ name: appName }))
+    __esmodule: true,
+    ...originalModule,
+    get: jest.fn(async () => ({ name: appName }))
   }
 })
 

--- a/plugins/heroku/test/repeatedCheckForBuildSuccess.test.ts
+++ b/plugins/heroku/test/repeatedCheckForBuildSuccess.test.ts
@@ -1,4 +1,3 @@
-
 import { describe, it, expect, jest } from '@jest/globals'
 import { repeatedCheckForBuildSuccess } from '../src/repeatedCheckForBuildSuccess'
 import heroku from '../src/herokuClient'
@@ -10,19 +9,19 @@ const appName = 'test-app-name'
 const buildId = 'test-build-id'
 
 const buildInfo = {
-	id: 'test-build-id',
-    status: 'succeeded',
-    slug: {
-		id: 'test-slug-id'
-	}
+  id: 'test-build-id',
+  status: 'succeeded',
+  slug: {
+    id: 'test-slug-id'
+  }
 }
 
 const mockHerokuGet = jest.spyOn(heroku, 'get')
 
 describe('repeatedCheckForBuildSuccess', () => {
   it('calls heroku api with the app name', async () => {
-	mockHerokuGet.mockImplementationOnce(async () => Promise.resolve(buildInfo))
-	
+    mockHerokuGet.mockImplementationOnce(async () => Promise.resolve(buildInfo))
+
     await repeatedCheckForBuildSuccess(logger, appName, buildId)
 
     expect(heroku.get).toHaveBeenCalledWith(`/apps/${appName}/builds/${buildId}`)

--- a/plugins/heroku/test/repeatedCheckForSuccessStatus.test.ts
+++ b/plugins/heroku/test/repeatedCheckForSuccessStatus.test.ts
@@ -17,8 +17,11 @@ const reviewApp = {
 }
 
 jest.mock('../src/herokuClient', () => {
+  const originalModule = jest.requireActual('../src/herokuClient') as object
   return {
-    get: jest.fn(() => reviewApp)
+    __esmodule: true,
+    ...originalModule,
+    get: jest.fn(async () => reviewApp)
   }
 })
 

--- a/plugins/heroku/test/scaleDyno.test.ts
+++ b/plugins/heroku/test/scaleDyno.test.ts
@@ -15,8 +15,11 @@ const response = [
 ]
 
 jest.mock('../src/herokuClient', () => {
+  const originalModule = jest.requireActual('../src/herokuClient') as object
   return {
-    patch: jest.fn((path: string) => {
+    __esmodule: true,
+    ...originalModule,
+    patch: jest.fn(async (path: string) => {
       if (!path.includes('test-staging-app-name')) {
         throw new Error()
       }

--- a/plugins/heroku/test/setConfigVars.test.ts
+++ b/plugins/heroku/test/setConfigVars.test.ts
@@ -50,13 +50,16 @@ class VaultEnvVarsMock {
   }
 }
 jest.mock('../src/herokuClient', () => {
+  const originalModule = jest.requireActual('../src/herokuClient') as object
   return {
-    patch: jest.fn((str: string) => {
+    __esmodule: true,
+    ...originalModule,
+    patch: jest.fn(async (str: string) => {
       if (str.includes('wrong')) {
         throw new Error()
       }
     }),
-    get: jest.fn((str: string) => {
+    get: jest.fn(async (str: string) => {
       if (str.includes('wrong')) {
         throw new Error()
       }

--- a/plugins/heroku/test/setStagingSlug.test.ts
+++ b/plugins/heroku/test/setStagingSlug.test.ts
@@ -9,24 +9,23 @@ const appName = 'test-app-name'
 const slug = 'test-slug-id'
 
 describe('setStagingSlug', () => {
+  it('posts to heroku api with app name and slug id', async () => {
+    mockHerokuPost.mockImplementation(async () => Promise.resolve({ slug: { id: 'test-slug-id' } }))
 
-	it('posts to heroku api with app name and slug id', async () => {
-		mockHerokuPost.mockImplementation(async () => Promise.resolve({ slug: {id: 'test-slug-id'}}))
-		
-		await setStagingSlug(logger, appName, slug)
+    await setStagingSlug(logger, appName, slug)
 
-		expect(heroku.post).toBeCalledWith(`/apps/${appName}/releases`, {body: {slug}})
-	})
+    expect(heroku.post).toBeCalledWith(`/apps/${appName}/releases`, { body: { slug } })
+  })
 
-	it('throws an error if unsuccessful', async () => {
-		mockHerokuPost.mockImplementation(async () => Promise.reject())
-		
-		await expect(setStagingSlug(logger, appName, slug)).rejects.toThrowError()
-	})
+  it('throws an error if unsuccessful', async () => {
+    mockHerokuPost.mockImplementation(async () => Promise.reject())
 
-	it('resolves if successful', async () => {
-		mockHerokuPost.mockImplementation(async () => Promise.resolve({ slug: {id: 'test-slug-id'}}))
-		
-		await expect(setStagingSlug(logger, appName, slug)).resolves.not.toThrow()
-	})
+    await expect(setStagingSlug(logger, appName, slug)).rejects.toThrowError()
+  })
+
+  it('resolves if successful', async () => {
+    mockHerokuPost.mockImplementation(async () => Promise.resolve({ slug: { id: 'test-slug-id' } }))
+
+    await expect(setStagingSlug(logger, appName, slug)).resolves.not.toThrow()
+  })
 })

--- a/plugins/heroku/test/tasks/review.test.ts
+++ b/plugins/heroku/test/tasks/review.test.ts
@@ -18,7 +18,10 @@ let pipeline = 'test-pipeline'
 const appId = 'test-review-app-id'
 
 jest.mock('../../src/herokuClient', () => {
+  const originalModule = jest.requireActual('../../src/herokuClient') as object
   return {
+    __esmodule: true,
+    ...originalModule,
     get: jest.fn((path: string) => {
       if (path.includes('test-pipeline')) {
         return Promise.resolve({ id: 'test-pipeline-id' })


### PR DESCRIPTION
# Description

We've long had a problem where errors thrown when getting a unsuccessful status code from the Heroku API neither include the actual error response body from Heroku, nor provide any information on what API call was the one that caused the error. The `heroku-client` package itself is largely to blame for this: it does bundle up a good amount of information in the errors it throws, but it's hidden away in added fields to the `Error` class that the client doesn't document anywhere.

For this PR, I've augmented the errors thrown from the Heroku API to include the response body from the API, as well as requiring code to pass an argument describing what it's going to use the Heroku client for before you can use the client managed by `herokuClient.ts`. This means we can always provide additional context for where the Tool Kit task ran into issues. In the future it should be trivial to also add another (optional) argument that allows callers to pass a string on suggested remediations based on guesses on why we might have hit an error at a given call site, but I've spent enough time on this PR (particularly wrangling Jest's confusing mocking system) and don't particularly have the context necessary to write up these suggestions 😅

**Before:**
![Screenshot 2023-04-25 at 12 20 34](https://user-images.githubusercontent.com/7020796/234261338-7522074f-eb82-47eb-b54e-ecfc9692f639.png)

**After:**
![Screenshot 2023-04-25 at 12 19 48](https://user-images.githubusercontent.com/7020796/234261207-7f3f5018-bc57-4b4d-9f19-7c5fd22c5116.png)

# Checklist:

- [x] My branch has been rebased onto the latest commit on main (don't merge main into your branch)
- [x] My commit messages are [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/), for example: `feat(circleci): add support for nightly workflows`, `fix: set Heroku app name for staging apps too`
