### PR TITLE
CPP-1337 Disable native fetch in forked Node processes

### DIFF
--- a/lib/types/src/schema/node.ts
+++ b/lib/types/src/schema/node.ts
@@ -4,7 +4,8 @@ export const NodeSchema = z.object({
   entry: z.string().default('./server/app.js'),
   args: z.string().array().optional(),
   useVault: z.boolean().default(true),
-  ports: z.number().array().default([3001, 3002, 3003])
+  ports: z.number().array().default([3001, 3002, 3003]),
+  allowNativeFetch: z.boolean().default(false)
 })
 export type NodeOptions = z.infer<typeof NodeSchema>
 

--- a/lib/types/src/schema/nodemon.ts
+++ b/lib/types/src/schema/nodemon.ts
@@ -4,7 +4,8 @@ export const NodemonSchema = z.object({
   entry: z.string().default('./server/app.js'),
   configPath: z.string().optional(),
   useVault: z.boolean().default(true),
-  ports: z.number().array().default([3001, 3002, 3003])
+  ports: z.number().array().default([3001, 3002, 3003]),
+  allowNativeFetch: z.boolean().default(false)
 })
 export type NodemonOptions = z.infer<typeof NodemonSchema>
 

--- a/plugins/node/readme.md
+++ b/plugins/node/readme.md
@@ -26,6 +26,7 @@ plugins:
 | `entry` | path to the node application | `'./server/app.js'` |
 | `useVault` | option to run the application with environment variables from Vault | `true` |
 | `ports` | ports to try to bind to for this application | `[3001, 3002, 3003]` |
+| `allowNativeFetch` | use Node's native fetch if supported | `false` |
 
 ## Tasks
 

--- a/plugins/node/readme.md
+++ b/plugins/node/readme.md
@@ -24,6 +24,7 @@ plugins:
 | Key | Description | Default value |
 |-|-|-|
 | `entry` | path to the node application | `'./server/app.js'` |
+| `args` | additional arguments to pass to your application | `[]` |
 | `useVault` | option to run the application with environment variables from Vault | `true` |
 | `ports` | ports to try to bind to for this application | `[3001, 3002, 3003]` |
 | `allowNativeFetch` | use Node's native fetch if supported | `false` |

--- a/plugins/nodemon/readme.md
+++ b/plugins/nodemon/readme.md
@@ -22,6 +22,7 @@ plugins:
 | Key | Description | Default value |
 |-|-|-|
 | `entry` | path to the node application | `'./server/app.js'` |
+| `configPath` | path to custom nodemon config | [automatic config resolution](https://github.com/remy/nodemon#config-files) |
 | `useVault` | option to run the application with environment variables from Vault | `true` |
 | `ports` | ports to try to bind to for this application | `[3001, 3002, 3003]` |
 | `allowNativeFetch` | use Node's native fetch if supported | `false` |

--- a/plugins/nodemon/readme.md
+++ b/plugins/nodemon/readme.md
@@ -24,6 +24,7 @@ plugins:
 | `entry` | path to the node application | `'./server/app.js'` |
 | `useVault` | option to run the application with environment variables from Vault | `true` |
 | `ports` | ports to try to bind to for this application | `[3001, 3002, 3003]` |
+| `allowNativeFetch` | use Node's native fetch if supported | `false` |
 
 ## Tasks
 


### PR DESCRIPTION
# Description

We aren't ready to support native `fetch` yet as we're still using `node-fetch`/`isomorphic-fetch` in a lot of places and there will likely be subtle bugs we'll have to hunt for as part of a concentrated migration. In the meantime, to facilitate the migration to Node 18, Tool Kit will run its forked Node processes (i.e., `npm start`'ing Customer Products apps) with the `--no-experimental-fetch` flag set so that we can make the most of Node 18 whilst excluding the native `fetch` implementation. Passing this flag to a Node runtime that doesn't know about native `fetch` will result in the error
```
bad option: --no-experimental-fetch
```
so we need to use the builtin [`process.allowedNodeEnvironmentFlags`](https://nodejs.org/dist/latest-v18.x/docs/api/process.html#processallowednodeenvironmentflags) function to check that the flag is compatible first. If it isn't then the runtime doesn't support native `fetch` anyway (for now: it's possible a future version of Node will force native `fetch`, but we can say that this version of Tool Kit doesn't support that hypothetical version.)

**question**: Do we want to allow users to disable this flag if they've already migrated to native `fetch`? This might help with our own migrations...?

# Checklist:

- [x] My branch has been rebased onto the latest commit on main (don't merge main into your branch)
- [x] My commit messages are [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/), for example: `feat(circleci): add support for nightly workflows`, `fix: set Heroku app name for staging apps too`
