### PR TITLE
feat(cypress): pull vault env variables into local hook

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -47,13 +47,13 @@
     },
     "core/cli": {
       "name": "dotcom-tool-kit",
-      "version": "3.2.0",
+      "version": "3.2.1",
       "license": "MIT",
       "dependencies": {
         "@dotcom-tool-kit/error": "^3.1.0",
         "@dotcom-tool-kit/logger": "^3.1.1",
-        "@dotcom-tool-kit/options": "^3.1.2",
-        "@dotcom-tool-kit/types": "^3.3.0",
+        "@dotcom-tool-kit/options": "^3.1.3",
+        "@dotcom-tool-kit/types": "^3.3.1",
         "@dotcom-tool-kit/wait-for-ok": "^3.1.0",
         "cosmiconfig": "^7.0.0",
         "lodash": "^4.17.21",
@@ -67,17 +67,17 @@
         "dotcom-tool-kit": "bin/run"
       },
       "devDependencies": {
-        "@dotcom-tool-kit/babel": "^3.1.2",
-        "@dotcom-tool-kit/backend-heroku-app": "^2.1.7",
-        "@dotcom-tool-kit/circleci": "^5.3.4",
-        "@dotcom-tool-kit/circleci-deploy": "^3.2.4",
-        "@dotcom-tool-kit/eslint": "^3.1.2",
-        "@dotcom-tool-kit/frontend-app": "^3.1.8",
-        "@dotcom-tool-kit/heroku": "^3.2.2",
-        "@dotcom-tool-kit/mocha": "^3.1.2",
-        "@dotcom-tool-kit/n-test": "^3.2.2",
-        "@dotcom-tool-kit/npm": "^3.1.2",
-        "@dotcom-tool-kit/webpack": "^3.1.3",
+        "@dotcom-tool-kit/babel": "^3.1.3",
+        "@dotcom-tool-kit/backend-heroku-app": "^2.1.8",
+        "@dotcom-tool-kit/circleci": "^5.3.5",
+        "@dotcom-tool-kit/circleci-deploy": "^3.2.5",
+        "@dotcom-tool-kit/eslint": "^3.1.3",
+        "@dotcom-tool-kit/frontend-app": "^3.1.9",
+        "@dotcom-tool-kit/heroku": "^3.2.3",
+        "@dotcom-tool-kit/mocha": "^3.1.3",
+        "@dotcom-tool-kit/n-test": "^3.2.3",
+        "@dotcom-tool-kit/npm": "^3.1.3",
+        "@dotcom-tool-kit/webpack": "^3.1.4",
         "@jest/globals": "^27.4.6",
         "@types/lodash": "^4.14.185",
         "@types/node": "^16.18.23",
@@ -122,15 +122,15 @@
     },
     "core/create": {
       "name": "@dotcom-tool-kit/create",
-      "version": "3.1.9",
+      "version": "3.1.10",
       "license": "ISC",
       "dependencies": {
         "@aws-sdk/client-iam": "^3.282.0",
         "@aws-sdk/client-sts": "^3.282.0",
         "@dotcom-tool-kit/error": "^3.1.0",
         "@dotcom-tool-kit/logger": "^3.1.1",
-        "@dotcom-tool-kit/types": "^3.3.0",
-        "@dotcom-tool-kit/vault": "^3.1.2",
+        "@dotcom-tool-kit/types": "^3.3.1",
+        "@dotcom-tool-kit/vault": "^3.1.3",
         "@financial-times/package-json": "^3.0.0",
         "@octokit/rest": "^19.0.5",
         "@quarterto/parse-makefile-rules": "^1.1.0",
@@ -158,7 +158,7 @@
         "@types/pacote": "^11.1.3",
         "@types/prompts": "^2.0.14",
         "cosmiconfig": "^7.0.1",
-        "dotcom-tool-kit": "^3.2.0"
+        "dotcom-tool-kit": "^3.2.1"
       },
       "engines": {
         "node": "16.x || 18.x",
@@ -1872,10 +1872,10 @@
     },
     "lib/options": {
       "name": "@dotcom-tool-kit/options",
-      "version": "3.1.2",
+      "version": "3.1.3",
       "license": "ISC",
       "dependencies": {
-        "@dotcom-tool-kit/types": "^3.3.0",
+        "@dotcom-tool-kit/types": "^3.3.1",
         "tslib": "^2.3.1"
       },
       "engines": {
@@ -1931,7 +1931,7 @@
     },
     "lib/types": {
       "name": "@dotcom-tool-kit/types",
-      "version": "3.3.0",
+      "version": "3.3.1",
       "license": "ISC",
       "dependencies": {
         "@dotcom-tool-kit/error": "^3.1.0",
@@ -1958,12 +1958,12 @@
     },
     "lib/vault": {
       "name": "@dotcom-tool-kit/vault",
-      "version": "3.1.2",
+      "version": "3.1.3",
       "license": "ISC",
       "dependencies": {
         "@dotcom-tool-kit/error": "^3.1.0",
-        "@dotcom-tool-kit/options": "^3.1.2",
-        "@dotcom-tool-kit/types": "^3.3.0",
+        "@dotcom-tool-kit/options": "^3.1.3",
+        "@dotcom-tool-kit/types": "^3.3.1",
         "@financial-times/n-fetch": "^1.0.0-beta.12",
         "fs": "0.0.1-security",
         "os": "^0.1.2",
@@ -29292,12 +29292,12 @@
     },
     "plugins/babel": {
       "name": "@dotcom-tool-kit/babel",
-      "version": "3.1.2",
+      "version": "3.1.3",
       "license": "MIT",
       "dependencies": {
         "@dotcom-tool-kit/error": "^3.1.0",
         "@dotcom-tool-kit/logger": "^3.1.1",
-        "@dotcom-tool-kit/types": "^3.3.0",
+        "@dotcom-tool-kit/types": "^3.3.1",
         "fast-glob": "^3.2.11",
         "tslib": "^2.3.1"
       },
@@ -29322,10 +29322,10 @@
     },
     "plugins/backend-app": {
       "name": "@dotcom-tool-kit/backend-app",
-      "version": "3.1.7",
+      "version": "3.1.8",
       "license": "ISC",
       "dependencies": {
-        "@dotcom-tool-kit/backend-heroku-app": "^2.1.7"
+        "@dotcom-tool-kit/backend-heroku-app": "^2.1.8"
       },
       "engines": {
         "node": "16.x || 18.x",
@@ -29337,15 +29337,15 @@
     },
     "plugins/backend-heroku-app": {
       "name": "@dotcom-tool-kit/backend-heroku-app",
-      "version": "2.1.7",
+      "version": "2.1.8",
       "license": "ISC",
       "dependencies": {
-        "@dotcom-tool-kit/circleci-deploy": "^3.2.4",
-        "@dotcom-tool-kit/heroku": "^3.2.2",
+        "@dotcom-tool-kit/circleci-deploy": "^3.2.5",
+        "@dotcom-tool-kit/heroku": "^3.2.3",
         "@dotcom-tool-kit/husky-npm": "^4.1.0",
-        "@dotcom-tool-kit/node": "^3.2.0",
-        "@dotcom-tool-kit/npm": "^3.1.2",
-        "@dotcom-tool-kit/secret-squirrel": "^2.1.2"
+        "@dotcom-tool-kit/node": "^3.2.1",
+        "@dotcom-tool-kit/npm": "^3.1.3",
+        "@dotcom-tool-kit/secret-squirrel": "^2.1.3"
       },
       "engines": {
         "node": "16.x || 18.x",
@@ -29357,15 +29357,15 @@
     },
     "plugins/backend-serverless-app": {
       "name": "@dotcom-tool-kit/backend-serverless-app",
-      "version": "2.1.7",
+      "version": "2.1.8",
       "license": "ISC",
       "dependencies": {
-        "@dotcom-tool-kit/circleci-deploy": "^3.2.4",
+        "@dotcom-tool-kit/circleci-deploy": "^3.2.5",
         "@dotcom-tool-kit/husky-npm": "^4.1.0",
-        "@dotcom-tool-kit/node": "^3.2.0",
-        "@dotcom-tool-kit/npm": "^3.1.2",
-        "@dotcom-tool-kit/secret-squirrel": "^2.1.2",
-        "@dotcom-tool-kit/serverless": "^2.1.2"
+        "@dotcom-tool-kit/node": "^3.2.1",
+        "@dotcom-tool-kit/npm": "^3.1.3",
+        "@dotcom-tool-kit/secret-squirrel": "^2.1.3",
+        "@dotcom-tool-kit/serverless": "^2.1.3"
       },
       "engines": {
         "node": "16.x || 18.x",
@@ -29377,13 +29377,13 @@
     },
     "plugins/circleci": {
       "name": "@dotcom-tool-kit/circleci",
-      "version": "5.3.4",
+      "version": "5.3.5",
       "license": "ISC",
       "dependencies": {
         "@dotcom-tool-kit/error": "^3.1.0",
         "@dotcom-tool-kit/logger": "^3.1.1",
         "@dotcom-tool-kit/state": "^3.1.0",
-        "@dotcom-tool-kit/types": "^3.3.0",
+        "@dotcom-tool-kit/types": "^3.3.1",
         "jest-diff": "^29.5.0",
         "lodash": "^4.17.21",
         "tslib": "^2.3.1",
@@ -29407,10 +29407,10 @@
     },
     "plugins/circleci-deploy": {
       "name": "@dotcom-tool-kit/circleci-deploy",
-      "version": "3.2.4",
+      "version": "3.2.5",
       "license": "ISC",
       "dependencies": {
-        "@dotcom-tool-kit/circleci": "^5.3.4",
+        "@dotcom-tool-kit/circleci": "^5.3.5",
         "tslib": "^2.3.1"
       },
       "devDependencies": {
@@ -29431,11 +29431,11 @@
     },
     "plugins/circleci-heroku": {
       "name": "@dotcom-tool-kit/circleci-heroku",
-      "version": "3.1.7",
+      "version": "3.1.8",
       "license": "ISC",
       "dependencies": {
-        "@dotcom-tool-kit/circleci-deploy": "^3.2.4",
-        "@dotcom-tool-kit/heroku": "^3.2.2",
+        "@dotcom-tool-kit/circleci-deploy": "^3.2.5",
+        "@dotcom-tool-kit/heroku": "^3.2.3",
         "tslib": "^2.3.1"
       },
       "engines": {
@@ -29453,12 +29453,12 @@
     },
     "plugins/circleci-npm": {
       "name": "@dotcom-tool-kit/circleci-npm",
-      "version": "5.2.4",
+      "version": "5.2.5",
       "license": "ISC",
       "dependencies": {
-        "@dotcom-tool-kit/circleci": "^5.3.4",
-        "@dotcom-tool-kit/npm": "^3.1.2",
-        "@dotcom-tool-kit/types": "^3.3.0",
+        "@dotcom-tool-kit/circleci": "^5.3.5",
+        "@dotcom-tool-kit/npm": "^3.1.3",
+        "@dotcom-tool-kit/types": "^3.3.1",
         "tslib": "^2.3.1"
       },
       "engines": {
@@ -29575,13 +29575,13 @@
     },
     "plugins/component": {
       "name": "@dotcom-tool-kit/component",
-      "version": "3.1.7",
+      "version": "3.1.8",
       "license": "ISC",
       "dependencies": {
-        "@dotcom-tool-kit/circleci-npm": "^5.2.4",
+        "@dotcom-tool-kit/circleci-npm": "^5.2.5",
         "@dotcom-tool-kit/husky-npm": "^4.1.0",
-        "@dotcom-tool-kit/npm": "^3.1.2",
-        "@dotcom-tool-kit/secret-squirrel": "^2.1.2"
+        "@dotcom-tool-kit/npm": "^3.1.3",
+        "@dotcom-tool-kit/secret-squirrel": "^2.1.3"
       },
       "engines": {
         "node": "16.x || 18.x",
@@ -29595,6 +29595,9 @@
       "name": "@dotcom-tool-kit/cypress",
       "version": "3.1.0",
       "license": "ISC",
+      "dependencies": {
+        "@dotcom-tool-kit/vault": "^3.1.3"
+      },
       "engines": {
         "node": "16.x || 18.x",
         "npm": "7.x || 8.x || 9.x"
@@ -29605,12 +29608,12 @@
     },
     "plugins/eslint": {
       "name": "@dotcom-tool-kit/eslint",
-      "version": "3.1.2",
+      "version": "3.1.3",
       "license": "ISC",
       "dependencies": {
         "@dotcom-tool-kit/error": "^3.1.0",
         "@dotcom-tool-kit/logger": "^3.1.1",
-        "@dotcom-tool-kit/types": "^3.3.0",
+        "@dotcom-tool-kit/types": "^3.3.1",
         "tslib": "^2.3.1"
       },
       "devDependencies": {
@@ -29827,12 +29830,12 @@
     },
     "plugins/frontend-app": {
       "name": "@dotcom-tool-kit/frontend-app",
-      "version": "3.1.8",
+      "version": "3.1.9",
       "license": "ISC",
       "dependencies": {
-        "@dotcom-tool-kit/backend-heroku-app": "^2.1.7",
-        "@dotcom-tool-kit/upload-assets-to-s3": "^3.1.2",
-        "@dotcom-tool-kit/webpack": "^3.1.3"
+        "@dotcom-tool-kit/backend-heroku-app": "^2.1.8",
+        "@dotcom-tool-kit/upload-assets-to-s3": "^3.1.3",
+        "@dotcom-tool-kit/webpack": "^3.1.4"
       },
       "engines": {
         "node": "16.x || 18.x",
@@ -29844,16 +29847,16 @@
     },
     "plugins/heroku": {
       "name": "@dotcom-tool-kit/heroku",
-      "version": "3.2.2",
+      "version": "3.2.3",
       "license": "ISC",
       "dependencies": {
         "@dotcom-tool-kit/error": "^3.1.0",
         "@dotcom-tool-kit/logger": "^3.1.1",
-        "@dotcom-tool-kit/npm": "^3.1.2",
+        "@dotcom-tool-kit/npm": "^3.1.3",
         "@dotcom-tool-kit/package-json-hook": "^4.1.0",
         "@dotcom-tool-kit/state": "^3.1.0",
-        "@dotcom-tool-kit/types": "^3.3.0",
-        "@dotcom-tool-kit/vault": "^3.1.2",
+        "@dotcom-tool-kit/types": "^3.3.1",
+        "@dotcom-tool-kit/vault": "^3.1.3",
         "@dotcom-tool-kit/wait-for-ok": "^3.1.0",
         "@octokit/request": "^5.6.0",
         "@octokit/request-error": "^2.1.0",
@@ -29904,11 +29907,11 @@
     },
     "plugins/jest": {
       "name": "@dotcom-tool-kit/jest",
-      "version": "3.1.2",
+      "version": "3.2.0",
       "license": "ISC",
       "dependencies": {
         "@dotcom-tool-kit/logger": "^3.1.1",
-        "@dotcom-tool-kit/types": "^3.3.0",
+        "@dotcom-tool-kit/types": "^3.3.1",
         "tslib": "^2.3.1"
       },
       "devDependencies": {
@@ -29921,7 +29924,7 @@
       },
       "peerDependencies": {
         "dotcom-tool-kit": "3.x",
-        "jest-cli": "27.x"
+        "jest-cli": "27.x || 28.x || 29.x"
       }
     },
     "plugins/jest/node_modules/tslib": {
@@ -29931,12 +29934,12 @@
     },
     "plugins/lint-staged": {
       "name": "@dotcom-tool-kit/lint-staged",
-      "version": "4.1.2",
+      "version": "4.1.3",
       "license": "ISC",
       "dependencies": {
         "@dotcom-tool-kit/logger": "^3.1.1",
         "@dotcom-tool-kit/package-json-hook": "^4.1.0",
-        "@dotcom-tool-kit/types": "^3.3.0",
+        "@dotcom-tool-kit/types": "^3.3.1",
         "lint-staged": "^11.2.3",
         "tslib": "^2.3.1"
       },
@@ -29950,12 +29953,12 @@
     },
     "plugins/lint-staged-npm": {
       "name": "@dotcom-tool-kit/lint-staged-npm",
-      "version": "3.1.2",
+      "version": "3.1.3",
       "license": "ISC",
       "dependencies": {
         "@dotcom-tool-kit/husky-npm": "^4.1.0",
-        "@dotcom-tool-kit/lint-staged": "^4.1.2",
-        "@dotcom-tool-kit/options": "^3.1.2",
+        "@dotcom-tool-kit/lint-staged": "^4.1.3",
+        "@dotcom-tool-kit/options": "^3.1.3",
         "tslib": "^2.3.1"
       },
       "engines": {
@@ -30028,12 +30031,12 @@
     },
     "plugins/mocha": {
       "name": "@dotcom-tool-kit/mocha",
-      "version": "3.1.2",
+      "version": "3.1.3",
       "license": "ISC",
       "dependencies": {
         "@dotcom-tool-kit/error": "^3.1.0",
         "@dotcom-tool-kit/logger": "^3.1.1",
-        "@dotcom-tool-kit/types": "^3.3.0",
+        "@dotcom-tool-kit/types": "^3.3.1",
         "glob": "^7.1.7",
         "tslib": "^2.3.1"
       },
@@ -30059,12 +30062,12 @@
     },
     "plugins/n-test": {
       "name": "@dotcom-tool-kit/n-test",
-      "version": "3.2.2",
+      "version": "3.2.3",
       "license": "ISC",
       "dependencies": {
         "@dotcom-tool-kit/logger": "^3.1.1",
         "@dotcom-tool-kit/state": "^3.1.0",
-        "@dotcom-tool-kit/types": "^3.3.0",
+        "@dotcom-tool-kit/types": "^3.3.1",
         "@financial-times/n-test": "^6.1.0-beta.1",
         "tslib": "^2.3.1"
       },
@@ -30180,14 +30183,14 @@
     },
     "plugins/next-router": {
       "name": "@dotcom-tool-kit/next-router",
-      "version": "3.2.0",
+      "version": "3.2.1",
       "license": "ISC",
       "dependencies": {
         "@dotcom-tool-kit/error": "^3.1.0",
         "@dotcom-tool-kit/logger": "^3.1.1",
         "@dotcom-tool-kit/state": "^3.1.0",
-        "@dotcom-tool-kit/types": "^3.3.0",
-        "@dotcom-tool-kit/vault": "^3.1.2",
+        "@dotcom-tool-kit/types": "^3.3.1",
+        "@dotcom-tool-kit/vault": "^3.1.3",
         "ft-next-router": "^1.0.0",
         "tslib": "^2.3.1"
       },
@@ -30206,13 +30209,13 @@
     },
     "plugins/node": {
       "name": "@dotcom-tool-kit/node",
-      "version": "3.2.0",
+      "version": "3.2.1",
       "license": "ISC",
       "dependencies": {
         "@dotcom-tool-kit/error": "^3.1.0",
         "@dotcom-tool-kit/state": "^3.1.0",
-        "@dotcom-tool-kit/types": "^3.3.0",
-        "@dotcom-tool-kit/vault": "^3.1.2",
+        "@dotcom-tool-kit/types": "^3.3.1",
+        "@dotcom-tool-kit/vault": "^3.1.3",
         "get-port": "^5.1.1",
         "tslib": "^2.3.1",
         "wait-port": "^0.2.9"
@@ -30232,13 +30235,13 @@
     },
     "plugins/nodemon": {
       "name": "@dotcom-tool-kit/nodemon",
-      "version": "3.2.0",
+      "version": "3.2.1",
       "license": "ISC",
       "dependencies": {
         "@dotcom-tool-kit/error": "^3.1.0",
         "@dotcom-tool-kit/state": "^3.1.0",
-        "@dotcom-tool-kit/types": "^3.3.0",
-        "@dotcom-tool-kit/vault": "^3.1.2",
+        "@dotcom-tool-kit/types": "^3.3.1",
+        "@dotcom-tool-kit/vault": "^3.1.3",
         "get-port": "^5.1.1",
         "tslib": "^2.3.1"
       },
@@ -30261,14 +30264,14 @@
     },
     "plugins/npm": {
       "name": "@dotcom-tool-kit/npm",
-      "version": "3.1.2",
+      "version": "3.1.3",
       "license": "ISC",
       "dependencies": {
         "@actions/exec": "^1.1.0",
         "@dotcom-tool-kit/error": "^3.1.0",
         "@dotcom-tool-kit/package-json-hook": "^4.1.0",
         "@dotcom-tool-kit/state": "^3.1.0",
-        "@dotcom-tool-kit/types": "^3.3.0",
+        "@dotcom-tool-kit/types": "^3.3.1",
         "libnpmpack": "^3.1.0",
         "libnpmpublish": "^5.0.1",
         "pacote": "^12.0.3",
@@ -30429,10 +30432,10 @@
     },
     "plugins/pa11y": {
       "name": "@dotcom-tool-kit/pa11y",
-      "version": "0.4.3",
+      "version": "0.4.4",
       "license": "ISC",
       "dependencies": {
-        "@dotcom-tool-kit/types": "^3.3.0",
+        "@dotcom-tool-kit/types": "^3.3.1",
         "pa11y-ci": "^3.0.1",
         "tslib": "^2.3.1"
       },
@@ -30454,13 +30457,13 @@
     },
     "plugins/prettier": {
       "name": "@dotcom-tool-kit/prettier",
-      "version": "3.1.2",
+      "version": "3.1.3",
       "license": "ISC",
       "dependencies": {
         "@dotcom-tool-kit/error": "^3.1.0",
         "@dotcom-tool-kit/logger": "^3.1.1",
         "@dotcom-tool-kit/package-json-hook": "^4.1.0",
-        "@dotcom-tool-kit/types": "^3.3.0",
+        "@dotcom-tool-kit/types": "^3.3.1",
         "fast-glob": "^3.2.7",
         "hook-std": "^2.0.0",
         "prettier": "^2.2.1",
@@ -30487,11 +30490,11 @@
     },
     "plugins/secret-squirrel": {
       "name": "@dotcom-tool-kit/secret-squirrel",
-      "version": "2.1.2",
+      "version": "2.1.3",
       "license": "ISC",
       "dependencies": {
         "@dotcom-tool-kit/logger": "^3.1.1",
-        "@dotcom-tool-kit/types": "^3.3.0",
+        "@dotcom-tool-kit/types": "^3.3.1",
         "tslib": "^2.3.1"
       },
       "engines": {
@@ -30510,13 +30513,13 @@
     },
     "plugins/serverless": {
       "name": "@dotcom-tool-kit/serverless",
-      "version": "2.1.2",
+      "version": "2.1.3",
       "license": "ISC",
       "dependencies": {
         "@dotcom-tool-kit/error": "^3.1.0",
         "@dotcom-tool-kit/state": "^3.1.0",
-        "@dotcom-tool-kit/types": "^3.3.0",
-        "@dotcom-tool-kit/vault": "^3.1.2",
+        "@dotcom-tool-kit/types": "^3.3.1",
+        "@dotcom-tool-kit/vault": "^3.1.3",
         "get-port": "^5.1.1",
         "tslib": "^2.3.1",
         "wait-port": "^0.2.9"
@@ -30537,11 +30540,11 @@
     },
     "plugins/typescript": {
       "name": "@dotcom-tool-kit/typescript",
-      "version": "2.1.2",
+      "version": "2.1.3",
       "license": "ISC",
       "dependencies": {
         "@dotcom-tool-kit/logger": "^3.1.1",
-        "@dotcom-tool-kit/types": "^3.3.0"
+        "@dotcom-tool-kit/types": "^3.3.1"
       },
       "devDependencies": {
         "@jest/globals": "^29.3.1",
@@ -30745,13 +30748,13 @@
     },
     "plugins/upload-assets-to-s3": {
       "name": "@dotcom-tool-kit/upload-assets-to-s3",
-      "version": "3.1.2",
+      "version": "3.1.3",
       "license": "ISC",
       "dependencies": {
         "@aws-sdk/client-s3": "^3.256.0",
         "@dotcom-tool-kit/error": "^3.1.0",
         "@dotcom-tool-kit/logger": "^3.1.1",
-        "@dotcom-tool-kit/types": "^3.3.0",
+        "@dotcom-tool-kit/types": "^3.3.1",
         "glob": "^7.1.6",
         "mime": "^2.5.2",
         "tslib": "^2.3.1"
@@ -30779,12 +30782,12 @@
     },
     "plugins/webpack": {
       "name": "@dotcom-tool-kit/webpack",
-      "version": "3.1.3",
+      "version": "3.1.4",
       "license": "MIT",
       "dependencies": {
         "@dotcom-tool-kit/error": "^3.1.0",
         "@dotcom-tool-kit/logger": "^3.1.1",
-        "@dotcom-tool-kit/types": "^3.3.0",
+        "@dotcom-tool-kit/types": "^3.3.1",
         "tslib": "^2.3.1",
         "webpack-cli": "^4.6.0"
       },
@@ -34681,7 +34684,7 @@
         "@babel/preset-env": "^7.16.11",
         "@dotcom-tool-kit/error": "^3.1.0",
         "@dotcom-tool-kit/logger": "^3.1.1",
-        "@dotcom-tool-kit/types": "^3.3.0",
+        "@dotcom-tool-kit/types": "^3.3.1",
         "@jest/globals": "^27.4.6",
         "fast-glob": "^3.2.11",
         "tslib": "^2.3.1",
@@ -34698,29 +34701,29 @@
     "@dotcom-tool-kit/backend-app": {
       "version": "file:plugins/backend-app",
       "requires": {
-        "@dotcom-tool-kit/backend-heroku-app": "^2.1.7"
+        "@dotcom-tool-kit/backend-heroku-app": "^2.1.8"
       }
     },
     "@dotcom-tool-kit/backend-heroku-app": {
       "version": "file:plugins/backend-heroku-app",
       "requires": {
-        "@dotcom-tool-kit/circleci-deploy": "^3.2.4",
-        "@dotcom-tool-kit/heroku": "^3.2.2",
+        "@dotcom-tool-kit/circleci-deploy": "^3.2.5",
+        "@dotcom-tool-kit/heroku": "^3.2.3",
         "@dotcom-tool-kit/husky-npm": "^4.1.0",
-        "@dotcom-tool-kit/node": "^3.2.0",
-        "@dotcom-tool-kit/npm": "^3.1.2",
-        "@dotcom-tool-kit/secret-squirrel": "^2.1.2"
+        "@dotcom-tool-kit/node": "^3.2.1",
+        "@dotcom-tool-kit/npm": "^3.1.3",
+        "@dotcom-tool-kit/secret-squirrel": "^2.1.3"
       }
     },
     "@dotcom-tool-kit/backend-serverless-app": {
       "version": "file:plugins/backend-serverless-app",
       "requires": {
-        "@dotcom-tool-kit/circleci-deploy": "^3.2.4",
+        "@dotcom-tool-kit/circleci-deploy": "^3.2.5",
         "@dotcom-tool-kit/husky-npm": "^4.1.0",
-        "@dotcom-tool-kit/node": "^3.2.0",
-        "@dotcom-tool-kit/npm": "^3.1.2",
-        "@dotcom-tool-kit/secret-squirrel": "^2.1.2",
-        "@dotcom-tool-kit/serverless": "^2.1.2"
+        "@dotcom-tool-kit/node": "^3.2.1",
+        "@dotcom-tool-kit/npm": "^3.1.3",
+        "@dotcom-tool-kit/secret-squirrel": "^2.1.3",
+        "@dotcom-tool-kit/serverless": "^2.1.3"
       }
     },
     "@dotcom-tool-kit/circleci": {
@@ -34729,7 +34732,7 @@
         "@dotcom-tool-kit/error": "^3.1.0",
         "@dotcom-tool-kit/logger": "^3.1.1",
         "@dotcom-tool-kit/state": "^3.1.0",
-        "@dotcom-tool-kit/types": "^3.3.0",
+        "@dotcom-tool-kit/types": "^3.3.1",
         "@jest/globals": "^27.4.6",
         "@types/jest": "^27.4.0",
         "@types/js-yaml": "^4.0.3",
@@ -34816,7 +34819,7 @@
     "@dotcom-tool-kit/circleci-deploy": {
       "version": "file:plugins/circleci-deploy",
       "requires": {
-        "@dotcom-tool-kit/circleci": "^5.3.4",
+        "@dotcom-tool-kit/circleci": "^5.3.5",
         "tslib": "^2.3.1",
         "winston": "^3.5.1"
       },
@@ -34831,8 +34834,8 @@
     "@dotcom-tool-kit/circleci-heroku": {
       "version": "file:plugins/circleci-heroku",
       "requires": {
-        "@dotcom-tool-kit/circleci-deploy": "^3.2.4",
-        "@dotcom-tool-kit/heroku": "^3.2.2",
+        "@dotcom-tool-kit/circleci-deploy": "^3.2.5",
+        "@dotcom-tool-kit/heroku": "^3.2.3",
         "tslib": "^2.3.1"
       },
       "dependencies": {
@@ -34846,9 +34849,9 @@
     "@dotcom-tool-kit/circleci-npm": {
       "version": "file:plugins/circleci-npm",
       "requires": {
-        "@dotcom-tool-kit/circleci": "^5.3.4",
-        "@dotcom-tool-kit/npm": "^3.1.2",
-        "@dotcom-tool-kit/types": "^3.3.0",
+        "@dotcom-tool-kit/circleci": "^5.3.5",
+        "@dotcom-tool-kit/npm": "^3.1.3",
+        "@dotcom-tool-kit/types": "^3.3.1",
         "tslib": "^2.3.1"
       },
       "dependencies": {
@@ -34862,10 +34865,10 @@
     "@dotcom-tool-kit/component": {
       "version": "file:plugins/component",
       "requires": {
-        "@dotcom-tool-kit/circleci-npm": "^5.2.4",
+        "@dotcom-tool-kit/circleci-npm": "^5.2.5",
         "@dotcom-tool-kit/husky-npm": "^4.1.0",
-        "@dotcom-tool-kit/npm": "^3.1.2",
-        "@dotcom-tool-kit/secret-squirrel": "^2.1.2"
+        "@dotcom-tool-kit/npm": "^3.1.3",
+        "@dotcom-tool-kit/secret-squirrel": "^2.1.3"
       }
     },
     "@dotcom-tool-kit/create": {
@@ -34875,8 +34878,8 @@
         "@aws-sdk/client-sts": "^3.282.0",
         "@dotcom-tool-kit/error": "^3.1.0",
         "@dotcom-tool-kit/logger": "^3.1.1",
-        "@dotcom-tool-kit/types": "^3.3.0",
-        "@dotcom-tool-kit/vault": "^3.1.2",
+        "@dotcom-tool-kit/types": "^3.3.1",
+        "@dotcom-tool-kit/vault": "^3.1.3",
         "@financial-times/package-json": "^3.0.0",
         "@octokit/rest": "^19.0.5",
         "@quarterto/parse-makefile-rules": "^1.1.0",
@@ -34889,7 +34892,7 @@
         "cli-highlight": "^2.1.11",
         "code-suggester": "^4.3.0",
         "cosmiconfig": "^7.0.1",
-        "dotcom-tool-kit": "^3.2.0",
+        "dotcom-tool-kit": "^3.2.1",
         "import-cwd": "^3.0.0",
         "komatsu": "^1.3.0",
         "lodash": "^4.17.21",
@@ -35618,7 +35621,9 @@
     },
     "@dotcom-tool-kit/cypress": {
       "version": "file:plugins/cypress",
-      "requires": {}
+      "requires": {
+        "@dotcom-tool-kit/vault": "^3.1.3"
+      }
     },
     "@dotcom-tool-kit/error": {
       "version": "file:lib/error",
@@ -35638,7 +35643,7 @@
       "requires": {
         "@dotcom-tool-kit/error": "^3.1.0",
         "@dotcom-tool-kit/logger": "^3.1.1",
-        "@dotcom-tool-kit/types": "^3.3.0",
+        "@dotcom-tool-kit/types": "^3.3.1",
         "@jest/globals": "^27.4.6",
         "@types/eslint": "^7.2.13",
         "eslint": "^8.15.0",
@@ -35784,9 +35789,9 @@
     "@dotcom-tool-kit/frontend-app": {
       "version": "file:plugins/frontend-app",
       "requires": {
-        "@dotcom-tool-kit/backend-heroku-app": "^2.1.7",
-        "@dotcom-tool-kit/upload-assets-to-s3": "^3.1.2",
-        "@dotcom-tool-kit/webpack": "^3.1.3"
+        "@dotcom-tool-kit/backend-heroku-app": "^2.1.8",
+        "@dotcom-tool-kit/upload-assets-to-s3": "^3.1.3",
+        "@dotcom-tool-kit/webpack": "^3.1.4"
       }
     },
     "@dotcom-tool-kit/heroku": {
@@ -35794,11 +35799,11 @@
       "requires": {
         "@dotcom-tool-kit/error": "^3.1.0",
         "@dotcom-tool-kit/logger": "^3.1.1",
-        "@dotcom-tool-kit/npm": "^3.1.2",
+        "@dotcom-tool-kit/npm": "^3.1.3",
         "@dotcom-tool-kit/package-json-hook": "^4.1.0",
         "@dotcom-tool-kit/state": "^3.1.0",
-        "@dotcom-tool-kit/types": "^3.3.0",
-        "@dotcom-tool-kit/vault": "^3.1.2",
+        "@dotcom-tool-kit/types": "^3.3.1",
+        "@dotcom-tool-kit/vault": "^3.1.3",
         "@dotcom-tool-kit/wait-for-ok": "^3.1.0",
         "@octokit/request": "^5.6.0",
         "@octokit/request-error": "^2.1.0",
@@ -35836,7 +35841,7 @@
       "version": "file:plugins/jest",
       "requires": {
         "@dotcom-tool-kit/logger": "^3.1.1",
-        "@dotcom-tool-kit/types": "^3.3.0",
+        "@dotcom-tool-kit/types": "^3.3.1",
         "@jest/globals": "^27.4.6",
         "tslib": "^2.3.1",
         "winston": "^3.5.1"
@@ -35854,7 +35859,7 @@
       "requires": {
         "@dotcom-tool-kit/logger": "^3.1.1",
         "@dotcom-tool-kit/package-json-hook": "^4.1.0",
-        "@dotcom-tool-kit/types": "^3.3.0",
+        "@dotcom-tool-kit/types": "^3.3.1",
         "lint-staged": "^11.2.3",
         "tslib": "^2.3.1"
       },
@@ -35901,8 +35906,8 @@
       "version": "file:plugins/lint-staged-npm",
       "requires": {
         "@dotcom-tool-kit/husky-npm": "^4.1.0",
-        "@dotcom-tool-kit/lint-staged": "^4.1.2",
-        "@dotcom-tool-kit/options": "^3.1.2",
+        "@dotcom-tool-kit/lint-staged": "^4.1.3",
+        "@dotcom-tool-kit/options": "^3.1.3",
         "tslib": "^2.3.1"
       },
       "dependencies": {
@@ -35938,7 +35943,7 @@
       "requires": {
         "@dotcom-tool-kit/error": "^3.1.0",
         "@dotcom-tool-kit/logger": "^3.1.1",
-        "@dotcom-tool-kit/types": "^3.3.0",
+        "@dotcom-tool-kit/types": "^3.3.1",
         "@jest/globals": "^27.4.6",
         "@types/glob": "^7.1.3",
         "@types/mocha": "^8.2.2",
@@ -35959,7 +35964,7 @@
       "requires": {
         "@dotcom-tool-kit/logger": "^3.1.1",
         "@dotcom-tool-kit/state": "^3.1.0",
-        "@dotcom-tool-kit/types": "^3.3.0",
+        "@dotcom-tool-kit/types": "^3.3.1",
         "@financial-times/n-test": "^6.1.0-beta.1",
         "@jest/globals": "^27.4.6",
         "@types/jest": "^27.4.0",
@@ -36049,8 +36054,8 @@
         "@dotcom-tool-kit/error": "^3.1.0",
         "@dotcom-tool-kit/logger": "^3.1.1",
         "@dotcom-tool-kit/state": "^3.1.0",
-        "@dotcom-tool-kit/types": "^3.3.0",
-        "@dotcom-tool-kit/vault": "^3.1.2",
+        "@dotcom-tool-kit/types": "^3.3.1",
+        "@dotcom-tool-kit/vault": "^3.1.3",
         "ft-next-router": "^1.0.0",
         "tslib": "^2.3.1"
       },
@@ -36067,8 +36072,8 @@
       "requires": {
         "@dotcom-tool-kit/error": "^3.1.0",
         "@dotcom-tool-kit/state": "^3.1.0",
-        "@dotcom-tool-kit/types": "^3.3.0",
-        "@dotcom-tool-kit/vault": "^3.1.2",
+        "@dotcom-tool-kit/types": "^3.3.1",
+        "@dotcom-tool-kit/vault": "^3.1.3",
         "get-port": "^5.1.1",
         "tslib": "^2.3.1",
         "wait-port": "^0.2.9"
@@ -36086,8 +36091,8 @@
       "requires": {
         "@dotcom-tool-kit/error": "^3.1.0",
         "@dotcom-tool-kit/state": "^3.1.0",
-        "@dotcom-tool-kit/types": "^3.3.0",
-        "@dotcom-tool-kit/vault": "^3.1.2",
+        "@dotcom-tool-kit/types": "^3.3.1",
+        "@dotcom-tool-kit/vault": "^3.1.3",
         "@types/nodemon": "^1.19.1",
         "get-port": "^5.1.1",
         "tslib": "^2.3.1"
@@ -36107,7 +36112,7 @@
         "@dotcom-tool-kit/error": "^3.1.0",
         "@dotcom-tool-kit/package-json-hook": "^4.1.0",
         "@dotcom-tool-kit/state": "^3.1.0",
-        "@dotcom-tool-kit/types": "^3.3.0",
+        "@dotcom-tool-kit/types": "^3.3.1",
         "@types/libnpmpublish": "^4.0.1",
         "@types/pacote": "^11.1.3",
         "@types/tar": "^6.1.1",
@@ -36224,7 +36229,7 @@
     "@dotcom-tool-kit/options": {
       "version": "file:lib/options",
       "requires": {
-        "@dotcom-tool-kit/types": "^3.3.0",
+        "@dotcom-tool-kit/types": "^3.3.1",
         "tslib": "^2.3.1"
       },
       "dependencies": {
@@ -36238,7 +36243,7 @@
     "@dotcom-tool-kit/pa11y": {
       "version": "file:plugins/pa11y",
       "requires": {
-        "@dotcom-tool-kit/types": "^3.3.0",
+        "@dotcom-tool-kit/types": "^3.3.1",
         "@types/pa11y": "^5.3.4",
         "pa11y-ci": "^3.0.1",
         "tslib": "^2.3.1"
@@ -36275,7 +36280,7 @@
         "@dotcom-tool-kit/error": "^3.1.0",
         "@dotcom-tool-kit/logger": "^3.1.1",
         "@dotcom-tool-kit/package-json-hook": "^4.1.0",
-        "@dotcom-tool-kit/types": "^3.3.0",
+        "@dotcom-tool-kit/types": "^3.3.1",
         "@jest/globals": "^27.4.6",
         "fast-glob": "^3.2.7",
         "hook-std": "^2.0.0",
@@ -36935,7 +36940,7 @@
       "version": "file:plugins/secret-squirrel",
       "requires": {
         "@dotcom-tool-kit/logger": "^3.1.1",
-        "@dotcom-tool-kit/types": "^3.3.0",
+        "@dotcom-tool-kit/types": "^3.3.1",
         "tslib": "^2.3.1"
       },
       "dependencies": {
@@ -36951,8 +36956,8 @@
       "requires": {
         "@dotcom-tool-kit/error": "^3.1.0",
         "@dotcom-tool-kit/state": "^3.1.0",
-        "@dotcom-tool-kit/types": "^3.3.0",
-        "@dotcom-tool-kit/vault": "^3.1.2",
+        "@dotcom-tool-kit/types": "^3.3.1",
+        "@dotcom-tool-kit/vault": "^3.1.3",
         "get-port": "^5.1.1",
         "tslib": "^2.3.1",
         "wait-port": "^0.2.9"
@@ -37003,7 +37008,7 @@
       "version": "file:plugins/typescript",
       "requires": {
         "@dotcom-tool-kit/logger": "^3.1.1",
-        "@dotcom-tool-kit/types": "^3.3.0",
+        "@dotcom-tool-kit/types": "^3.3.1",
         "@jest/globals": "^29.3.1",
         "typescript": "^4.9.4",
         "winston": "^3.8.2"
@@ -37168,7 +37173,7 @@
         "@aws-sdk/types": "^3.13.1",
         "@dotcom-tool-kit/error": "^3.1.0",
         "@dotcom-tool-kit/logger": "^3.1.1",
-        "@dotcom-tool-kit/types": "^3.3.0",
+        "@dotcom-tool-kit/types": "^3.3.1",
         "@jest/globals": "^27.4.6",
         "@types/glob": "^7.1.3",
         "@types/jest": "^27.4.0",
@@ -37190,8 +37195,8 @@
       "version": "file:lib/vault",
       "requires": {
         "@dotcom-tool-kit/error": "^3.1.0",
-        "@dotcom-tool-kit/options": "^3.1.2",
-        "@dotcom-tool-kit/types": "^3.3.0",
+        "@dotcom-tool-kit/options": "^3.1.3",
+        "@dotcom-tool-kit/types": "^3.3.1",
         "@financial-times/n-fetch": "^1.0.0-beta.12",
         "@types/jest": "^27.0.2",
         "fs": "0.0.1-security",
@@ -37236,7 +37241,7 @@
       "requires": {
         "@dotcom-tool-kit/error": "^3.1.0",
         "@dotcom-tool-kit/logger": "^3.1.1",
-        "@dotcom-tool-kit/types": "^3.3.0",
+        "@dotcom-tool-kit/types": "^3.3.1",
         "@jest/globals": "^27.4.6",
         "ts-node": "^10.0.0",
         "tslib": "^2.3.1",
@@ -42863,22 +42868,22 @@
     "dotcom-tool-kit": {
       "version": "file:core/cli",
       "requires": {
-        "@dotcom-tool-kit/babel": "^3.1.2",
-        "@dotcom-tool-kit/backend-heroku-app": "^2.1.7",
-        "@dotcom-tool-kit/circleci": "^5.3.4",
-        "@dotcom-tool-kit/circleci-deploy": "^3.2.4",
+        "@dotcom-tool-kit/babel": "^3.1.3",
+        "@dotcom-tool-kit/backend-heroku-app": "^2.1.8",
+        "@dotcom-tool-kit/circleci": "^5.3.5",
+        "@dotcom-tool-kit/circleci-deploy": "^3.2.5",
         "@dotcom-tool-kit/error": "^3.1.0",
-        "@dotcom-tool-kit/eslint": "^3.1.2",
-        "@dotcom-tool-kit/frontend-app": "^3.1.8",
-        "@dotcom-tool-kit/heroku": "^3.2.2",
+        "@dotcom-tool-kit/eslint": "^3.1.3",
+        "@dotcom-tool-kit/frontend-app": "^3.1.9",
+        "@dotcom-tool-kit/heroku": "^3.2.3",
         "@dotcom-tool-kit/logger": "^3.1.1",
-        "@dotcom-tool-kit/mocha": "^3.1.2",
-        "@dotcom-tool-kit/n-test": "^3.2.2",
-        "@dotcom-tool-kit/npm": "^3.1.2",
-        "@dotcom-tool-kit/options": "^3.1.2",
-        "@dotcom-tool-kit/types": "^3.3.0",
+        "@dotcom-tool-kit/mocha": "^3.1.3",
+        "@dotcom-tool-kit/n-test": "^3.2.3",
+        "@dotcom-tool-kit/npm": "^3.1.3",
+        "@dotcom-tool-kit/options": "^3.1.3",
+        "@dotcom-tool-kit/types": "^3.3.1",
         "@dotcom-tool-kit/wait-for-ok": "^3.1.0",
-        "@dotcom-tool-kit/webpack": "^3.1.3",
+        "@dotcom-tool-kit/webpack": "^3.1.4",
         "@jest/globals": "^27.4.6",
         "@types/lodash": "^4.14.185",
         "@types/node": "^16.18.23",

--- a/plugins/cypress/package.json
+++ b/plugins/cypress/package.json
@@ -20,6 +20,9 @@
     "/lib",
     ".toolkitrc.yml"
   ],
+  "dependencies": {
+    "@dotcom-tool-kit/vault": "^3.1.3"
+  },
   "peerDependencies": {
     "dotcom-tool-kit": "3.x"
   },

--- a/plugins/cypress/src/tasks/cypress.ts
+++ b/plugins/cypress/src/tasks/cypress.ts
@@ -3,6 +3,7 @@ import { hookFork, waitOnExit } from '@dotcom-tool-kit/logger'
 import { readState } from '@dotcom-tool-kit/state'
 import { Task } from '@dotcom-tool-kit/types'
 import { CypressSchema } from '@dotcom-tool-kit/types/src/schema/cypress'
+import { VaultEnvVars } from '@dotcom-tool-kit/vault'
 
 export class CypressLocal extends Task<typeof CypressSchema> {
   async run(): Promise<void> {
@@ -11,7 +12,12 @@ export class CypressLocal extends Task<typeof CypressSchema> {
       cypressEnv.CYPRESS_BASE_URL = this.options.localUrl
     }
 
-    const env = { ...process.env, ...cypressEnv }
+    const vault = new VaultEnvVars(this.logger, {
+      environment: 'development'
+    })
+    const vaultEnv = await vault.get()
+
+    const env = { ...process.env, ...cypressEnv, ...vaultEnv }
     this.logger.info('running cypress' + (env.CYPRESS_BASE_URL ? ` against ${env.CYPRESS_BASE_URL}` : ''))
     const testProcess = spawn('cypress', ['run'], { env })
     hookFork(this.logger, 'cypress', testProcess)


### PR DESCRIPTION
# Description

`next-appetite` currently [extends the CypressLocal task ](https://github.com/Financial-Times/next-appetite/blob/main/toolkit/cypress/index.js)to pull in vault environment variables.

We want to do similar for `cp-content-pipeline` therefore we should have this logic in tool-kit.
# Checklist:

- [x] My branch has been rebased onto the latest commit on main (don't merge main into your branch)
- [x] My commit messages are [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/), for example: `feat(circleci): add support for nightly workflows`, `fix: set Heroku app name for staging apps too`
