### PR TITLE
Disable native fetch in forked next-router processes as well

### DIFF
--- a/plugins/next-router/src/tasks/next-router.ts
+++ b/plugins/next-router/src/tasks/next-router.ts
@@ -21,11 +21,17 @@ export default class NextRouter extends Task<typeof NextRouterSchema> {
 
     const routerBin = require.resolve('ft-next-router/bin/next-router')
     const vaultEnv = await vault.get()
+    let { execArgv } = process
+    // disable native fetch if supported by runtime as next-router uses isomorphic-fetch
+    if (process.allowedNodeEnvironmentFlags.has('--no-experimental-fetch')) {
+      execArgv = [...execArgv, '--no-experimental-fetch']
+    }
     const child = fork(routerBin, ['--daemon'], {
       env: {
         ...process.env,
         ...vaultEnv
       },
+      execArgv,
       silent: true
     })
     hookFork(this.logger, 'next-router', child)


### PR DESCRIPTION
# Description

next-router uses `isomorphic-fetch` which will be overridden by native `fetch` and cause weird behaviour so let's disable native `fetch` until we've cleaned next-router up. I don't _think_ any other plugins that `fork` Node processes will be affected by this – the next-router plugin is the only one dependent on `isomorphic-fetch` and other plugins are for much bigger packages which need to connect to the internet far less.

# Checklist:

- [x] My branch has been rebased onto the latest commit on main (don't merge main into your branch)
- [x] My commit messages are [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/), for example: `feat(circleci): add support for nightly workflows`, `fix: set Heroku app name for staging apps too`
