### PR TITLE
Disable Node 18's native fetch across all plugins

### DIFF
--- a/core/cli/readme.md
+++ b/core/cli/readme.md
@@ -1,0 +1,13 @@
+# dotcom-tool-kit
+
+_(This README is for the core `dotcom-tool-kit` package that must be installed to use Tool Kit. You can find the documentation for the Tool Kit project itself at https://github.com/Financial-Times/dotcom-tool-kit/blob/main/readme.md.)_
+
+The primary Tool Kit binary that will be invoked to handle all your hooks and tasks.
+
+## Options
+
+There are some global options available that will affect all plugins. All are optional but you can override them with the `dotcom-tool-kit` key.
+
+| Key | Description | Default value |
+|-|-|-|
+| `allowNativeFetch` | use Node's native fetch if supported | `false` |

--- a/core/cli/src/index.ts
+++ b/core/cli/src/index.ts
@@ -11,6 +11,22 @@ type ErrorSummary = {
   error: Error
 }
 
+// function that plugins can check if they need to implement their own logic to
+// disable Node 18's native fetch
+export const shouldDisableNativeFetch = (): boolean => {
+  // disable Node 18's native fetch if the Node runtime supports it (older
+  // runtimes don't support the flag, implying they also don't use native
+  // fetch) and the user hasn't opted out of the behaviour
+  return (
+    /* eslint-disable-next-line @typescript-eslint/no-non-null-assertion --
+     * the root plugin has default options and it always exists so is always
+     * defined
+     **/
+    !getOptions('app root')!.allowNativeFetch &&
+    process.allowedNodeEnvironmentFlags.has('--no-experimental-fetch')
+  )
+}
+
 export async function runTasks(logger: Logger, hooks: string[], files?: string[]): Promise<void> {
   const config = await loadConfig(logger)
 
@@ -37,6 +53,10 @@ ${availableHooks}`
   }
 
   await checkInstall(config)
+
+  if (shouldDisableNativeFetch()) {
+    process.execArgv.push('--no-experimental-fetch')
+  }
 
   for (const hook of hooks) {
     const errors: ErrorSummary[] = []

--- a/core/cli/src/plugin.ts
+++ b/core/cli/src/plugin.ts
@@ -266,12 +266,15 @@ export function resolvePlugin(plugin: Plugin, config: ValidPluginsConfig, logger
     // merge options from this plugin's config with any options we've collected already
     // TODO this is almost the exact same code as for hooks, refactor
     for (const [id, configOptions] of Object.entries(plugin.rcFile.options)) {
-      const existingOptions = config.options[id]
+      // users can specify root options with the dotcom-tool-kit key to mirror
+      // the name of the root npm package
+      const pluginId = id === 'dotcom-tool-kit' ? 'app root' : id
+      const existingOptions = config.options[pluginId]
 
       const pluginOptions: PluginOptions = {
         options: configOptions,
         plugin,
-        forPlugin: config.plugins[id]
+        forPlugin: config.plugins[pluginId]
       }
 
       if (existingOptions) {
@@ -288,15 +291,15 @@ export function resolvePlugin(plugin: Plugin, config: ValidPluginsConfig, logger
             conflicting: conflicting.concat(pluginOptions)
           }
 
-          config.options[id] = conflict
+          config.options[pluginId] = conflict
         } else {
           // if we're here, any existing options are from a child plugin,
           // so merge in overrides from the parent
-          config.options[id] = { ...existingOptions, ...pluginOptions }
+          config.options[pluginId] = { ...existingOptions, ...pluginOptions }
         }
       } else {
         // this options key might not have been set yet, in which case use the new one
-        config.options[id] = pluginOptions
+        config.options[pluginId] = pluginOptions
       }
     }
   }

--- a/lib/types/src/schema.ts
+++ b/lib/types/src/schema.ts
@@ -28,6 +28,7 @@ export type PromptGenerators<T> = T extends z.ZodObject<infer Shape>
 import { BabelSchema } from './schema/babel'
 import { CircleCISchema } from './schema/circleci'
 import { CypressSchema } from './schema/cypress'
+import { RootSchema } from './schema/dotcom-tool-kit'
 import { ESLintSchema } from './schema/eslint'
 import { HerokuSchema } from './schema/heroku'
 import { LintStagedNpmSchema } from './schema/lint-staged-npm'
@@ -46,6 +47,7 @@ import { VaultSchema } from './schema/vault'
 import { WebpackSchema } from './schema/webpack'
 
 export const Schemas = {
+  'app root': RootSchema,
   '@dotcom-tool-kit/babel': BabelSchema,
   '@dotcom-tool-kit/circleci': CircleCISchema,
   '@dotcom-tool-kit/cypress': CypressSchema,

--- a/lib/types/src/schema/dotcom-tool-kit.ts
+++ b/lib/types/src/schema/dotcom-tool-kit.ts
@@ -1,0 +1,8 @@
+import { z } from 'zod'
+
+export const RootSchema = z.object({
+  allowNativeFetch: z.boolean().default(false)
+})
+export type RootOptions = z.infer<typeof RootSchema>
+
+export const Schema = RootSchema

--- a/lib/types/src/schema/node.ts
+++ b/lib/types/src/schema/node.ts
@@ -4,8 +4,7 @@ export const NodeSchema = z.object({
   entry: z.string().default('./server/app.js'),
   args: z.string().array().optional(),
   useVault: z.boolean().default(true),
-  ports: z.number().array().default([3001, 3002, 3003]),
-  allowNativeFetch: z.boolean().default(false)
+  ports: z.number().array().default([3001, 3002, 3003])
 })
 export type NodeOptions = z.infer<typeof NodeSchema>
 

--- a/lib/types/src/schema/nodemon.ts
+++ b/lib/types/src/schema/nodemon.ts
@@ -4,8 +4,7 @@ export const NodemonSchema = z.object({
   entry: z.string().default('./server/app.js'),
   configPath: z.string().optional(),
   useVault: z.boolean().default(true),
-  ports: z.number().array().default([3001, 3002, 3003]),
-  allowNativeFetch: z.boolean().default(false)
+  ports: z.number().array().default([3001, 3002, 3003])
 })
 export type NodemonOptions = z.infer<typeof NodemonSchema>
 

--- a/plugins/next-router/src/tasks/next-router.ts
+++ b/plugins/next-router/src/tasks/next-router.ts
@@ -21,17 +21,11 @@ export default class NextRouter extends Task<typeof NextRouterSchema> {
 
     const routerBin = require.resolve('ft-next-router/bin/next-router')
     const vaultEnv = await vault.get()
-    let { execArgv } = process
-    // disable native fetch if supported by runtime as next-router uses isomorphic-fetch
-    if (process.allowedNodeEnvironmentFlags.has('--no-experimental-fetch')) {
-      execArgv = [...execArgv, '--no-experimental-fetch']
-    }
     const child = fork(routerBin, ['--daemon'], {
       env: {
         ...process.env,
         ...vaultEnv
       },
-      execArgv,
       silent: true
     })
     hookFork(this.logger, 'next-router', child)

--- a/plugins/node/readme.md
+++ b/plugins/node/readme.md
@@ -27,7 +27,6 @@ plugins:
 | `args` | additional arguments to pass to your application | `[]` |
 | `useVault` | option to run the application with environment variables from Vault | `true` |
 | `ports` | ports to try to bind to for this application | `[3001, 3002, 3003]` |
-| `allowNativeFetch` | use Node's native fetch if supported | `false` |
 
 ## Tasks
 

--- a/plugins/node/src/tasks/node.ts
+++ b/plugins/node/src/tasks/node.ts
@@ -1,10 +1,10 @@
+import { ToolKitError } from '@dotcom-tool-kit/error'
+import { hookConsole, hookFork, styles } from '@dotcom-tool-kit/logger'
+import { writeState } from '@dotcom-tool-kit/state'
 import { Task } from '@dotcom-tool-kit/types'
 import { NodeSchema } from '@dotcom-tool-kit/types/lib/schema/node'
-import { ToolKitError } from '@dotcom-tool-kit/error'
-import { fork } from 'child_process'
 import { VaultEnvVars } from '@dotcom-tool-kit/vault'
-import { writeState } from '@dotcom-tool-kit/state'
-import { hookConsole, hookFork, styles } from '@dotcom-tool-kit/logger'
+import { fork } from 'child_process'
 import getPort from 'get-port'
 import waitPort from 'wait-port'
 
@@ -12,7 +12,7 @@ export default class Node extends Task<typeof NodeSchema> {
   static description = ''
 
   async run(): Promise<void> {
-    const { entry, args, useVault, ports, allowNativeFetch } = this.options
+    const { entry, args, useVault, ports } = this.options
 
     let vaultEnv = {}
 
@@ -38,12 +38,6 @@ export default class Node extends Task<typeof NodeSchema> {
       throw error
     }
 
-    let { execArgv } = process
-    // disable native fetch if supported by runtime
-    if (!allowNativeFetch && process.allowedNodeEnvironmentFlags.has('--no-experimental-fetch')) {
-      execArgv = [...execArgv, '--no-experimental-fetch']
-    }
-
     this.logger.verbose('starting the child node process...')
     const child = fork(entry, args, {
       env: {
@@ -51,7 +45,6 @@ export default class Node extends Task<typeof NodeSchema> {
         PORT: port.toString(),
         ...process.env
       },
-      execArgv,
       silent: true
     })
     hookFork(this.logger, entry, child)

--- a/plugins/nodemon/readme.md
+++ b/plugins/nodemon/readme.md
@@ -25,7 +25,6 @@ plugins:
 | `configPath` | path to custom nodemon config | [automatic config resolution](https://github.com/remy/nodemon#config-files) |
 | `useVault` | option to run the application with environment variables from Vault | `true` |
 | `ports` | ports to try to bind to for this application | `[3001, 3002, 3003]` |
-| `allowNativeFetch` | use Node's native fetch if supported | `false` |
 
 ## Tasks
 


### PR DESCRIPTION
# Description

We don't yet want to support Node 18's new fetch implementation. Tool Kit is enabling this by passing the `--no-experimental-fetch` flag to processes forked by the Node and Nodemon tasks. However, plenty of other tasks (e.g., Jest and Mocha) also involve spawning child Node processes and they don't have this flag passed to them. This can cause issues when running tests, for example.

Instead of adding a code snippet to each relevant task to make sure fetch is disabled, let's handle the flag at the top-level by setting it in the global `process.execArgv` object that will be read by all calls to `fork()`.

This presents the issue of how we're going to let users opt out of the behaviour if they legitimately want to use the new fetch. Previously, users would have to set an option for each plugin, but this won't work when we're setting the flags once globally rather than per plugin. It would make more sense to specify an option that will apply globally. So users can now pass global options to a `dotcom-tool-kit` key in their options object. We can add more options in the future, but for now the only option is to enable Node 18's native fetch (off by default).

I've also removed the per plugin options. This is _technically_ a breaking change, but I've [searched](https://github.com/search?q=org%3AFinancial-Times%20allowNativeFetch&type=code) GitHub and no one was using this escape hatch yet so I think we can get away with yanking it out again.

# Checklist:

- [x] My branch has been rebased onto the latest commit on main (don't merge main into your branch)
- [x] My commit messages are [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/), for example: `feat(circleci): add support for nightly workflows`, `fix: set Heroku app name for staging apps too`
