### PR TITLE
CPP-1695: recover $PATH env

### DIFF
--- a/plugins/serverless/src/tasks/deploy.ts
+++ b/plugins/serverless/src/tasks/deploy.ts
@@ -35,7 +35,10 @@ export default class ServerlessDeploy extends Task<typeof ServerlessSchema> {
       }
 
       const child = spawn('serverless', args, {
-        env: dopplerEnv
+        env: {
+          ...process.env,
+          ...dopplerEnv
+        }
       })
 
       hookFork(this.logger, 'serverless', child)

--- a/plugins/serverless/src/tasks/provision.ts
+++ b/plugins/serverless/src/tasks/provision.ts
@@ -42,7 +42,10 @@ export default class ServerlessProvision extends Task<typeof ServerlessSchema> {
     }
 
     const child = spawn('serverless', args, {
-      env: dopplerEnv
+      env: {
+        ...process.env,
+        ...dopplerEnv
+      }
     })
 
     hookFork(this.logger, 'serverless', child)


### PR DESCRIPTION
# Description

CI failed to provision a review app as the it could not find the serverless command which would be in the $PATH.

https://app.circleci.com/pipelines/github/Financial-Times/next-url-management-api/1710/workflows/f401f0d4-88bf-4c89-a71e-e91b21019b63/jobs/7209?invite=true#step-106-1081_30

# Checklist:

- [x] My branch has been rebased onto the latest commit on main (don't merge main into your branch)
- [x] My commit messages are [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/), for example: `feat(circleci): add support for nightly workflows`, `fix: set Heroku app name for staging apps too`
