### PR TITLE
Fix CircleCI configuration error by never appending executor name to approval job

### DIFF
--- a/plugins/circleci/src/circleci-config.ts
+++ b/plugins/circleci/src/circleci-config.ts
@@ -112,7 +112,7 @@ export const generateConfigWithJob = (options: JobGeneratorOptions): CircleCISta
     : {
         // only require the latest Node version of a matrix job in order to
         // avoid workspace conflicts
-        requires: options.requires.map((dep) => `${dep}-node`),
+        requires: options.requires.map((dep) => (dep === 'waiting-for-approval' ? dep : `${dep}-node`)),
         // append the default executor name to the job name so that multiple
         // non-matrix jobs can be chained one after another without having to
         // know whether a matrix job precedes them or not

--- a/plugins/circleci/test/__snapshots__/circleci-config.test.ts.snap
+++ b/plugins/circleci/test/__snapshots__/circleci-config.test.ts.snap
@@ -1,0 +1,171 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`CircleCI config hook install correctly generates a new configuration file 1`] = `
+Object {
+  "executors": Object {
+    "node": Object {
+      "docker": Array [
+        Object {
+          "image": "cimg/node:16.14-browsers",
+        },
+      ],
+    },
+  },
+  "jobs": Object {
+    "checkout": Object {
+      "docker": Array [
+        Object {
+          "image": "cimg/base:stable",
+        },
+      ],
+      "steps": Array [
+        "checkout",
+        Object {
+          "tool-kit/persist-workspace": Object {
+            "path": ".",
+          },
+        },
+      ],
+    },
+  },
+  "orbs": Object {
+    "tool-kit": "financial-times/dotcom-tool-kit@4",
+  },
+  "version": 2.1,
+  "workflows": Object {
+    "nightly": Object {
+      "jobs": Array [
+        "checkout",
+        Object {
+          "tool-kit/setup": Object {
+            "matrix": Object {
+              "parameters": Object {
+                "executor": Array [
+                  "node",
+                ],
+              },
+            },
+            "name": "tool-kit/setup-<< matrix.executor >>",
+            "requires": Array [
+              "checkout",
+            ],
+          },
+        },
+        Object {
+          "test-job": Object {
+            "executor": "node",
+            "name": "test-job-node",
+            "requires": Array [
+              "that-job-node",
+            ],
+          },
+        },
+      ],
+      "when": Object {
+        "and": Array [
+          Object {
+            "equal": Array [
+              "scheduled_pipeline",
+              "<< pipeline.trigger_source >>",
+            ],
+          },
+          Object {
+            "equal": Array [
+              "nightly",
+              "<< pipeline.schedule.name >>",
+            ],
+          },
+        ],
+      },
+    },
+    "tool-kit": Object {
+      "jobs": Array [
+        Object {
+          "checkout": Object {
+            "filters": Object {
+              "tags": Object {
+                "only": "/^v\\\\d+\\\\.\\\\d+\\\\.\\\\d+(-.+)?/",
+              },
+            },
+          },
+        },
+        Object {
+          "waiting-for-approval": Object {
+            "filters": Object {
+              "branches": Object {
+                "only": "/(^renovate-.*|^nori/.*)/",
+              },
+            },
+            "type": "approval",
+          },
+        },
+        Object {
+          "tool-kit/setup": Object {
+            "filters": Object {
+              "tags": Object {
+                "only": "/^v\\\\d+\\\\.\\\\d+\\\\.\\\\d+(-.+)?/",
+              },
+            },
+            "matrix": Object {
+              "parameters": Object {
+                "executor": Array [
+                  "node",
+                ],
+              },
+            },
+            "name": "tool-kit/setup-<< matrix.executor >>",
+            "requires": Array [
+              "checkout",
+              "waiting-for-approval",
+            ],
+          },
+        },
+        Object {
+          "test-job": Object {
+            "executor": "node",
+            "filters": Object {
+              "tags": Object {
+                "only": "/^v\\\\d+\\\\.\\\\d+\\\\.\\\\d+(-.+)?/",
+              },
+            },
+            "name": "test-job-node",
+            "requires": Array [
+              "waiting-for-approval",
+              "that-job-node",
+            ],
+          },
+        },
+        Object {
+          "test-another-job": Object {
+            "filters": Object {
+              "tags": Object {
+                "only": "/^v\\\\d+\\\\.\\\\d+\\\\.\\\\d+(-.+)?/",
+              },
+            },
+            "matrix": Object {
+              "parameters": Object {
+                "executor": Array [
+                  "node",
+                ],
+              },
+            },
+            "name": "test-another-job-<< matrix.executor >>",
+            "requires": Array [
+              "waiting-for-approval",
+              "this-job-<< matrix.executor >>",
+            ],
+          },
+        },
+      ],
+      "when": Object {
+        "not": Object {
+          "equal": Array [
+            "scheduled_pipeline",
+            "<< pipeline.trigger_source >>",
+          ],
+        },
+      },
+    },
+  },
+}
+`;

--- a/plugins/circleci/test/files/with-hook/.circleci/config.yml
+++ b/plugins/circleci/test/files/with-hook/.circleci/config.yml
@@ -4,7 +4,8 @@ workflows:
       - test-job:
           name: test-job-node
           requires:
-            - another-job-node
+            - waiting-for-approval
+            - that-job-node
           executor: node
           filters:
             tags:
@@ -14,5 +15,6 @@ workflows:
       - test-job:
           name: test-job-node
           requires:
-            - another-job-node
+            - waiting-for-approval
+            - that-job-node
           executor: node


### PR DESCRIPTION
# Description

This keeps the code consistent across jobs that do and do not use Node matrices. The `waiting-for-approval` job cannot take Node versions as a matrix as it is not a job defined in the `dotcom-tool-kit` orb, so we don't append the executor to its name either. This should happen in jobs that don't use multiple executors too so we don't get CircleCI errors about referring to a `waiting-for-approval-node` job that has never been defined.

I thought I'd caught all the bugs introduced by #432 in #439 after testing with the `n-express` project. However, this issue is only found in repositories that use a job that shouldn't be split into a matrix but also needs to wait for approval, i.e., the `deploy-review` job used for Heroku review deployments, so I only encountered it after testing a Heroku app again. I've added a snapshot test as part of the PR in the hopes that it will be easier to catch issues like this earlier on.

# Checklist:

- [x] My branch has been rebased onto the latest commit on main (don't merge main into your branch)
- [x] My commit messages are [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/), for example: `feat(circleci): add support for nightly workflows`, `fix: set Heroku app name for staging apps too`
