### PR TITLE
feat: cache root cypress folder

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -34,6 +34,7 @@ references:
       key: cache-v1-{{ .Branch }}-{{ checksum "./package.json" }}
       paths:
         - ./node_modules/
+        - "~/.cache/Cypress"
 
   #
   # Cache restoration


### PR DESCRIPTION
# Description

Update in Cypress requires caching of ~/cache/Cypress folder for tests to run in CircleCI


<img width="1012" alt="Screenshot 2023-08-29 at 11 28 46" src="https://github.com/Financial-Times/dotcom-tool-kit/assets/70697198/66e42105-72ca-4036-921b-51eecc409e00">


# Checklist:

- [x] My branch has been rebased onto the latest commit on main (don't merge main into your branch)
- [x] My commit messages are [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/), for example: `feat(circleci): add support for nightly workflows`, `fix: set Heroku app name for staging apps too`
