### PR TITLE
Don't depend on all Node versions for joining jobs in CircleCI configurations

### DIFF
--- a/plugins/circleci/src/circleci-config.ts
+++ b/plugins/circleci/src/circleci-config.ts
@@ -109,7 +109,16 @@ export const generateConfigWithJob = (options: JobGeneratorOptions): CircleCISta
         ),
         ...matrixBoilerplate()
       }
-    : { requires: options.requires, ...nightlyBoilerplate }
+    : {
+        // only require the latest Node version of a matrix job in order to
+        // avoid workspace conflicts
+        requires: options.requires.map((dep) => `${dep}-node`),
+        // append the default executor name to the job name so that multiple
+        // non-matrix jobs can be chained one after another without having to
+        // know whether a matrix job precedes them or not
+        name: `${options.name}-node`,
+        ...nightlyBoilerplate
+      }
   const config: CircleCIStatePartial = {
     workflows: {
       'tool-kit': {

--- a/plugins/circleci/test/circleci-config.test.ts
+++ b/plugins/circleci/test/circleci-config.test.ts
@@ -109,7 +109,7 @@ describe('CircleCI config hook', () => {
               jobs: expect.arrayContaining([
                 expect.objectContaining({
                   'test-job': expect.objectContaining({
-                    requires: ['another-job']
+                    requires: ['another-job-node']
                   })
                 })
               ])
@@ -118,7 +118,7 @@ describe('CircleCI config hook', () => {
               jobs: expect.arrayContaining([
                 {
                   'test-job': expect.objectContaining({
-                    requires: ['another-job']
+                    requires: ['another-job-node']
                   })
                 }
               ])
@@ -145,7 +145,7 @@ describe('CircleCI config hook', () => {
               jobs: expect.arrayContaining([
                 expect.objectContaining({
                   'test-job': expect.objectContaining({
-                    requires: ['another-job']
+                    requires: ['another-job-node']
                   })
                 }),
                 expect.objectContaining({
@@ -159,7 +159,7 @@ describe('CircleCI config hook', () => {
               jobs: expect.arrayContaining([
                 {
                   'test-job': expect.objectContaining({
-                    requires: ['another-job']
+                    requires: ['another-job-node']
                   })
                 }
               ])
@@ -181,7 +181,7 @@ describe('CircleCI config hook', () => {
       const config = YAML.parse(mockedWriteFile.mock.calls[0][1] as string)
       const partialExpectedJob = {
         'test-job': expect.objectContaining({
-          requires: ['another-job']
+          requires: ['another-job-node']
         })
       }
       const { jobs } = config.workflows['tool-kit']

--- a/plugins/circleci/test/files/with-hook/.circleci/config.yml
+++ b/plugins/circleci/test/files/with-hook/.circleci/config.yml
@@ -2,8 +2,9 @@ workflows:
   tool-kit:
     jobs:
       - test-job:
+          name: test-job-node
           requires:
-            - another-job
+            - another-job-node
           executor: node
           filters:
             tags:
@@ -11,6 +12,7 @@ workflows:
   nightly:
     jobs:
       - test-job:
+          name: test-job-node
           requires:
-            - another-job
+            - another-job-node
           executor: node


### PR DESCRIPTION
# Description

This avoids the [same issue we see in n-gage projects](https://github.com/Financial-Times/n-tracking/pull/119) where depending on all the Node version matrix jobs when 'fanning-in' with a job that does not use a matrix meant that we could not attach the workspace as the `node_modules` directory in the matrix jobs conflicted. The downside now is that the fanned-in job will still run even if a matrix job for an older Node version fails. I don't think CircleCI provides any way to work around this when testing multiple Node versions concurrently (there's no way to select which job to attach a workspace from, for instance).

# Checklist:

- [x] My branch has been rebased onto the latest commit on main (don't merge main into your branch)
- [x] My commit messages are [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/), for example: `feat(circleci): add support for nightly workflows`, `fix: set Heroku app name for staging apps too`
