### PR TITLE
CPP-1509 Support new Heroku apps which now include random identifier

### DIFF
--- a/plugins/heroku/src/declarations.d.ts
+++ b/plugins/heroku/src/declarations.d.ts
@@ -57,6 +57,7 @@ declare module 'heroku-client' {
 
   export type HerokuApiResGetGtg = {
     name: string
+    web_url: string | null
   }
 
   export type HerokuApiResPost = {

--- a/plugins/heroku/src/promoteStagingToProduction.ts
+++ b/plugins/heroku/src/promoteStagingToProduction.ts
@@ -29,7 +29,7 @@ async function promoteStagingToProduction(
         }
       })
       .catch(extractHerokuError(`promoting app ID ${appId} to production`))
-      .then((response) => gtg(logger, response.app.name, 'production', false))
+      .then((response) => gtg(logger, response.app.name, 'production'))
   )
 
   for (const id of appIds) {

--- a/plugins/heroku/src/tasks/staging.ts
+++ b/plugins/heroku/src/tasks/staging.ts
@@ -39,7 +39,7 @@ export default class HerokuStaging extends Task<typeof HerokuSchema> {
       //scale up staging
       await scaleDyno(this.logger, appName, 1)
 
-      await gtg(this.logger, appName, 'staging', false)
+      await gtg(this.logger, appName, 'staging')
     } catch (err) {
       if (err instanceof ToolKitError) {
         throw err

--- a/plugins/heroku/test/gtg.test.ts
+++ b/plugins/heroku/test/gtg.test.ts
@@ -8,13 +8,18 @@ import winston, { Logger } from 'winston'
 const logger = (winston as unknown) as Logger
 
 const appName = 'test-app-name'
+const makeUrl = (appName: string) => `https://${appName}-1234567890ab.herokuapp.com/`
 
 jest.mock('../src/herokuClient', () => {
   const originalModule = jest.requireActual('../src/herokuClient') as object
   return {
     __esmodule: true,
     ...originalModule,
-    get: jest.fn(async () => ({ name: appName }))
+    get: jest.fn(async (apiPath: string) => {
+      // gets app ID/name parameter and 'resolves' IDs to names
+      const appName = apiPath.slice(apiPath.lastIndexOf('/') + 1).replace('-id', '-name')
+      return { name: appName, web_url: makeUrl(appName) }
+    })
   }
 })
 
@@ -27,43 +32,35 @@ jest.mock('@dotcom-tool-kit/state', () => {
 jest.mock('@dotcom-tool-kit/wait-for-ok', () => {
   return {
     waitForOk: jest.fn((_, url: string) => {
-      return url.includes('test-app-name') ? Promise.resolve() : Promise.reject(new Error(`😢`))
+      return url.includes(appName) ? Promise.resolve() : Promise.reject(new Error(`😢`))
     })
   }
 })
 
 describe('gtg', () => {
-  it('makes an api call to heroku if passed an id', async () => {
+  it('makes an api call to heroku to get name from ID', async () => {
     await gtg(logger, 'test-app-id', 'staging')
 
     expect(heroku.get).toHaveBeenCalledTimes(1)
   })
 
-  it(`doesn't make an api call to heroku if passed a name`, async () => {
-    await gtg(logger, appName, 'staging', false)
-
-    expect(heroku.get).toHaveBeenCalledTimes(0)
-  })
-
   it('writes app name to state file', async () => {
-    await gtg(logger, appName, 'staging', false)
+    await gtg(logger, appName, 'staging')
 
     expect(writeState).toBeCalledWith('staging', { appName: 'test-app-name' })
   })
 
   it('calls wait for ok with the correct url', async () => {
-    await gtg(logger, appName, 'staging', false)
+    await gtg(logger, appName, 'staging')
 
-    const url = `https://${appName}.herokuapp.com/__gtg`
-
-    expect(waitForOk).toBeCalledWith(logger, url)
+    expect(waitForOk).toBeCalledWith(logger, makeUrl(appName) + '__gtg')
   })
 
   it('throws an error if the app fails to respond', async () => {
-    await expect(gtg(logger, 'wrong-app-name', 'staging', false)).rejects.toThrowError()
+    await expect(gtg(logger, 'wrong-app-name', 'staging')).rejects.toThrowError()
   })
 
   it('resolves if successful', async () => {
-    await expect(gtg(logger, appName, 'staging', false)).resolves.not.toThrow()
+    await expect(gtg(logger, appName, 'staging')).resolves.not.toThrow()
   })
 })

--- a/plugins/heroku/test/promoteStagingToProduction.test.ts
+++ b/plugins/heroku/test/promoteStagingToProduction.test.ts
@@ -70,8 +70,8 @@ describe('promoteStagingToProduction', () => {
     mockHerokuPost.mockImplementationOnce(async () => Promise.resolve(goodHerokuResponse[1]))
     await promoteStagingToProduction(logger, slugId)
 
-    expect(gtg).toHaveBeenNthCalledWith(1, logger, 'app-name-1', 'production', false)
-    expect(gtg).toHaveBeenNthCalledWith(2, logger, 'app-name-2', 'production', false)
+    expect(gtg).toHaveBeenNthCalledWith(1, logger, 'app-name-1', 'production')
+    expect(gtg).toHaveBeenNthCalledWith(2, logger, 'app-name-2', 'production')
   })
 
   it('completes successfully when function completes', async () => {

--- a/plugins/heroku/test/tasks/staging.test.ts
+++ b/plugins/heroku/test/tasks/staging.test.ts
@@ -164,7 +164,7 @@ describe('staging', () => {
 
     await task.run()
 
-    expect(gtg).toBeCalledWith(expect.anything(), appName, 'staging', false)
+    expect(gtg).toBeCalledWith(expect.anything(), appName, 'staging')
   })
 
   it('should throw an error if it fails', async () => {


### PR DESCRIPTION
# Description

Heroku made a [change](https://devcenter.heroku.com/changelog-items/2597) to the naming of the domain apps run on a couple of months ago. Previously, the domain would be based on the name of the app, but now a random 12-character string is appended to make them more unique I guess. This change only affects newly created apps.

We were assuming the previous format when constructing the URL for gtg tests. This meant that gtg tests have started to fail when deploying new apps. The correct domain is actually returned by the [same API](https://devcenter.heroku.com/articles/platform-api-reference#app-info) that we were previously using to check app names/convert to names from an app ID, so let's use that. This works for apps using the old domain naming system as well as the new one.

Tested on `ft-next-static-staging` using the [cursed script](https://github.com/Financial-Times/next-static/tree/main/scripts/test-deployment).

Closes #471.

# Checklist:

- [x] My branch has been rebased onto the latest commit on main (don't merge main into your branch)
- [x] My commit messages are [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/), for example: `feat(circleci): add support for nightly workflows`, `fix: set Heroku app name for staging apps too`
