### PR TITLE
Enable nodemon plugin to run non-node scripts

### DIFF
--- a/lib/types/src/schema/nodemon.ts
+++ b/lib/types/src/schema/nodemon.ts
@@ -2,6 +2,7 @@ import { z } from 'zod'
 
 export const NodemonSchema = z.object({
   entry: z.string().default('./server/app.js'),
+  command: z.string().optional(),
   configPath: z.string().optional(),
   useVault: z.boolean().default(true),
   ports: z.number().array().default([3001, 3002, 3003]),

--- a/plugins/nodemon/readme.md
+++ b/plugins/nodemon/readme.md
@@ -22,6 +22,7 @@ plugins:
 | Key | Description | Default value |
 |-|-|-|
 | `entry` | path to the node application | `'./server/app.js'` |
+| `command` | option to run a non-node script. `entry` will be ignored when `command` is used | `undefined` |
 | `configPath` | path to custom nodemon config | [automatic config resolution](https://github.com/remy/nodemon#config-files) |
 | `useVault` | option to run the application with environment variables from Vault | `true` |
 | `ports` | ports to try to bind to for this application | `[3001, 3002, 3003]` |


### PR DESCRIPTION
# Description

Enable the nodemon plugin to accept a `command` option that allows it to run non-node scripts via the nodemon `--exec` argument.

# Justification

A use case might be when a system has multiple processes or workers that we want to run locally. This option would allow us to combine `nodemon` with `heroku local` to start all processes at the same time.

[Slack discussion](https://financialtimes.slack.com/archives/C02TRE2V2Q1/p1683061191559699)

