### PR TITLE
draft: Speculative fix for Heroku URLs changing

### DIFF
--- a/plugins/heroku/src/gtg.ts
+++ b/plugins/heroku/src/gtg.ts
@@ -5,19 +5,23 @@ import { waitForOk } from '@dotcom-tool-kit/wait-for-ok'
 import { State, writeState } from '@dotcom-tool-kit/state'
 
 async function gtg(logger: Logger, appIdName: string, environment: keyof State, id = true): Promise<void> {
-  let appName = appIdName
-  // gtg called with id rather than name; get name from Heroku
-  if (id) {
-    const appDetails = await heroku
-      .get<HerokuApiResGetGtg>(`/apps/${appIdName}`)
-      .catch(extractHerokuError(`getting app name for app ${appIdName}`))
-    appName = appDetails.name
+  const appDetails = await heroku
+    .get<HerokuApiResGetGtg>(`/apps/${appIdName}`)
+    .catch(extractHerokuError(`getting app name for app ${appIdName}`))
+  let appName = appDetails.name
+  let url = `https://${appName}.herokuapp.com/__gtg`
+
+  // prefer the application web_url for the gtg endpoint.
+  if (appDetails.web_url) {
+    const webUrl = new URL(appDetails.web_url)
+    webUrl.path = "/__gtg"
+    url = webUrl
   }
+  
   // save name to state file
   writeState(environment, {
     appName
   })
-  const url = `https://${appName}.herokuapp.com/__gtg`
 
   return waitForOk(logger, url)
 }

--- a/plugins/heroku/src/gtg.ts
+++ b/plugins/heroku/src/gtg.ts
@@ -15,7 +15,7 @@ async function gtg(logger: Logger, appIdName: string, environment: keyof State, 
   if (appDetails.web_url) {
     const webUrl = new URL(appDetails.web_url)
     webUrl.path = "/__gtg"
-    url = webUrl
+    url = webUrl.href
   }
   
   // save name to state file


### PR DESCRIPTION
# Why?
Heroku have recently changed their URL scheme for staging (and possibly other environments).

# What?
*Always* speak to Heroku and retrieve the web_url property for the current application.
