### PR TITLE
Fix installation errors with circleci-heroku

### DIFF
--- a/plugins/circleci-heroku/package.json
+++ b/plugins/circleci-heroku/package.json
@@ -2,7 +2,7 @@
   "name": "@dotcom-tool-kit/circleci-heroku",
   "version": "3.1.7",
   "description": "",
-  "main": "lib",
+  "main": "index.js",
   "scripts": {
     "test": "cd ../../ ; npx jest --silent --projects plugins/circleci-heroku"
   },
@@ -21,10 +21,6 @@
   },
   "bugs": "https://github.com/financial-times/dotcom-tool-kit/issues",
   "homepage": "https://github.com/financial-times/dotcom-tool-kit/tree/main/plugins/circleci-heroku",
-  "files": [
-    "/lib",
-    ".toolkitrc.yml"
-  ],
   "volta": {
     "extends": "../../package.json"
   },


### PR DESCRIPTION
# Description

This change should have been part of the [commit](https://github.com/Financial-Times/dotcom-tool-kit/commit/331ae1a11a17da0baa7db4e0c15a10a8420b6fb8) to use the `circleci-deploy` and `heroku` plugins and moving any code out of this package, replacing it with a shim `index.js` file. The `main` field now points to `index.js`, meaning that `require`'ing the package no longer returns an error about `lib/index.js` not existing.

Also include all files in the npm package now that we aren't generating any build artefacts.

Fixes the issue seen in https://github.com/Financial-Times/platform-scripts/pull/29.

# Checklist:

- [x] My branch has been rebased onto the latest commit on main (don't merge main into your branch)
- [x] My commit messages are [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/), for example: `feat(circleci): add support for nightly workflows`, `fix: set Heroku app name for staging apps too`
