### PR TITLE
Fix CircleCI status badge

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -2,7 +2,7 @@
    <img alt="FT.com Tool Kit" src="etc/logo.svg" width="300">
 </h1>
 
-[![CircleCI](https://circleci.com/gh/Financial-Times/dotcom-tool-kit.svg?style=svg&circle-token=f1f296a3a084deef4caabb72cfaf9617a654d244)](https://circleci.com/gh/Financial-Times/dotcom-tool-kit)
+[![CircleCI](https://dl.circleci.com/status-badge/img/gh/Financial-Times/dotcom-tool-kit/tree/main.svg?style=svg)](https://dl.circleci.com/status-badge/redirect/gh/Financial-Times/dotcom-tool-kit/tree/main)
 
 Tool Kit is modern developer tooling for FT.com repositories. It's fully modular, allowing repos that need different tooling to install separate plugins that work consistently together.
 


### PR DESCRIPTION
# Description

The CircleCI status badge has stopped loading; I'm not sure when it stopped loading. We were previously using a URL with an API token in so that the status would show when Tool Kit was a private repository, and we should probably have removed that token sooner once it was public lol? Doesn't matter now as the token is long expired (I've confirmed via the CircleCI API) I've regenerated the badge using the CircleCI UI.

# Checklist:

- [x] My branch has been rebased onto the latest commit on main (don't merge main into your branch)
- [x] My commit messages are [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/), for example: `feat(circleci): add support for nightly workflows`, `fix: set Heroku app name for staging apps too`
