### PR TITLE
CPP-1372: use latest change-api-orb to fix change-api curl request

### DIFF
--- a/orb/src/@orb.yml
+++ b/orb/src/@orb.yml
@@ -12,6 +12,6 @@ display:
 # If your orb requires other orbs, you can import them like this. Otherwise remove the "orbs" stanza.
 orbs:
   node: circleci/node@5.0.2
-  change-api: financial-times/change-api@1.0.7
+  change-api: financial-times/change-api@1.0.8
   aws-cli: circleci/aws-cli@3.1.4
   serverless-framework: circleci/serverless-framework@2.0.1


### PR DESCRIPTION
The latest change-api orb drops the use of `--retry-all-errors` and `--fail-with-body`. These were new curl options which wasn't available for the CircleCI containers we use.

# Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. 

# Checklist:

- [x] My branch has been rebased onto the latest commit on main (don't merge main into your branch)
- [x] My commit messages are [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/), for example: `feat(circleci): add support for nightly workflows`, `fix: set Heroku app name for staging apps too`
