### PR TITLE
Skip syncing Doppler secrets to Heroku in favour of official integration

### DIFF
--- a/plugins/heroku/src/setConfigVars.ts
+++ b/plugins/heroku/src/setConfigVars.ts
@@ -14,8 +14,13 @@ async function setAppConfigVars(
   logger.info(`setting config vars for ${appIdName}`)
 
   const dopplerEnvVars = new DopplerEnvVars(logger, environment)
+  const { secrets: configVars, source } = await dopplerEnvVars.getWithSource()
+  // HACK:20230925:IM we only want to set secrets from Vault, if we're using
+  // Doppler we should let its own Heroku integration handle secrets syncing
+  if (source === 'doppler') {
+    return
+  }
 
-  const configVars = await dopplerEnvVars.get()
   const { region } = await heroku
     .get<HerokuApiResGetRegion>(`/apps/${appIdName}`)
     .catch(extractHerokuError(`getting region for app ${appIdName}`))
@@ -46,7 +51,12 @@ async function setStageConfigVars(
 
   const dopplerEnvVars = new DopplerEnvVars(logger, environment)
 
-  const configVars = await dopplerEnvVars.get()
+  const { secrets: configVars, source } = await dopplerEnvVars.getWithSource()
+  // HACK:20230925:IM we only want to set secrets from Vault, if we're using
+  // Doppler we should let its own Heroku integration handle secrets syncing
+  if (source === 'doppler') {
+    return
+  }
 
   if (systemCode) {
     configVars.SYSTEM_CODE = systemCode


### PR DESCRIPTION
# Description

We plan to use the Doppler's official [Heroku integration](https://docs.doppler.com/docs/heroku) so we don't need to upload secrets from Doppler to Heroku here. Also note that the generated config vars (`REGION`, `NODE_ENV`, and `SYSTEM_CODE`) will now be stored in Doppler in [branch configs](https://docs.doppler.com/docs/branch-configs) instead to maintain a single source of truth (and also because it will override any we set ourselves here.)

# Checklist:

- [x] My branch has been rebased onto the latest commit on main (don't merge main into your branch)
- [x] My commit messages are [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/), for example: `feat(circleci): add support for nightly workflows`, `fix: set Heroku app name for staging apps too`
