### PR TITLE
feat: use latest version of n-test

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -46,7 +46,7 @@
     },
     "core/cli": {
       "name": "dotcom-tool-kit",
-      "version": "3.1.0",
+      "version": "3.1.1",
       "license": "MIT",
       "dependencies": {
         "@dotcom-tool-kit/error": "^3.1.0",
@@ -67,11 +67,11 @@
       },
       "devDependencies": {
         "@dotcom-tool-kit/babel": "^3.1.0",
-        "@dotcom-tool-kit/backend-heroku-app": "^2.1.0",
-        "@dotcom-tool-kit/circleci": "^5.1.0",
-        "@dotcom-tool-kit/circleci-deploy": "^3.1.0",
+        "@dotcom-tool-kit/backend-heroku-app": "^2.1.1",
+        "@dotcom-tool-kit/circleci": "^5.1.1",
+        "@dotcom-tool-kit/circleci-deploy": "^3.1.1",
         "@dotcom-tool-kit/eslint": "^3.1.0",
-        "@dotcom-tool-kit/frontend-app": "^3.1.0",
+        "@dotcom-tool-kit/frontend-app": "^3.1.1",
         "@dotcom-tool-kit/heroku": "^3.1.0",
         "@dotcom-tool-kit/mocha": "^3.1.0",
         "@dotcom-tool-kit/n-test": "^3.1.0",
@@ -121,7 +121,7 @@
     },
     "core/create": {
       "name": "@dotcom-tool-kit/create",
-      "version": "3.1.0",
+      "version": "3.1.1",
       "license": "ISC",
       "dependencies": {
         "@aws-sdk/client-iam": "^3.282.0",
@@ -157,7 +157,7 @@
         "@types/pacote": "^11.1.3",
         "@types/prompts": "^2.0.14",
         "cosmiconfig": "^7.0.1",
-        "dotcom-tool-kit": "^3.1.0"
+        "dotcom-tool-kit": "^3.1.1"
       },
       "engines": {
         "node": "16.x || 18.x",
@@ -7139,6 +7139,7 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/@financial-times/n-test/-/n-test-5.0.1.tgz",
       "integrity": "sha512-KZV1RUZ0rxK4gaxHE8BsZ6kd6znO3SlQY4t+BtuM0r622AP2ocMQYEktp1+Wr+H2dE/PT8T3clplAgpsy/5Jyg==",
+      "dev": true,
       "hasInstallScript": true,
       "dependencies": {
         "chalk": "^2.3.0",
@@ -7160,6 +7161,7 @@
     },
     "node_modules/@financial-times/n-test/node_modules/ansi-styles": {
       "version": "3.2.1",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "color-convert": "^1.9.0"
@@ -7170,6 +7172,7 @@
     },
     "node_modules/@financial-times/n-test/node_modules/chalk": {
       "version": "2.4.2",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ansi-styles": "^3.2.1",
@@ -7182,6 +7185,7 @@
     },
     "node_modules/@financial-times/n-test/node_modules/color-convert": {
       "version": "1.9.3",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "color-name": "1.1.3"
@@ -7189,14 +7193,17 @@
     },
     "node_modules/@financial-times/n-test/node_modules/color-name": {
       "version": "1.1.3",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/@financial-times/n-test/node_modules/commander": {
       "version": "3.0.2",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/@financial-times/n-test/node_modules/escape-string-regexp": {
       "version": "1.0.5",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.8.0"
@@ -7204,6 +7211,7 @@
     },
     "node_modules/@financial-times/n-test/node_modules/has-flag": {
       "version": "3.0.0",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=4"
@@ -7211,6 +7219,7 @@
     },
     "node_modules/@financial-times/n-test/node_modules/supports-color": {
       "version": "5.5.0",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "has-flag": "^3.0.0"
@@ -29299,10 +29308,10 @@
     },
     "plugins/backend-app": {
       "name": "@dotcom-tool-kit/backend-app",
-      "version": "3.1.0",
+      "version": "3.1.1",
       "license": "ISC",
       "dependencies": {
-        "@dotcom-tool-kit/backend-heroku-app": "^2.1.0"
+        "@dotcom-tool-kit/backend-heroku-app": "^2.1.1"
       },
       "engines": {
         "node": "16.x || 18.x",
@@ -29314,10 +29323,10 @@
     },
     "plugins/backend-heroku-app": {
       "name": "@dotcom-tool-kit/backend-heroku-app",
-      "version": "2.1.0",
+      "version": "2.1.1",
       "license": "ISC",
       "dependencies": {
-        "@dotcom-tool-kit/circleci-deploy": "^3.1.0",
+        "@dotcom-tool-kit/circleci-deploy": "^3.1.1",
         "@dotcom-tool-kit/heroku": "^3.1.0",
         "@dotcom-tool-kit/husky-npm": "^4.1.0",
         "@dotcom-tool-kit/node": "^3.1.0",
@@ -29334,10 +29343,10 @@
     },
     "plugins/backend-serverless-app": {
       "name": "@dotcom-tool-kit/backend-serverless-app",
-      "version": "2.1.0",
+      "version": "2.1.1",
       "license": "ISC",
       "dependencies": {
-        "@dotcom-tool-kit/circleci-deploy": "^3.1.0",
+        "@dotcom-tool-kit/circleci-deploy": "^3.1.1",
         "@dotcom-tool-kit/husky-npm": "^4.1.0",
         "@dotcom-tool-kit/node": "^3.1.0",
         "@dotcom-tool-kit/npm": "^3.1.0",
@@ -29354,7 +29363,7 @@
     },
     "plugins/circleci": {
       "name": "@dotcom-tool-kit/circleci",
-      "version": "5.1.0",
+      "version": "5.1.1",
       "license": "ISC",
       "dependencies": {
         "@dotcom-tool-kit/error": "^3.1.0",
@@ -29383,10 +29392,10 @@
     },
     "plugins/circleci-deploy": {
       "name": "@dotcom-tool-kit/circleci-deploy",
-      "version": "3.1.0",
+      "version": "3.1.1",
       "license": "ISC",
       "dependencies": {
-        "@dotcom-tool-kit/circleci": "^5.1.0",
+        "@dotcom-tool-kit/circleci": "^5.1.1",
         "tslib": "^2.3.1"
       },
       "devDependencies": {
@@ -29407,10 +29416,10 @@
     },
     "plugins/circleci-heroku": {
       "name": "@dotcom-tool-kit/circleci-heroku",
-      "version": "3.1.0",
+      "version": "3.1.1",
       "license": "ISC",
       "dependencies": {
-        "@dotcom-tool-kit/circleci-deploy": "^3.1.0",
+        "@dotcom-tool-kit/circleci-deploy": "^3.1.1",
         "@dotcom-tool-kit/heroku": "^3.1.0",
         "tslib": "^2.3.1"
       },
@@ -29429,10 +29438,10 @@
     },
     "plugins/circleci-npm": {
       "name": "@dotcom-tool-kit/circleci-npm",
-      "version": "5.1.0",
+      "version": "5.1.1",
       "license": "ISC",
       "dependencies": {
-        "@dotcom-tool-kit/circleci": "^5.1.0",
+        "@dotcom-tool-kit/circleci": "^5.1.1",
         "@dotcom-tool-kit/npm": "^3.1.0",
         "@dotcom-tool-kit/types": "^3.1.0",
         "tslib": "^2.3.1"
@@ -29476,10 +29485,10 @@
     },
     "plugins/component": {
       "name": "@dotcom-tool-kit/component",
-      "version": "3.1.0",
+      "version": "3.1.1",
       "license": "ISC",
       "dependencies": {
-        "@dotcom-tool-kit/circleci-npm": "^5.1.0",
+        "@dotcom-tool-kit/circleci-npm": "^5.1.1",
         "@dotcom-tool-kit/husky-npm": "^4.1.0",
         "@dotcom-tool-kit/npm": "^3.1.0",
         "@dotcom-tool-kit/secret-squirrel": "^2.1.0"
@@ -29728,10 +29737,10 @@
     },
     "plugins/frontend-app": {
       "name": "@dotcom-tool-kit/frontend-app",
-      "version": "3.1.0",
+      "version": "3.1.1",
       "license": "ISC",
       "dependencies": {
-        "@dotcom-tool-kit/backend-heroku-app": "^2.1.0",
+        "@dotcom-tool-kit/backend-heroku-app": "^2.1.1",
         "@dotcom-tool-kit/upload-assets-to-s3": "^3.1.0",
         "@dotcom-tool-kit/webpack": "^3.1.0"
       },
@@ -29966,7 +29975,7 @@
         "@dotcom-tool-kit/logger": "^3.1.0",
         "@dotcom-tool-kit/state": "^3.1.0",
         "@dotcom-tool-kit/types": "^3.1.0",
-        "@financial-times/n-test": "^5.0.1",
+        "@financial-times/n-test": "6.1.0-beta.1",
         "tslib": "^2.3.1"
       },
       "devDependencies": {
@@ -29980,6 +29989,98 @@
       },
       "peerDependencies": {
         "dotcom-tool-kit": "3.x"
+      }
+    },
+    "plugins/n-test/node_modules/@financial-times/n-test": {
+      "version": "6.1.0-beta.1",
+      "resolved": "https://registry.npmjs.org/@financial-times/n-test/-/n-test-6.1.0-beta.1.tgz",
+      "integrity": "sha512-xVCswU9R4MWKxtJ+xi9Ur9aZoBiqOvbtDbtD7bEBUMssHdRbs0xXsZNto2fDm18w7TicZZZZfMtbYS8Ob1snag==",
+      "hasInstallScript": true,
+      "dependencies": {
+        "chalk": "^2.3.0",
+        "commander": "^3.0.0",
+        "directly": "^2.0.6",
+        "get-pixels": "^3.3.2",
+        "inquirer": "^7.0.0",
+        "node-fetch": "^2.1.1",
+        "puppeteer": "18.1.0",
+        "webdriverio": "^5.0.0"
+      },
+      "bin": {
+        "n-test": "bin/n-test.js"
+      },
+      "engines": {
+        "node": "16.x || 18.x",
+        "npm": "7.x || 8.x || 9.x"
+      }
+    },
+    "plugins/n-test/node_modules/ansi-styles": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+      "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+      "dependencies": {
+        "color-convert": "^1.9.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "plugins/n-test/node_modules/chalk": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+      "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+      "dependencies": {
+        "ansi-styles": "^3.2.1",
+        "escape-string-regexp": "^1.0.5",
+        "supports-color": "^5.3.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "plugins/n-test/node_modules/color-convert": {
+      "version": "1.9.3",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
+      "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
+      "dependencies": {
+        "color-name": "1.1.3"
+      }
+    },
+    "plugins/n-test/node_modules/color-name": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
+      "integrity": "sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw=="
+    },
+    "plugins/n-test/node_modules/commander": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-3.0.2.tgz",
+      "integrity": "sha512-Gar0ASD4BDyKC4hl4DwHqDrmvjoxWKZigVnAbn5H1owvm4CxCPdb0HQDehwNYMJpla5+M2tPmPARzhtYuwpHow=="
+    },
+    "plugins/n-test/node_modules/escape-string-regexp": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+      "integrity": "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==",
+      "engines": {
+        "node": ">=0.8.0"
+      }
+    },
+    "plugins/n-test/node_modules/has-flag": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+      "integrity": "sha512-sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw==",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "plugins/n-test/node_modules/supports-color": {
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+      "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+      "dependencies": {
+        "has-flag": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=4"
       }
     },
     "plugins/n-test/node_modules/tslib": {
@@ -34500,13 +34601,13 @@
     "@dotcom-tool-kit/backend-app": {
       "version": "file:plugins/backend-app",
       "requires": {
-        "@dotcom-tool-kit/backend-heroku-app": "^2.1.0"
+        "@dotcom-tool-kit/backend-heroku-app": "^2.1.1"
       }
     },
     "@dotcom-tool-kit/backend-heroku-app": {
       "version": "file:plugins/backend-heroku-app",
       "requires": {
-        "@dotcom-tool-kit/circleci-deploy": "^3.1.0",
+        "@dotcom-tool-kit/circleci-deploy": "^3.1.1",
         "@dotcom-tool-kit/heroku": "^3.1.0",
         "@dotcom-tool-kit/husky-npm": "^4.1.0",
         "@dotcom-tool-kit/node": "^3.1.0",
@@ -34517,7 +34618,7 @@
     "@dotcom-tool-kit/backend-serverless-app": {
       "version": "file:plugins/backend-serverless-app",
       "requires": {
-        "@dotcom-tool-kit/circleci-deploy": "^3.1.0",
+        "@dotcom-tool-kit/circleci-deploy": "^3.1.1",
         "@dotcom-tool-kit/husky-npm": "^4.1.0",
         "@dotcom-tool-kit/node": "^3.1.0",
         "@dotcom-tool-kit/npm": "^3.1.0",
@@ -34563,7 +34664,7 @@
     "@dotcom-tool-kit/circleci-deploy": {
       "version": "file:plugins/circleci-deploy",
       "requires": {
-        "@dotcom-tool-kit/circleci": "^5.1.0",
+        "@dotcom-tool-kit/circleci": "^5.1.1",
         "tslib": "^2.3.1",
         "winston": "^3.5.1"
       },
@@ -34578,7 +34679,7 @@
     "@dotcom-tool-kit/circleci-heroku": {
       "version": "file:plugins/circleci-heroku",
       "requires": {
-        "@dotcom-tool-kit/circleci-deploy": "^3.1.0",
+        "@dotcom-tool-kit/circleci-deploy": "^3.1.1",
         "@dotcom-tool-kit/heroku": "^3.1.0",
         "tslib": "^2.3.1"
       },
@@ -34593,7 +34694,7 @@
     "@dotcom-tool-kit/circleci-npm": {
       "version": "file:plugins/circleci-npm",
       "requires": {
-        "@dotcom-tool-kit/circleci": "^5.1.0",
+        "@dotcom-tool-kit/circleci": "^5.1.1",
         "@dotcom-tool-kit/npm": "^3.1.0",
         "@dotcom-tool-kit/types": "^3.1.0",
         "tslib": "^2.3.1"
@@ -34609,7 +34710,7 @@
     "@dotcom-tool-kit/component": {
       "version": "file:plugins/component",
       "requires": {
-        "@dotcom-tool-kit/circleci-npm": "^5.1.0",
+        "@dotcom-tool-kit/circleci-npm": "^5.1.1",
         "@dotcom-tool-kit/husky-npm": "^4.1.0",
         "@dotcom-tool-kit/npm": "^3.1.0",
         "@dotcom-tool-kit/secret-squirrel": "^2.1.0"
@@ -34636,7 +34737,7 @@
         "cli-highlight": "^2.1.11",
         "code-suggester": "^4.3.0",
         "cosmiconfig": "^7.0.1",
-        "dotcom-tool-kit": "^3.1.0",
+        "dotcom-tool-kit": "^3.1.1",
         "import-cwd": "^3.0.0",
         "komatsu": "^1.3.0",
         "lodash": "^4.17.21",
@@ -35531,7 +35632,7 @@
     "@dotcom-tool-kit/frontend-app": {
       "version": "file:plugins/frontend-app",
       "requires": {
-        "@dotcom-tool-kit/backend-heroku-app": "^2.1.0",
+        "@dotcom-tool-kit/backend-heroku-app": "^2.1.1",
         "@dotcom-tool-kit/upload-assets-to-s3": "^3.1.0",
         "@dotcom-tool-kit/webpack": "^3.1.0"
       }
@@ -35707,13 +35808,82 @@
         "@dotcom-tool-kit/logger": "^3.1.0",
         "@dotcom-tool-kit/state": "^3.1.0",
         "@dotcom-tool-kit/types": "^3.1.0",
-        "@financial-times/n-test": "^5.0.1",
+        "@financial-times/n-test": "6.1.0-beta.1",
         "@jest/globals": "^27.4.6",
         "@types/jest": "^27.4.0",
         "tslib": "^2.3.1",
         "winston": "^3.5.1"
       },
       "dependencies": {
+        "@financial-times/n-test": {
+          "version": "6.1.0-beta.1",
+          "resolved": "https://registry.npmjs.org/@financial-times/n-test/-/n-test-6.1.0-beta.1.tgz",
+          "integrity": "sha512-xVCswU9R4MWKxtJ+xi9Ur9aZoBiqOvbtDbtD7bEBUMssHdRbs0xXsZNto2fDm18w7TicZZZZfMtbYS8Ob1snag==",
+          "requires": {
+            "chalk": "^2.3.0",
+            "commander": "^3.0.0",
+            "directly": "^2.0.6",
+            "get-pixels": "^3.3.2",
+            "inquirer": "^7.0.0",
+            "node-fetch": "^2.1.1",
+            "puppeteer": "18.1.0",
+            "webdriverio": "^5.0.0"
+          }
+        },
+        "ansi-styles": {
+          "version": "3.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+          "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+          "requires": {
+            "color-convert": "^1.9.0"
+          }
+        },
+        "chalk": {
+          "version": "2.4.2",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+          "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+          "requires": {
+            "ansi-styles": "^3.2.1",
+            "escape-string-regexp": "^1.0.5",
+            "supports-color": "^5.3.0"
+          }
+        },
+        "color-convert": {
+          "version": "1.9.3",
+          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
+          "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
+          "requires": {
+            "color-name": "1.1.3"
+          }
+        },
+        "color-name": {
+          "version": "1.1.3",
+          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
+          "integrity": "sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw=="
+        },
+        "commander": {
+          "version": "3.0.2",
+          "resolved": "https://registry.npmjs.org/commander/-/commander-3.0.2.tgz",
+          "integrity": "sha512-Gar0ASD4BDyKC4hl4DwHqDrmvjoxWKZigVnAbn5H1owvm4CxCPdb0HQDehwNYMJpla5+M2tPmPARzhtYuwpHow=="
+        },
+        "escape-string-regexp": {
+          "version": "1.0.5",
+          "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+          "integrity": "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg=="
+        },
+        "has-flag": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+          "integrity": "sha512-sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw=="
+        },
+        "supports-color": {
+          "version": "5.5.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+          "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+          "requires": {
+            "has-flag": "^3.0.0"
+          }
+        },
         "tslib": {
           "version": "2.4.1",
           "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
@@ -37100,6 +37270,7 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/@financial-times/n-test/-/n-test-5.0.1.tgz",
       "integrity": "sha512-KZV1RUZ0rxK4gaxHE8BsZ6kd6znO3SlQY4t+BtuM0r622AP2ocMQYEktp1+Wr+H2dE/PT8T3clplAgpsy/5Jyg==",
+      "dev": true,
       "requires": {
         "chalk": "^2.3.0",
         "commander": "^3.0.0",
@@ -37113,12 +37284,14 @@
       "dependencies": {
         "ansi-styles": {
           "version": "3.2.1",
+          "dev": true,
           "requires": {
             "color-convert": "^1.9.0"
           }
         },
         "chalk": {
           "version": "2.4.2",
+          "dev": true,
           "requires": {
             "ansi-styles": "^3.2.1",
             "escape-string-regexp": "^1.0.5",
@@ -37127,24 +37300,30 @@
         },
         "color-convert": {
           "version": "1.9.3",
+          "dev": true,
           "requires": {
             "color-name": "1.1.3"
           }
         },
         "color-name": {
-          "version": "1.1.3"
+          "version": "1.1.3",
+          "dev": true
         },
         "commander": {
-          "version": "3.0.2"
+          "version": "3.0.2",
+          "dev": true
         },
         "escape-string-regexp": {
-          "version": "1.0.5"
+          "version": "1.0.5",
+          "dev": true
         },
         "has-flag": {
-          "version": "3.0.0"
+          "version": "3.0.0",
+          "dev": true
         },
         "supports-color": {
           "version": "5.5.0",
+          "dev": true,
           "requires": {
             "has-flag": "^3.0.0"
           }
@@ -42533,12 +42712,12 @@
       "version": "file:core/cli",
       "requires": {
         "@dotcom-tool-kit/babel": "^3.1.0",
-        "@dotcom-tool-kit/backend-heroku-app": "^2.1.0",
-        "@dotcom-tool-kit/circleci": "^5.1.0",
-        "@dotcom-tool-kit/circleci-deploy": "^3.1.0",
+        "@dotcom-tool-kit/backend-heroku-app": "^2.1.1",
+        "@dotcom-tool-kit/circleci": "^5.1.1",
+        "@dotcom-tool-kit/circleci-deploy": "^3.1.1",
         "@dotcom-tool-kit/error": "^3.1.0",
         "@dotcom-tool-kit/eslint": "^3.1.0",
-        "@dotcom-tool-kit/frontend-app": "^3.1.0",
+        "@dotcom-tool-kit/frontend-app": "^3.1.1",
         "@dotcom-tool-kit/heroku": "^3.1.0",
         "@dotcom-tool-kit/logger": "^3.1.0",
         "@dotcom-tool-kit/mocha": "^3.1.0",

--- a/plugins/n-test/package.json
+++ b/plugins/n-test/package.json
@@ -13,7 +13,7 @@
     "@dotcom-tool-kit/logger": "^3.1.0",
     "@dotcom-tool-kit/state": "^3.1.0",
     "@dotcom-tool-kit/types": "^3.1.0",
-    "@financial-times/n-test": "^5.0.1",
+    "@financial-times/n-test": "^6.1.0-beta.1",
     "tslib": "^2.3.1"
   },
   "repository": {


### PR DESCRIPTION
there is a beta version of n-test which supports node.js 18 so let's use that in the node.js 18 supporting version of the n-test plugin

# Checklist:

- [x] My branch has been rebased onto the latest commit on main (don't merge main into your branch)
- [x] My commit messages are [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/), for example: `feat(circleci): add support for nightly workflows`, `fix: set Heroku app name for staging apps too`
