### PR TITLE
Work around incompatibility between Webpack 4 and Node 18

### DIFF
--- a/plugins/webpack/test/tasks/webpack.test.ts
+++ b/plugins/webpack/test/tasks/webpack.test.ts
@@ -31,7 +31,7 @@ describe('webpack', () => {
       expect(fork).toBeCalledWith(
         webpackCLIPath,
         ['build', '--color', '--mode=development', '--config=webpack.config.js'],
-        { silent: true }
+        { silent: true, execArgv: expect.arrayContaining([]) }
       )
     })
   })
@@ -45,7 +45,7 @@ describe('webpack', () => {
       expect(fork).toBeCalledWith(
         webpackCLIPath,
         ['build', '--color', '--mode=production', '--config=webpack.config.js'],
-        { silent: true }
+        { silent: true, execArgv: expect.arrayContaining([]) }
       )
     })
   })


### PR DESCRIPTION
# Description

One of the changes going from Node 16 to Node 18 is a [bump](https://nodejs.org/en/blog/release/v17.0.0#openssl-30) to OpenSSL 3. This version of the library drops support for some legacy APIs, one of which is used by the Webpack build process for hashing build artefacts. This results in a [build error](https://app.circleci.com/pipelines/github/Financial-Times/next-static/2481/workflows/b75871a1-8675-4f1a-9cb5-682cfeed3f6a/jobs/10245) like
```
⚠ Error: error:0308010C:digital envelope routines::unsupported
    at new Hash (node:internal/crypto/hash:71:19)
    at Object.createHash (node:crypto:133:10)
    at module.exports (next-static/node_modules/webpack/lib/util/createHash.js:135:53)
    at NormalModule._initBuildHash (next-static/node_modules/webpack/lib/NormalModule.js:417:16)
<etc>
```
It doesn't [look](https://github.com/webpack/webpack/issues/14532) like the Webpack devs are going to backport a fix to Webpack 4. We could update to Webpack 5 to resolve the issue, but I don't think we should ask people to bump their Webpack major version at the same time we're already asking them to bump Node versions. Instead, let's leverage Tool Kit to work around the issue by passing in a [command line argument](https://nodejs.org/docs/latest-v18.x/api/cli.html#--openssl-legacy-provider) to the Node process running Webpack that enables the legacy APIs so that Webpack 4 can continue to function for now.

# Checklist:

- [x] My branch has been rebased onto the latest commit on main (don't merge main into your branch)
- [x] My commit messages are [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/), for example: `feat(circleci): add support for nightly workflows`, `fix: set Heroku app name for staging apps too`
