### PR TITLE
Revert default CircleCI executor back to Node 16

### DIFF
--- a/orb/src/executors/default.yml
+++ b/orb/src/executors/default.yml
@@ -1,7 +1,7 @@
 parameters:
   tag:
     type: string
-    default: '18.16-browsers'
+    default: '16.18-browsers'
 
 docker:
   - image: cimg/node:<< parameters.tag >>

--- a/plugins/circleci/src/circleci-config.ts
+++ b/plugins/circleci/src/circleci-config.ts
@@ -104,7 +104,7 @@ const getInitialState = (options: CircleCIOptions): CircleCIState => ({
   },
   executors: {
     node: {
-      docker: [{ image: `cimg/node:${options.nodeVersion ?? '18.16-browsers'}` }]
+      docker: [{ image: `cimg/node:${options.nodeVersion ?? '16.14-browsers'}` }]
     }
   },
   jobs: {


### PR DESCRIPTION
# Description

As part of adding support for Node 18 to Tool Kit we [bumped](https://github.com/Financial-Times/dotcom-tool-kit/pull/419) the default Node version used for CircleCI configurations so that they would be Node 18 if they weren't overridden by the `circleci` plugin's `nodeVersion` option. So currently any Tool Kit task will fail if you haven't overridden `nodeVersion` and you aren't using Node 18 in your CircleCI config, pushing you to run `dotcom-tool-kit --install` to update the config. However, we haven’t finished testing all our libraries to make sure Node 18 is fully supported yet, so we shouldn't be pushing people to Node 18 prematurely.

# Checklist:

- [x] My branch has been rebased onto the latest commit on main (don't merge main into your branch)
- [x] My commit messages are [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/), for example: `feat(circleci): add support for nightly workflows`, `fix: set Heroku app name for staging apps too`
