### PR TITLE
Strip trailing slashes in host URL passed to n-test

### DIFF
--- a/plugins/n-test/src/tasks/n-test.ts
+++ b/plugins/n-test/src/tasks/n-test.ts
@@ -16,6 +16,11 @@ export default class NTest extends Task<typeof SmokeTestSchema> {
       // subdomain to maintain backwards compatibility
       this.options.host =
         'url' in appState && appState.url ? appState.url : `https://${appState.appName}.herokuapp.com`
+      // HACK:20231003:IM n-test naively appends paths to the host URL so
+      // expects there to be no trailing slash
+      if (this.options.host.endsWith('/')) {
+        this.options.host = this.options.host.slice(0, -1)
+      }
     }
 
     const smokeTest = new SmokeTest(this.options)


### PR DESCRIPTION
# Description

Workaround n-test [naïvely appending](https://github.com/Financial-Times/n-test/blob/2da4f1a20e11269475d3d65c7671e319bd256bcf/lib/smoke/setup-page.js#L46C31-L46C31) paths to a base URL meaning the host option cannot end in a trailing slash (as it will result in n-test incorrectly testing URLs like `https://example.com//` instead). I'd prefer to fix the logic in n-test to append the path to the host correctly using `new URL(path, host)` [to treat the `host` as a base URL](https://developer.mozilla.org/en-US/docs/Web/API/URL/URL#syntax), but unfortunately a few [repositories](https://github.com/Financial-Times/next-errors/blob/294fb605afb9e83de3de6e3071f4525e3f816bc7/Makefile#L8) include a path prefix in their host option and this change would break their tests. So let's hack around the behaviour in Tool Kit instead.

# Checklist:

- [x] My branch has been rebased onto the latest commit on main (don't merge main into your branch)
- [x] My commit messages are [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/), for example: `feat(circleci): add support for nightly workflows`, `fix: set Heroku app name for staging apps too`
