### PR TITLE
Fix spurious warning in mocha plugin with default config

### DIFF
--- a/plugins/mocha/src/tasks/mocha.ts
+++ b/plugins/mocha/src/tasks/mocha.ts
@@ -12,7 +12,10 @@ export default class Mocha extends Task<typeof MochaSchema> {
   async run(): Promise<void> {
     const files = await promisify(glob)(this.options.files)
 
-    const args = ['--color', this.options.configPath ? `--config=${this.options.configPath}` : '', ...files]
+    const args = ['--color', ...files]
+    if (this.options.configPath) {
+      args.unshift(`--config=${this.options.configPath}`)
+    }
     this.logger.info(`running mocha ${args.join(' ')}`)
     const child = fork(mochaCLIPath, args, { silent: true })
     hookFork(this.logger, 'mocha', child)


### PR DESCRIPTION
# Description

We had some logic that would either include the `configPath` option passed to the plugin as an parameter for the `--config` argument, or an empty string if `configPath` was undefined. mocha was interpreting this empty string as a file glob of `""`, and always logging a warning that the file glob didn't match any files to test.

For example, running in next-static, you would see logging like:
```
[Mocha] running mocha --color  test/server/disable-flag.spec.js test/smoke.js
[Mocha][mocha]
⚠ Warning: Cannot find any files matching pattern ""
```
This PR fixes the noise by only creating an argument if the `configPath` option is defined.

# Checklist:

- [x] My branch has been rebased onto the latest commit on main (don't merge main into your branch)
- [x] My commit messages are [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/), for example: `feat(circleci): add support for nightly workflows`, `fix: set Heroku app name for staging apps too`
