### PR TITLE
CPP-1320 Support Node version matrices in CircleCI plugin

### DIFF
--- a/lib/types/src/schema/circleci.ts
+++ b/lib/types/src/schema/circleci.ts
@@ -1,7 +1,7 @@
 import { z } from 'zod'
 
 export const CircleCISchema = z.object({
-  nodeVersion: z.string().or(z.string().array()).optional(),
+  nodeVersion: z.string().or(z.string().array()).default('16.14-browsers'),
   cypressImage: z.string().optional()
 })
 export type CircleCIOptions = z.infer<typeof CircleCISchema>

--- a/lib/types/src/schema/circleci.ts
+++ b/lib/types/src/schema/circleci.ts
@@ -1,7 +1,7 @@
 import { z } from 'zod'
 
 export const CircleCISchema = z.object({
-  nodeVersion: z.string().optional(),
+  nodeVersion: z.string().or(z.string().array()).optional(),
   cypressImage: z.string().optional()
 })
 export type CircleCIOptions = z.infer<typeof CircleCISchema>

--- a/plugins/circleci-deploy/src/index.ts
+++ b/plugins/circleci-deploy/src/index.ts
@@ -37,6 +37,7 @@ export class DeployReview extends CircleCiConfigHook {
       name: DeployReview.job,
       addToNightly: true,
       requires: ['tool-kit/setup', 'waiting-for-approval'],
+      splitIntoMatrix: false,
       additionalFields: {
         filters: { branches: { ignore: 'main' } }
       }
@@ -46,12 +47,15 @@ export class DeployReview extends CircleCiConfigHook {
 
 export class DeployStaging extends CircleCiConfigHook {
   static job = 'tool-kit/deploy-staging'
-  config = generateConfigWithJob({
-    name: DeployStaging.job,
-    addToNightly: false,
-    requires: ['tool-kit/setup'],
-    additionalFields: { filters: { branches: { only: 'main' } } }
-  })
+  get config(): CircleCIStatePartial {
+    return generateConfigWithJob({
+      name: DeployStaging.job,
+      addToNightly: false,
+      requires: ['tool-kit/setup'],
+      splitIntoMatrix: false,
+      additionalFields: { filters: { branches: { only: 'main' } } }
+    })
+  }
 }
 
 abstract class CypressCiHook extends CircleCiConfigHook {
@@ -60,7 +64,12 @@ abstract class CypressCiHook extends CircleCiConfigHook {
 
   get config() {
     const options = getOptions('@dotcom-tool-kit/circleci')
-    const simplejobOptions = { name: this.job, addToNightly: false, requires: this.requiredJobs }
+    const simplejobOptions = {
+      name: this.job,
+      addToNightly: false,
+      requires: this.requiredJobs,
+      splitIntoMatrix: false
+    }
     if (options?.cypressImage) {
       return {
         executors: { cypress: { docker: [{ image: options.cypressImage }] } },
@@ -89,6 +98,7 @@ export class DeployProduction extends CircleCiConfigHook {
       name: DeployProduction.job,
       addToNightly: false,
       requires: [new TestStaging(this.logger).job, TestCI.job],
+      splitIntoMatrix: false,
       additionalFields: {
         filters: { branches: { only: 'main' } }
       }

--- a/plugins/circleci-npm/src/index.ts
+++ b/plugins/circleci-npm/src/index.ts
@@ -5,6 +5,7 @@ class PublishHook extends CircleCiConfigHook {
   config = generateConfigWithJob({
     name: PublishHook.job,
     requires: ['tool-kit/test'],
+    splitIntoMatrix: false,
     addToNightly: false,
     additionalFields: {
       context: 'npm-publish-token',

--- a/plugins/circleci/readme.md
+++ b/plugins/circleci/readme.md
@@ -29,7 +29,7 @@ npx dotcom-tool-kit --install
 
 | Key           | Description                             | Default value |
 | ------------- | --------------------------------------- | ------------- |
-| `nodeVersion` | the node versioned docker image tag for circleci to use. For example `18.16-browsers` or `16.14`. Can be an array of versions to create a matrix pipeline. The first version in the list is what will be used for publishing etc. | `16.14-browsers` |
+| `nodeVersion` | The Node versioned docker image tag for CircleCI to use. Any [CircleCI image tag](https://circleci.com/developer/images/image/cimg/node#image-tags) is valid, for example `18.16-browsers` or `16.14`. Can be an array of versions to create a matrix pipeline. The first version in the list is what will be used for publishing etc. | `16.14-browsers` |
 
 ## Hooks
 

--- a/plugins/circleci/readme.md
+++ b/plugins/circleci/readme.md
@@ -29,7 +29,7 @@ npx dotcom-tool-kit --install
 
 | Key           | Description                             | Default value |
 | ------------- | --------------------------------------- | ------------- |
-| `nodeVersion` | the node versioned docker image tag for circleci to use. For example `18.16-browsers` or `16.14`. Can be an array of versions to create a matrix pipeline. The first version in the list is what will be used for publishing etc. | `undefined`   |
+| `nodeVersion` | the node versioned docker image tag for circleci to use. For example `18.16-browsers` or `16.14`. Can be an array of versions to create a matrix pipeline. The first version in the list is what will be used for publishing etc. | `16.14-browsers` |
 
 ## Hooks
 

--- a/plugins/circleci/readme.md
+++ b/plugins/circleci/readme.md
@@ -29,7 +29,7 @@ npx dotcom-tool-kit --install
 
 | Key           | Description                             | Default value |
 | ------------- | --------------------------------------- | ------------- |
-| `nodeVersion` | the node versioned docker image tag for circleci to use. For example `18.16-browsers` or `16.14` | `undefined`   |
+| `nodeVersion` | the node versioned docker image tag for circleci to use. For example `18.16-browsers` or `16.14`. Can be an array of versions to create a matrix pipeline. The first version in the list is what will be used for publishing etc. | `undefined`   |
 
 ## Hooks
 

--- a/plugins/circleci/src/circleci-config.ts
+++ b/plugins/circleci/src/circleci-config.ts
@@ -15,7 +15,6 @@ import type { PartialDeep } from 'type-fest'
 import YAML from 'yaml'
 
 const MAJOR_ORB_VERSION = '4'
-const DEFAULT_NODE_VERSION = '16.14-browsers'
 
 export type CircleCIState = CircleConfig
 /**
@@ -27,8 +26,15 @@ export type CircleCIState = CircleConfig
 export type CircleCIStatePartial = PartialDeep<CircleCIState>
 
 const getNodeVersions = (): Array<string> => {
-  const nodeVersion = getOptions('@dotcom-tool-kit/circleci')?.nodeVersion
-  return Array.isArray(nodeVersion) ? nodeVersion : [nodeVersion ?? DEFAULT_NODE_VERSION]
+  // HACK: This function should only ever be called after the Tool Kit options
+  // are loaded so that we can see which node versions are specified. However,
+  // older versions of the other CircleCI plugins may not do this properly, so
+  // to avoid a breaking change we fall back to creating an array with a single
+  // empty string. The first executor is named 'node' without any reference to
+  // the version so the plugins which don't support matrices don't need to know
+  // the version option.
+  const nodeVersion = getOptions('@dotcom-tool-kit/circleci')?.nodeVersion ?? ''
+  return Array.isArray(nodeVersion) ? nodeVersion : [nodeVersion]
 }
 
 /* Applies a verion identifier for all but the first (and therefore default)

--- a/plugins/circleci/src/circleci-config.ts
+++ b/plugins/circleci/src/circleci-config.ts
@@ -14,7 +14,8 @@ import path from 'path'
 import type { PartialDeep } from 'type-fest'
 import YAML from 'yaml'
 
-const majorOrbVersion = '4'
+const MAJOR_ORB_VERSION = '4'
+const DEFAULT_NODE_VERSION = '16.14-browsers'
 
 export type CircleCIState = CircleConfig
 /**
@@ -25,24 +26,48 @@ export type CircleCIState = CircleConfig
  */
 export type CircleCIStatePartial = PartialDeep<CircleCIState>
 
+const getNodeVersions = (): Array<string> => {
+  const nodeVersion = getOptions('@dotcom-tool-kit/circleci')?.nodeVersion
+  return Array.isArray(nodeVersion) ? nodeVersion : [nodeVersion ?? DEFAULT_NODE_VERSION]
+}
+
+/* Applies a verion identifier for all but the first (and therefore default)
+ * Node executor, sanitising the Node version to be suitable for a CircleCI
+ * configuration name. */
+const nodeVersionToExecutor = (version: string, index: number): string =>
+  index === 0 ? 'node' : `node${version.replaceAll('.', '_')}`
+
 // These boilerplate objects are (typically) needed for each job. They can be
 // spread into your custom config, and are automatically included when calling
 // generateSimpleJob.
 
 /**
- * Every Tool Kit job, including jobs in the `nightly` workflow, uses the
- * executor we define at the top of the CircleCI config, which specifies the
+ * Every Tool Kit job uses a Node executor. We define a list of possible Node
+ * executors at the top of the CircleCI config, and jobs can either opt for the
+ * default executor (shortened to just 'node') with `nightlyBoilerplate` or to
+ * run with all the different executors in a matrix via `matrixBoilerplate`.
  * version of Node to use.
  */
 export const nightlyBoilerplate = {
   executor: 'node'
 }
+// Needs to be lazy as the node versions haven't been loaded yet when this
+// module is initialised.
+export const matrixBoilerplate = () => ({
+  matrix: {
+    parameters: {
+      executor: getNodeVersions().map(nodeVersionToExecutor)
+    }
+  }
+})
+
 /**
  * tagFilter sets the regex for GitHub release tags: CircleCI will ignore jobs
  * when doing a release if the filter isn't made explicit
  */
 export const tagFilter = { filters: { tags: { only: `${semVerRegex}` } } }
 /**
+ * @deprecated explicitly using each of the objects this spreads is preferred.
  * jobBoilerplate is the config needed for all Tool Kit jobs in the `tool-kit`
  * workflow, and combines the `nightlyBoilerplate` and `tagFilter` objects.
  */
@@ -56,6 +81,8 @@ export interface JobGeneratorOptions {
   /** whether to include in `nightly` workflow or just `tool-kit` */
   addToNightly: boolean
   requires: string[]
+  /** whether this job can be run multiple times with different Node versions */
+  splitIntoMatrix: boolean
   /** other fields to include in the job */
   additionalFields?: JobConfig
 }
@@ -63,17 +90,27 @@ export interface JobGeneratorOptions {
 /**
  * `generateConfigWithJob` generates a single job, structured so that it will
  * merge nicely with the rest of the config. This will include the `requires`
- * parameter, as well as the boilerplate properties from `jobBoilerplate`, but
- * any other options will need to be passed to `additionalFields`, such as
+ * parameter, as well as the boilerplate properties from `matrixBoilerplate`,
+ * but any other options will need to be passed to `additionalFields`, such as
  * `filters.branches`.
  */
 export const generateConfigWithJob = (options: JobGeneratorOptions): CircleCIStatePartial => {
+  const jobBase = options.splitIntoMatrix
+    ? {
+        name: `${options.name}-<< matrix.executor >>`,
+        requires: options.requires.map((dep) =>
+          dep === 'waiting-for-approval' ? dep : `${dep}-<< matrix.executor >>`
+        ),
+        ...matrixBoilerplate()
+      }
+    : { requires: options.requires, ...nightlyBoilerplate }
   const config: CircleCIStatePartial = {
     workflows: {
       'tool-kit': {
         jobs: [
           {
-            [options.name]: merge({ requires: options.requires }, jobBoilerplate, options.additionalFields)
+            // avoid overwriting the jobBase variable
+            [options.name]: merge({}, jobBase, tagFilter, options.additionalFields)
           }
         ]
       }
@@ -85,7 +122,7 @@ export const generateConfigWithJob = (options: JobGeneratorOptions): CircleCISta
       jobs: [
         {
           [options.name]: merge(
-            { requires: options.requires.filter((job) => job !== 'waiting-for-approval') },
+            { ...jobBase, requires: jobBase.requires.filter((dep) => dep !== 'waiting-for-approval') },
             nightlyBoilerplate,
             options.additionalFields
           )
@@ -97,19 +134,21 @@ export const generateConfigWithJob = (options: JobGeneratorOptions): CircleCISta
 }
 
 const getInitialState = (): CircleCIState => {
-  const options = getOptions('@dotcom-tool-kit/circleci') ?? {}
   return {
     version: 2.1,
     orbs: {
       'tool-kit': process.env.TOOL_KIT_FORCE_DEV_ORB
         ? 'financial-times/dotcom-tool-kit@dev:alpha'
-        : `financial-times/dotcom-tool-kit@${majorOrbVersion}`
+        : `financial-times/dotcom-tool-kit@${MAJOR_ORB_VERSION}`
     },
-    executors: {
-      node: {
-        docker: [{ image: `cimg/node:${options.nodeVersion ?? '16.14-browsers'}` }]
-      }
-    },
+    executors: Object.fromEntries(
+      getNodeVersions().map((version, i) => [
+        nodeVersionToExecutor(version, i),
+        {
+          docker: [{ image: `cimg/node:${version}` }]
+        }
+      ])
+    ),
     jobs: {
       checkout: {
         docker: [{ image: 'cimg/base:stable' }],
@@ -140,8 +179,10 @@ const getInitialState = (): CircleCIState => {
           },
           {
             'tool-kit/setup': {
+              name: 'tool-kit/setup-<< matrix.executor >>',
               requires: ['checkout', 'waiting-for-approval'],
-              ...jobBoilerplate
+              ...matrixBoilerplate(),
+              ...tagFilter
             }
           }
         ]
@@ -161,8 +202,9 @@ const getInitialState = (): CircleCIState => {
           'checkout',
           {
             'tool-kit/setup': {
+              name: 'tool-kit/setup-<< matrix.executor >>',
               requires: ['checkout'],
-              ...nightlyBoilerplate
+              ...matrixBoilerplate()
             }
           }
         ]

--- a/plugins/circleci/src/index.ts
+++ b/plugins/circleci/src/index.ts
@@ -3,16 +3,26 @@ import CircleCiConfigHook, { generateConfigWithJob } from './circleci-config'
 
 export class BuildCI extends CircleCiConfigHook {
   static job = 'tool-kit/build'
-  config = generateConfigWithJob({ name: BuildCI.job, requires: ['tool-kit/setup'], addToNightly: true })
+  get config() {
+    return generateConfigWithJob({
+      name: BuildCI.job,
+      requires: ['tool-kit/setup'],
+      splitIntoMatrix: true,
+      addToNightly: true
+    })
+  }
 }
 
 export class TestCI extends CircleCiConfigHook {
   static job = 'tool-kit/test'
-  config = generateConfigWithJob({
-    name: TestCI.job,
-    requires: [BuildCI.job],
-    addToNightly: true
-  })
+  get config() {
+    return generateConfigWithJob({
+      name: TestCI.job,
+      requires: [BuildCI.job],
+      splitIntoMatrix: true,
+      addToNightly: true
+    })
+  }
 }
 
 export const hooks = {


### PR DESCRIPTION
# Description

This PR adds the ability to run CI code with multiple versions of Node using CircleCI's [matrix jobs](https://circleci.com/docs/using-matrix-jobs/). This is useful when your project supports multiple different Node versions and you want to test that your code is compatible with all of them. To use the matrices you specify an array of Node versions for `@dotcom-tool-kit/circleci`'s `nodeVersion` option and the plugin will install a CircleCI executor for each and split each job that supports running multiple times (i.e., test and build jobs, but not deploy jobs). In order to maintain simplicity in the plugin (which benefits maintainers of both the Tool Kit repository and custom plugin authors), any job that supports matrices will always be passed a list of Node versions to run, even if the length of the list is just one. This should have no affect on the behaviour of the pipeline to how it worked previously, and means there are fewer conditional paths in the config generation logic.

I've tested that this code works in both a repository that uses a single Node version (next-static) and one that uses multiple (n-express). In both cases valid code was generated, as confirmed by the CircleCI CLI (running `circleci config validate .circleci/config.yml`).

Questions for the reviewer:
- The current implementation does not support the pipeline forking into matrix jobs, joining into a single job, then forking again. Will this ever be an issue?
- I figured that the `tool-kit/setup` job should be run in parallel, as `npm install` behaviour can be different based on the Node version – even when the npm version is the same (scripts that check `engines` for example). However, `npm install` is quite a long running process and it will be potentially expensive to run it multiple times. Do we think that this is acceptable or should we fall down on the tradeoff in the other direction?

# Checklist:

- [x] My branch has been rebased onto the latest commit on main (don't merge main into your branch)
- [x] My commit messages are [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/), for example: `feat(circleci): add support for nightly workflows`, `fix: set Heroku app name for staging apps too`
