### PR TITLE
CPP-1335 CPP-1336 Support running Tool Kit with Node 18 (NOT supporting using Node 18 in Tool Kit projects)

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -15,7 +15,7 @@ references:
       - image: cimg/node:<< parameters.node-version >>
     parameters:
       node-version:
-        default: '16.14'
+        default: '18.16'
         type: string
 
   workspace_root: &workspace_root ~/project
@@ -187,21 +187,21 @@ workflows:
           name: build-v<< matrix.node-version >>
           matrix:
             parameters:
-              node-version: [ '16.14' ]
+              node-version: [ '16.14', '18.16' ]
       - test:
           requires:
             - build-v<< matrix.node-version >>
           name: test-v<< matrix.node-version >>
           matrix:
             parameters:
-              node-version: [ '16.14' ]
+              node-version: [ '16.14', '18.16' ]
       - lint:
           requires:
             - build-v<< matrix.node-version >>
           name: lint-v<< matrix.node-version >>
           matrix:
             parameters:
-              node-version: [ '16.14' ]
+              node-version: [ '16.14', '18.16' ]
 
   release-please:
     when:
@@ -231,21 +231,21 @@ workflows:
           name: build-v<< matrix.node-version >>
           matrix:
             parameters:
-              node-version: [ '16.14' ]
+              node-version: [ '16.14', '18.16' ]
       - test:
           requires:
             - build-v<< matrix.node-version >>
           name: test-v<< matrix.node-version >>
           matrix:
             parameters:
-              node-version: [ '16.14' ]
+              node-version: [ '16.14', '18.16' ]
       - lint:
           requires:
             - build-v<< matrix.node-version >>
           name: lint-v<< matrix.node-version >>
           matrix:
             parameters:
-              node-version: [ '16.14' ]
+              node-version: [ '16.14', '18.16' ]
 
   build-test-publish:
     when:
@@ -260,7 +260,7 @@ workflows:
           name: build-v<< matrix.node-version >>
           matrix:
             parameters:
-              node-version: [ '16.14' ]
+              node-version: [ '16.14', '18.16' ]
       - test:
           filters:
             <<: *filters_release_build
@@ -269,7 +269,7 @@ workflows:
           name: test-v<< matrix.node-version >>
           matrix:
             parameters:
-              node-version: [ '16.14' ]
+              node-version: [ '16.14', '18.16' ]
       - lint:
           filters:
             <<: *filters_release_build
@@ -278,14 +278,14 @@ workflows:
           name: lint-v<< matrix.node-version >>
           matrix:
             parameters:
-              node-version: [ '16.14' ]
+              node-version: [ '16.14', '18.16' ]
       - publish:
           context: npm-publish-token
           filters:
             <<: *filters_release_build
           requires:
-            - lint-v16.14
-            - test-v16.14
+            - lint-v18.16
+            - test-v18.16
 
   build-test-prepublish:
     when:
@@ -300,7 +300,7 @@ workflows:
           name: build-v<< matrix.node-version >>
           matrix:
             parameters:
-              node-version: [ '16.14' ]
+              node-version: [ '16.14', '18.16' ]
       - test:
           filters:
             <<: *filters_prerelease_build
@@ -309,7 +309,7 @@ workflows:
           name: test-v<< matrix.node-version >>
           matrix:
             parameters:
-              node-version: [ '16.14' ]
+              node-version: [ '16.14', '18.16' ]
       - lint:
           filters:
             <<: *filters_prerelease_build
@@ -318,14 +318,14 @@ workflows:
           name: lint-v<< matrix.node-version >>
           matrix:
             parameters:
-              node-version: [ '16.14' ]
+              node-version: [ '16.14', '18.16' ]
       - prepublish:
           context: npm-publish-token
           filters:
             <<: *filters_prerelease_build
           requires:
-            - lint-v16.14
-            - test-v16.14
+            - lint-v18.16
+            - test-v18.16
 
   nightly:
     when:
@@ -342,7 +342,7 @@ workflows:
           name: build-v<< matrix.node-version >>
           matrix:
             parameters:
-              node-version: [ '16.14' ]
+              node-version: [ '16.14', '18.16' ]
       - test:
           requires:
             - build-v<< matrix.node-version >>
@@ -350,7 +350,7 @@ workflows:
           name: test-v<< matrix.node-version >>
           matrix:
             parameters:
-              node-version: [ '16.14' ]
+              node-version: [ '16.14', '18.16' ]
 
   # Prior to producing a development orb (which requires credentials) basic validation, linting, and even unit testing can be performed.
   # This workflow will run on every commit

--- a/package.json
+++ b/package.json
@@ -57,12 +57,11 @@
     "@types/superagent": "^4.1.10"
   },
   "volta": {
-    "node": "16.14.0",
-    "npm": "8.5.4"
+    "node": "18.16.0"
   },
   "engines": {
-    "node": "16.x",
-    "npm": "7.x || 8.x"
+    "node": "16.x || 18.x",
+    "npm": "7.x || 8.x || 9.x"
   },
   "overrides": {
     "type-fest": "3.6.0"


### PR DESCRIPTION
# Description

This PR does the necessary groundwork to start running and testing Tool Kit with Node 18. The pinned Volta version is Node 18 (and the `npm@9` version that is bundled with it), updating the `engines` field to officially support it, and running CI builds against it. **This does not mean that we now support updating projects that use Tool Kit to Node 18**. Instead, this is just the first step in ensuring we can support that by making sure the code is compatible with the new runtime version.   

# Checklist:

- [x] My branch has been rebased onto the latest commit on main (don't merge main into your branch)
- [x] My commit messages are [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/), for example: `feat(circleci): add support for nightly workflows`, `fix: set Heroku app name for staging apps too`
