### PR TITLE
CPP-1338 Bump default docker executor versions to Node 18

### DIFF
--- a/orb/README.md
+++ b/orb/README.md
@@ -8,22 +8,22 @@ Each job is a very simple wrapper that calls its respective hook, where most of 
 
 ```yaml
 parameters:
-  node-version:
-    default: '16.14'
-    type: string
+  executor:
+    default: default
+    type: executor
 
-executor:
-  name: node/default
-  tag: <<parameters.node-version>>
+executor: << parameters.executor >>
 
 steps:
   - attach-workspace
   - run:
       name: Run the project build-production task
       command: npx dotcom-tool-kit build:ci
+  - persist-workspace:
+      path: .
 ```
 
-You can expect any other given job to look very similar. We first define a parameter that allows consumers to set the version of node to use with the `node-version` parameter as a property added to the `build` job. We then use this parameter to pull in an appropriately versioned copy of the node docker image using the `executor` property. We run `attach-workspace`, which is the glue we use in many jobs to pick up the state from a previous job in the workflow, now rolled into a simple command (along with its counterpart `persist-workspace`.) Finally, we run the `build:ci` hook event, which will run any hooks for building the project in the CI, such as babel, webpack, etc.
+You can expect any other given job to look very similar. We first define a parameter that allows consumers to set the docker image and tag they want to use for the job. We then pass this parameter to the `executor` property to set the docker image that all the steps will use (based on the parameter passed). We run `attach-workspace`, which is the glue we use in many jobs to pick up the state from a previous job in the workflow, now rolled into a simple command (along with its counterpart `persist-workspace`.) Finally, we run the `build:ci` hook event, which will run any hooks for building the project in the CI, such as babel, webpack, etc.
 
 ## Adding Jobs To Your CircleCI Config
 

--- a/orb/src/executors/default.yml
+++ b/orb/src/executors/default.yml
@@ -1,7 +1,7 @@
 parameters:
   tag:
     type: string
-    default: '16.18-browsers'
+    default: '18.16-browsers'
 
 docker:
   - image: cimg/node:<< parameters.tag >>

--- a/plugins/circleci/src/circleci-config.ts
+++ b/plugins/circleci/src/circleci-config.ts
@@ -104,7 +104,7 @@ const getInitialState = (options: CircleCIOptions): CircleCIState => ({
   },
   executors: {
     node: {
-      docker: [{ image: `cimg/node:${options.nodeVersion ?? '16.14-browsers'}` }]
+      docker: [{ image: `cimg/node:${options.nodeVersion ?? '18.16-browsers'}` }]
     }
   },
   jobs: {


### PR DESCRIPTION
# Checklist:

- [x] My branch has been rebased onto the latest commit on main (don't merge main into your branch)
- [x] My commit messages are [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/), for example: `feat(circleci): add support for nightly workflows`, `fix: set Heroku app name for staging apps too`
