### PR TITLE
docs: clarify what nodeVersion option is used for in circleci plugin

### DIFF
--- a/plugins/circleci/readme.md
+++ b/plugins/circleci/readme.md
@@ -29,7 +29,7 @@ npx dotcom-tool-kit --install
 
 | Key           | Description                             | Default value |
 | ------------- | --------------------------------------- | ------------- |
-| `nodeVersion` | Define Node Version for CircleCI to use | `undefined`   |
+| `nodeVersion` | the node versioned docker image tag for circleci to use. For example `18.16-browsers` or `16.14` | `undefined`   |
 
 ## Hooks
 


### PR DESCRIPTION
as it's not obvious that this should be a docker image tag rather than a semver node version

# Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. 

# Checklist:

- [x] My branch has been rebased onto the latest commit on main (don't merge main into your branch)
- [x] My commit messages are [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/), for example: `feat(circleci): add support for nightly workflows`, `fix: set Heroku app name for staging apps too`
