### PR TITLE
CPP-1516 Improve the logger's robustness

### DIFF
--- a/lib/logger/src/format.ts
+++ b/lib/logger/src/format.ts
@@ -20,6 +20,10 @@ export const format = winston.format.printf((info) => {
     }
     if (info.process) {
       labels += `[${styles.dim(info.process)}]`
+    } else {
+      // simulate the newline present in a normal console.log (which we've
+      // removed from the Console transport)
+      message += '\n'
     }
 
     if (info.level === 'error') {

--- a/lib/logger/src/format.ts
+++ b/lib/logger/src/format.ts
@@ -7,44 +7,51 @@ import { styles } from './styles'
 // labels, greatly hindering readability.
 let lastLabel: string | undefined
 
-export const format = winston.format.printf((info) => {
-  let { message } = info
+export const createFormatter = (thisLogger: winston.Logger) =>
+  winston.format.printf((info) => {
+    let { message } = info
 
-  if (!info.skipformat) {
-    let labels = ''
-    if (info.hook) {
-      labels += `[${styles.hook(info.hook)}]`
-    }
-    if (info.task) {
-      labels += `[${styles.task(info.task)}]`
-    }
-    if (info.process) {
-      labels += `[${styles.dim(info.process)}]`
-    } else {
-      // simulate the newline present in a normal console.log (which we've
-      // removed from the Console transport)
-      message += '\n'
-    }
-
-    if (info.level === 'error') {
-      labels = styles.errorHighlight(labels)
-    } else if (info.level === 'warn') {
-      labels = styles.warningHighlight(labels)
-    }
-
-    if (labels && labels !== lastLabel) {
-      if (info.level === 'error') {
-        message = styles.error(message)
-      } else if (info.level === 'warn') {
-        message = styles.warning(message)
+    if (!info.skipformat) {
+      let labels = ''
+      if (info.hook) {
+        labels += `[${styles.hook(info.hook)}]`
       }
-      // Put hooked messages on a new line so we don't break fancy layouts from
-      // subprocesses, e.g., tables, with our metadata
-      const delimiter = info.process ? '\n' : ' '
-      message = `${labels}${delimiter}${message}`
-    }
-    lastLabel = labels
-  }
+      if (info.task) {
+        labels += `[${styles.task(info.task)}]`
+      }
+      if (info.process) {
+        labels += `[${styles.dim(info.process)}]`
+      } else {
+        // simulate the newline present in a normal console.log (which we've
+        // removed from the Console transport)
+        message += '\n'
+      }
 
-  return message
-})
+      if (info.level === 'error') {
+        labels = styles.errorHighlight(labels)
+      } else if (info.level === 'warn') {
+        labels = styles.warningHighlight(labels)
+      }
+
+      if (labels && labels !== lastLabel) {
+        if (info.level === 'error') {
+          message = styles.error(message)
+        } else if (info.level === 'warn') {
+          message = styles.warning(message)
+        }
+        // Put hooked messages on a new line so we don't break fancy layouts from
+        // subprocesses, e.g., tables, with our metadata
+        const delimiter = info.process ? '\n' : ' '
+        message = `${labels}${delimiter}${message}`
+      }
+      // HACK: We only want to track the last label for logs that aren't
+      // filtered out by winston. We need the logger to be instantiated before
+      // creating this formatter function so that we can call a method on it to
+      // check if the message will be filtered out or not.
+      if (thisLogger.isLevelEnabled(info.level)) {
+        lastLabel = labels
+      }
+    }
+
+    return message
+  })

--- a/lib/logger/src/helpers.ts
+++ b/lib/logger/src/helpers.ts
@@ -95,8 +95,10 @@ export function hookFork(
         new Transform({
           decodeStrings: false,
           readableObjectMode: true,
-          transform: (data, _enc, callback) => {
-            callback(null, { level, message: data.endsWith('\n') ? data.slice(0, -1) : data })
+          transform: (message, _enc, callback) => {
+            // add the log level and wrap the message for the winston stream to
+            // consume
+            callback(null, { level, message })
           }
         })
       )

--- a/lib/logger/src/index.ts
+++ b/lib/logger/src/index.ts
@@ -1,4 +1,4 @@
-export { format } from './format'
+export { createFormatter } from './format'
 export { hookConsole, hookFork, waitOnExit } from './helpers'
 export { rootLogger } from './logger'
 export { styles } from './styles'

--- a/lib/logger/src/logger.ts
+++ b/lib/logger/src/logger.ts
@@ -1,9 +1,9 @@
 import winston from 'winston'
-import { format } from './format'
+import { createFormatter } from './format'
 import { consoleTransport } from './transports'
 
 export const rootLogger: winston.Logger = winston.createLogger({
   level: process.env.LOG_LEVEL ?? (process.env.CIRCLECI ? 'verbose' : 'info'),
-  format,
   transports: [consoleTransport]
 })
+rootLogger.format = createFormatter(rootLogger)

--- a/lib/logger/src/transports.ts
+++ b/lib/logger/src/transports.ts
@@ -41,5 +41,8 @@ export class HookTransport extends Transport {
 
 export const consoleTransport = new transports.Console({
   stderrLevels: ['error'],
-  consoleWarnLevels: ['warn']
+  consoleWarnLevels: ['warn'],
+  // disable automatically adding a newline so that hooked process logs aren't
+  // separated by newlines after every flush
+  eol: ''
 })

--- a/plugins/nodemon/src/tasks/nodemon.ts
+++ b/plugins/nodemon/src/tasks/nodemon.ts
@@ -66,7 +66,8 @@ export default class Nodemon extends Task<typeof NodemonSchema> {
             return 'info'
         }
       }
-      nodemonLogger.log(nodemonToWinstonLogLevel(msg.type), msg.message)
+      // need to manually add a newline seeing as we're acting as a subprocess
+      nodemonLogger.log(nodemonToWinstonLogLevel(msg.type), msg.message + '\n')
     })
     await new Promise((resolve) => nodemon.on('start', resolve))
     writeState('local', { port })


### PR DESCRIPTION
# Description

Intercepting subprocesses' logging is a hairy proposition but it's necessary in Tool Kit to be able to add additional context for which thing that we've invoked is logging what. @AniaMakes recently reported some issues she was having with the logger in her project which should be fixed now. I also stumbled on another issue whilst testing the fix for the first. Technical details are in the commit descriptions but I'll include some before/after screenshots here to demonstrate the impact of the fixes.

### Unreadable Jest output being split across multiple lines
![terminal window with Jest output incorrectly split over multiple lines](https://github.com/Financial-Times/dotcom-tool-kit/assets/7020796/89b33e4d-6ef7-4695-85ec-209b735ebdbe)
vs
![terminal window with Jest output now logged correctly](https://github.com/Financial-Times/dotcom-tool-kit/assets/7020796/a584e7ca-8408-4110-9c4f-927459cad6e6)

### Some logs not having a label prepended to them when switching context
![terminal window showing some logs, the first one without a label specifying it's from the Nodemon process](https://github.com/Financial-Times/dotcom-tool-kit/assets/7020796/0819547d-6589-492d-bcaa-334865c43650)
vs
![terminal window showing some logs, with the first now printing a label for context](https://github.com/Financial-Times/dotcom-tool-kit/assets/7020796/a725c588-7658-4e49-857b-7cc552855070)

# Checklist:

- [x] My branch has been rebased onto the latest commit on main (don't merge main into your branch)
- [x] My commit messages are [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/), for example: `feat(circleci): add support for nightly workflows`, `fix: set Heroku app name for staging apps too`
