### PR TITLE
Don't include executor setting twice for nightly jobs in generated CircleCI config

### DIFF
--- a/plugins/circleci/src/circleci-config.ts
+++ b/plugins/circleci/src/circleci-config.ts
@@ -138,7 +138,6 @@ export const generateConfigWithJob = (options: JobGeneratorOptions): CircleCISta
         {
           [options.name]: merge(
             { ...jobBase, requires: jobBase.requires.filter((dep) => dep !== 'waiting-for-approval') },
-            nightlyBoilerplate,
             options.additionalFields
           )
         }


### PR DESCRIPTION
# Description

An extra boilerplate object was left to be spread in nightly CircleCI jobs after #432. This object set the `executor` of a job to `node` – a docker image using the default Node version for the package – but this was redundant as the `jobBase` object on the line above already specified the `executor`, either as `node` or a matrix of different possible executors, e.g.,

```yaml
- tool-kit/build:
    name: tool-kit/build-<< matrix.executor >>
    requires:
      - tool-kit/setup-<< matrix.executor >>
    matrix:
      parameters:
        executor:
          - node
          - node16_20
    executor: node
```

I don't think this previously generated CircleCI configuration was broken, but the extra `executor` field is unnecessary and (hopefully) overridden by the matrix parameters. I've tested these changes with n-express and don't think there should be any more adjustments required after this 😅

# Checklist:

- [x] My branch has been rebased onto the latest commit on main (don't merge main into your branch)
- [x] My commit messages are [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/), for example: `feat(circleci): add support for nightly workflows`, `fix: set Heroku app name for staging apps too`
