### PR TITLE
feat(jest): support jest v28 and v29

### DIFF
--- a/plugins/jest/package.json
+++ b/plugins/jest/package.json
@@ -15,7 +15,7 @@
     "tslib": "^2.3.1"
   },
   "peerDependencies": {
-    "jest-cli": "27.x",
+    "jest-cli": "27.x || 28.x || 29.x",
     "dotcom-tool-kit": "3.x"
   },
   "repository": {


### PR DESCRIPTION
release notes:
- https://jestjs.io/docs/28.x/upgrading-to-jest28
- https://jestjs.io/docs/upgrading-to-jest29

all the changes are in Jest itself, not the CLI, which means this is safe to release as a minor version. existing users of the Jest plugin will still use the version they have in `package-lock.json`. new users will i believe get v29 automatically installed. that's probably fine.
