### PR TITLE
CPP-925:  Stop force using npm 8 on circleci

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,6 @@
 version: 2.1
 
 orbs:
-  node: circleci/node@4.6.0
   orb-tools: circleci/orb-tools@10.0.5
 
 references:
@@ -102,8 +101,6 @@ jobs:
     steps:
       - checkout
       - *restore_cache
-      - node/install-npm:
-          version: '8'
       - run:
           name: Install project dependencies
           command: npm install

--- a/orb/src/jobs/setup.yml
+++ b/orb/src/jobs/setup.yml
@@ -2,6 +2,10 @@ parameters:
   executor:
     default: default
     type: executor
+  npm-version:
+    description: This value is deprecated and no longer used. We now use Node's bundled version of npm.
+    default: ''
+    type: string
 
 executor: << parameters.executor >>
 

--- a/orb/src/jobs/setup.yml
+++ b/orb/src/jobs/setup.yml
@@ -4,13 +4,17 @@ parameters:
     type: executor
   npm-version:
     description: This value is deprecated and no longer used. We now use Node's bundled version of npm.
-    default: ''
+    default: ""
     type: string
 
 executor: << parameters.executor >>
 
 steps:
   - attach-workspace
+  - when:
+      condition: << parameters.npm-version >>
+      steps:
+          - run: sudo npm install -g npm@$PARAM_NPM_VERSION
   - node/install-packages
   - persist-workspace:
       path: .

--- a/orb/src/jobs/setup.yml
+++ b/orb/src/jobs/setup.yml
@@ -2,15 +2,11 @@ parameters:
   executor:
     default: default
     type: executor
-  npm-version:
-    default: '8'
-    type: string
 
 executor: << parameters.executor >>
 
 steps:
   - attach-workspace
-  - run: sudo npm install -g npm@<<parameters.npm-version>>
   - node/install-packages
   - persist-workspace:
       path: .


### PR DESCRIPTION
This is no longer needed now all systems use atleast Node v16 which is bundled with npm v8.
