### PR TITLE
Make npm regex for determining release tags stricter

### DIFF
--- a/lib/types/src/npm.ts
+++ b/lib/types/src/npm.ts
@@ -1,3 +1,3 @@
 export const semVerRegex = /^v\d+\.\d+\.\d+(-.+)?/
 export const prereleaseRegex = /^v\d+\.\d+\.\d+(?:-\w+\.\d+)$/
-export const releaseRegex = /^v\d+\.\d+\.\d+/
+export const releaseRegex = /^v\d+\.\d+\.\d+$/


### PR DESCRIPTION
# Description

The terminating anchor was seemingly removed accidentally in a [previous commit](https://github.com/Financial-Times/dotcom-tool-kit/commit/72d2faa644b8c0e1c71131e3559e802017f0d0f5), but it's necessary to make sure prerelease versions don't use the `latest` tag on npm. e.g., `1.0.0-beta.1` would match the previous regex as the `1.0.0` substring would match, however it wouldn't match the new regex as the string continues afterwards, so the `$` does not match.

# Checklist:

- [x] My branch has been rebased onto the latest commit on main (don't merge main into your branch)
- [x] My commit messages are [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/), for example: `feat(circleci): add support for nightly workflows`, `fix: set Heroku app name for staging apps too`
