### PR TITLE
Remove n logger

### DIFF
--- a/lib/vault/package.json
+++ b/lib/vault/package.json
@@ -10,7 +10,7 @@
     "@dotcom-tool-kit/error": "^3.1.0",
     "@dotcom-tool-kit/options": "^3.1.4",
     "@dotcom-tool-kit/types": "^3.4.0",
-    "@financial-times/n-fetch": "^1.0.0-beta.12",
+    "@financial-times/n-fetch": "^1.0.0",
     "fs": "0.0.1-security",
     "os": "^0.1.2",
     "path": "^0.12.7",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1989,7 +1989,7 @@
         "@dotcom-tool-kit/error": "^3.1.0",
         "@dotcom-tool-kit/options": "^3.1.4",
         "@dotcom-tool-kit/types": "^3.4.0",
-        "@financial-times/n-fetch": "^1.0.0-beta.12",
+        "@financial-times/n-fetch": "^1.0.0",
         "fs": "0.0.1-security",
         "os": "^0.1.2",
         "path": "^0.12.7",
@@ -1999,6 +1999,20 @@
       "devDependencies": {
         "@types/jest": "^27.0.2",
         "winston": "^3.5.1"
+      },
+      "engines": {
+        "node": "16.x || 18.x",
+        "npm": "7.x || 8.x || 9.x"
+      }
+    },
+    "lib/vault/node_modules/@financial-times/n-fetch": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@financial-times/n-fetch/-/n-fetch-1.0.0.tgz",
+      "integrity": "sha512-6ayYnrlSJZvGU8/ZJEskxYH2kdvwJU/aL9MSXc3FmPj3dft7ecMxsB4p8PsWeJamHyd8EjaL7Mwm63LR2DwePg==",
+      "dependencies": {
+        "@dotcom-reliability-kit/logger": "^2.2.7",
+        "http-errors": "^1.6.1",
+        "node-fetch": "^2.0.0"
       },
       "engines": {
         "node": "16.x || 18.x",
@@ -6818,6 +6832,15 @@
         "node": ">=10.0.0"
       }
     },
+    "node_modules/@dotcom-reliability-kit/app-info": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@dotcom-reliability-kit/app-info/-/app-info-2.1.0.tgz",
+      "integrity": "sha512-u7QicgkUbN58IMywvXmNuXxMK5bHUKfjeDC6s3u7TQg5uTGNicdrpBb8zB2O5K++g5KIlVnAafPcJct3ct9Nfw==",
+      "engines": {
+        "node": "16.x || 18.x || 20.x",
+        "npm": "7.x || 8.x || 9.x"
+      }
+    },
     "node_modules/@dotcom-reliability-kit/eslint-config": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/@dotcom-reliability-kit/eslint-config/-/eslint-config-2.0.0.tgz",
@@ -6829,6 +6852,33 @@
       },
       "peerDependencies": {
         "eslint": ">=8.27.0"
+      }
+    },
+    "node_modules/@dotcom-reliability-kit/logger": {
+      "version": "2.2.9",
+      "resolved": "https://registry.npmjs.org/@dotcom-reliability-kit/logger/-/logger-2.2.9.tgz",
+      "integrity": "sha512-+3KSEdsypnz54VMgSVXnjyXTeJ5ZfyHF4jU3tcNcDrouGHT+JpD1ERkypfRfidwRRGtGup4FC2kjczpPGmecsw==",
+      "dependencies": {
+        "@dotcom-reliability-kit/app-info": "^2.1.0",
+        "@dotcom-reliability-kit/serialize-error": "^2.1.0",
+        "lodash.clonedeep": "^4.5.0",
+        "pino": "^8.15.1"
+      },
+      "engines": {
+        "node": "16.x || 18.x || 20.x",
+        "npm": "7.x || 8.x || 9.x"
+      },
+      "peerDependencies": {
+        "pino-pretty": ">=7.0.0 <11.0.0"
+      }
+    },
+    "node_modules/@dotcom-reliability-kit/serialize-error": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@dotcom-reliability-kit/serialize-error/-/serialize-error-2.1.0.tgz",
+      "integrity": "sha512-JYgnyvds/FZ0KJVRtOAsk9skue5i/vDBkRvQQg5Q/xlbwLdeUSAtD3XXBtlaohHov8kY7/I9UaXcoG6zXZ3a5Q==",
+      "engines": {
+        "node": "16.x || 18.x || 20.x",
+        "npm": "7.x || 8.x || 9.x"
       }
     },
     "node_modules/@dotcom-tool-kit/babel": {
@@ -7078,6 +7128,7 @@
       "version": "1.0.0-beta.12",
       "resolved": "https://registry.npmjs.org/@financial-times/n-fetch/-/n-fetch-1.0.0-beta.12.tgz",
       "integrity": "sha512-oF/824kUTuk3TfLtZ9eFfjq3ZJ/+Iwz+Hi5iPeF4lyT3zt+4ES0oJt8u4XxsR++9Z5nIlDV0/bp2m4/ofU+4Yw==",
+      "dev": true,
       "hasInstallScript": true,
       "dependencies": {
         "@financial-times/n-logger": "^10.2.0",
@@ -7093,6 +7144,7 @@
       "version": "10.3.1",
       "resolved": "https://registry.npmjs.org/@financial-times/n-logger/-/n-logger-10.3.1.tgz",
       "integrity": "sha512-qOy3Mqp10W8tD1hQiO6iuqDRE89gTdylIoxlkySK2/4RXGp8oUJm4ulpoIJzC2aw7ZDAvt8Yx47Z6osDfCBEvw==",
+      "dev": true,
       "hasInstallScript": true,
       "dependencies": {
         "json-stringify-safe": "^5.0.1",
@@ -7108,6 +7160,7 @@
       "version": "2.6.4",
       "resolved": "https://registry.npmjs.org/async/-/async-2.6.4.tgz",
       "integrity": "sha512-mzo5dfJYwAn29PeiJ0zvwTo04zj8HDJj0Mn8TD7sno7q12prdbnasKJHhkm2c1LgrhlJ0teaea8860oxi51mGA==",
+      "dev": true,
       "dependencies": {
         "lodash": "^4.17.14"
       }
@@ -7116,6 +7169,7 @@
       "version": "2.4.7",
       "resolved": "https://registry.npmjs.org/winston/-/winston-2.4.7.tgz",
       "integrity": "sha512-vLB4BqzCKDnnZH9PHGoS2ycawueX4HLqENXQitvFHczhgW2vFpSOn31LZtVr1KU8YTw7DS4tM+cqyovxo8taVg==",
+      "dev": true,
       "dependencies": {
         "async": "^2.6.4",
         "colors": "1.0.x",
@@ -11042,6 +11096,17 @@
       "version": "1.1.1",
       "license": "ISC"
     },
+    "node_modules/abort-controller": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/abort-controller/-/abort-controller-3.0.0.tgz",
+      "integrity": "sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg==",
+      "dependencies": {
+        "event-target-shim": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=6.5"
+      }
+    },
     "node_modules/acorn": {
       "version": "7.4.1",
       "license": "MIT",
@@ -11614,6 +11679,14 @@
       },
       "engines": {
         "node": ">= 4.5.0"
+      }
+    },
+    "node_modules/atomic-sleep": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/atomic-sleep/-/atomic-sleep-1.0.0.tgz",
+      "integrity": "sha512-kNOjDqAh7px0XWNI+4QbzoiR/nTkHAWNud2uvnJquD1/x5a7EQZMJT0AczqK0Qn67oY/TTQ1LbUKajZpp3I9tQ==",
+      "engines": {
+        "node": ">=8.0.0"
       }
     },
     "node_modules/available-typed-arrays": {
@@ -15506,6 +15579,14 @@
         "es5-ext": "~0.10.14"
       }
     },
+    "node_modules/event-target-shim": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/event-target-shim/-/event-target-shim-5.0.1.tgz",
+      "integrity": "sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ==",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/eventemitter3": {
       "version": "4.0.7",
       "license": "MIT"
@@ -15809,6 +15890,12 @@
         "node": "> 0.1.90"
       }
     },
+    "node_modules/fast-copy": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/fast-copy/-/fast-copy-3.0.1.tgz",
+      "integrity": "sha512-Knr7NOtK3HWRYGtHoJrjkaWepqT8thIVGAwt0p0aUs1zqkAzXZV4vo9fFNwyb5fcqK1GKYFYxldQdIDVKhUAfA==",
+      "peer": true
+    },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
       "license": "MIT"
@@ -15834,6 +15921,14 @@
     "node_modules/fast-levenshtein": {
       "version": "2.0.6",
       "license": "MIT"
+    },
+    "node_modules/fast-redact": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/fast-redact/-/fast-redact-3.3.0.tgz",
+      "integrity": "sha512-6T5V1QK1u4oF+ATxs1lWUmlEk6P2T9HqJG3e2DnHOdVgZy2rFJBoEnrIedcTXlkAHU/zKC+7KETJ+KGGKwxgMQ==",
+      "engines": {
+        "node": ">=6"
+      }
     },
     "node_modules/fast-safe-stringify": {
       "version": "2.1.1",
@@ -17068,6 +17163,56 @@
       "license": "MIT",
       "bin": {
         "he": "bin/he"
+      }
+    },
+    "node_modules/help-me": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/help-me/-/help-me-4.2.0.tgz",
+      "integrity": "sha512-TAOnTB8Tz5Dw8penUuzHVrKNKlCIbwwbHnXraNJxPwf8LRtE2HlM84RYuezMFcwOJmoYOCWVDyJ8TQGxn9PgxA==",
+      "peer": true,
+      "dependencies": {
+        "glob": "^8.0.0",
+        "readable-stream": "^3.6.0"
+      }
+    },
+    "node_modules/help-me/node_modules/brace-expansion": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
+      "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+      "peer": true,
+      "dependencies": {
+        "balanced-match": "^1.0.0"
+      }
+    },
+    "node_modules/help-me/node_modules/glob": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-8.1.0.tgz",
+      "integrity": "sha512-r8hpEjiQEYlF2QU0df3dS+nxxSIreXQS1qRhMJM0Q5NDdR386C7jb7Hwwod8Fgiuex+k0GFjgft18yvxm5XoCQ==",
+      "peer": true,
+      "dependencies": {
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^5.0.1",
+        "once": "^1.3.0"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/help-me/node_modules/minimatch": {
+      "version": "5.1.6",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.6.tgz",
+      "integrity": "sha512-lKwV/1brpG6mBUFHtb7NUmtABCb2WZZmm2wNiOA5hAb8VdCS4B3dtMWyvcoViccwAW/COERjXLt0zP1zXUN26g==",
+      "peer": true,
+      "dependencies": {
+        "brace-expansion": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/heroku-client": {
@@ -19043,6 +19188,15 @@
       "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/panva"
+      }
+    },
+    "node_modules/joycon": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/joycon/-/joycon-3.1.1.tgz",
+      "integrity": "sha512-34wB/Y7MW7bzjKRjUKTa46I2Z7eV62Rkhva+KkopW7Qvv/OSWBqvkSY7vusOPrNuZcUG3tApvdVgNB8POj3SPw==",
+      "peer": true,
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/jpeg-js": {
@@ -22044,6 +22198,14 @@
       "version": "1.0.10",
       "license": "MIT"
     },
+    "node_modules/on-exit-leak-free": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/on-exit-leak-free/-/on-exit-leak-free-2.1.2.tgz",
+      "integrity": "sha512-0eJJY6hXLGf1udHwfNftBqH+g73EU4B504nZeKpz1sYRKafAghwxEJunB2O7rDZkL4PGfsMVnTXZ2EjibbqcsA==",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
     "node_modules/on-finished": {
       "version": "2.3.0",
       "license": "MIT",
@@ -23305,6 +23467,161 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/pino": {
+      "version": "8.15.4",
+      "resolved": "https://registry.npmjs.org/pino/-/pino-8.15.4.tgz",
+      "integrity": "sha512-3s+SfSxeugMt8QeBVXprIJAgXuGDeGuHBfquXKEXKnpghlXzMGMjoa8tOSyzz00iBfQX3xlZvm2yJQ+d6SrVsg==",
+      "dependencies": {
+        "atomic-sleep": "^1.0.0",
+        "fast-redact": "^3.1.1",
+        "on-exit-leak-free": "^2.1.0",
+        "pino-abstract-transport": "v1.1.0",
+        "pino-std-serializers": "^6.0.0",
+        "process-warning": "^2.0.0",
+        "quick-format-unescaped": "^4.0.3",
+        "real-require": "^0.2.0",
+        "safe-stable-stringify": "^2.3.1",
+        "sonic-boom": "^3.1.0",
+        "thread-stream": "^2.0.0"
+      },
+      "bin": {
+        "pino": "bin.js"
+      }
+    },
+    "node_modules/pino-abstract-transport": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/pino-abstract-transport/-/pino-abstract-transport-1.1.0.tgz",
+      "integrity": "sha512-lsleG3/2a/JIWUtf9Q5gUNErBqwIu1tUKTT3dUzaf5DySw9ra1wcqKjJjLX1VTY64Wk1eEOYsVGSaGfCK85ekA==",
+      "dependencies": {
+        "readable-stream": "^4.0.0",
+        "split2": "^4.0.0"
+      }
+    },
+    "node_modules/pino-abstract-transport/node_modules/buffer": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
+      "integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "dependencies": {
+        "base64-js": "^1.3.1",
+        "ieee754": "^1.2.1"
+      }
+    },
+    "node_modules/pino-abstract-transport/node_modules/readable-stream": {
+      "version": "4.4.2",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-4.4.2.tgz",
+      "integrity": "sha512-Lk/fICSyIhodxy1IDK2HazkeGjSmezAWX2egdtJnYhtzKEsBPJowlI6F6LPb5tqIQILrMbx22S5o3GuJavPusA==",
+      "dependencies": {
+        "abort-controller": "^3.0.0",
+        "buffer": "^6.0.3",
+        "events": "^3.3.0",
+        "process": "^0.11.10",
+        "string_decoder": "^1.3.0"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      }
+    },
+    "node_modules/pino-abstract-transport/node_modules/split2": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/split2/-/split2-4.2.0.tgz",
+      "integrity": "sha512-UcjcJOWknrNkF6PLX83qcHM6KHgVKNkV62Y8a5uYDVv9ydGQVwAHMKqHdJje1VTWpljG0WYpCDhrCdAOYH4TWg==",
+      "engines": {
+        "node": ">= 10.x"
+      }
+    },
+    "node_modules/pino-pretty": {
+      "version": "10.2.2",
+      "resolved": "https://registry.npmjs.org/pino-pretty/-/pino-pretty-10.2.2.tgz",
+      "integrity": "sha512-RvAdCQAU51MdVsJdvXX4Bipb52wwldXtOzlva1NT8q2d7tmgYWFIMLhoSnfx2Sr+Hi7BLGpR/n8wgrcq5G/ykA==",
+      "peer": true,
+      "dependencies": {
+        "colorette": "^2.0.7",
+        "dateformat": "^4.6.3",
+        "fast-copy": "^3.0.0",
+        "fast-safe-stringify": "^2.1.1",
+        "help-me": "^4.0.1",
+        "joycon": "^3.1.1",
+        "minimist": "^1.2.6",
+        "on-exit-leak-free": "^2.1.0",
+        "pino-abstract-transport": "^1.0.0",
+        "pump": "^3.0.0",
+        "readable-stream": "^4.0.0",
+        "secure-json-parse": "^2.4.0",
+        "sonic-boom": "^3.0.0",
+        "strip-json-comments": "^3.1.1"
+      },
+      "bin": {
+        "pino-pretty": "bin.js"
+      }
+    },
+    "node_modules/pino-pretty/node_modules/buffer": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
+      "integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "peer": true,
+      "dependencies": {
+        "base64-js": "^1.3.1",
+        "ieee754": "^1.2.1"
+      }
+    },
+    "node_modules/pino-pretty/node_modules/dateformat": {
+      "version": "4.6.3",
+      "resolved": "https://registry.npmjs.org/dateformat/-/dateformat-4.6.3.tgz",
+      "integrity": "sha512-2P0p0pFGzHS5EMnhdxQi7aJN+iMheud0UhG4dlE1DLAlvL8JHjJJTX/CSm4JXwV0Ka5nGk3zC5mcb5bUQUxxMA==",
+      "peer": true,
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/pino-pretty/node_modules/readable-stream": {
+      "version": "4.4.2",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-4.4.2.tgz",
+      "integrity": "sha512-Lk/fICSyIhodxy1IDK2HazkeGjSmezAWX2egdtJnYhtzKEsBPJowlI6F6LPb5tqIQILrMbx22S5o3GuJavPusA==",
+      "peer": true,
+      "dependencies": {
+        "abort-controller": "^3.0.0",
+        "buffer": "^6.0.3",
+        "events": "^3.3.0",
+        "process": "^0.11.10",
+        "string_decoder": "^1.3.0"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      }
+    },
+    "node_modules/pino-std-serializers": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/pino-std-serializers/-/pino-std-serializers-6.2.2.tgz",
+      "integrity": "sha512-cHjPPsE+vhj/tnhCy/wiMh3M3z3h/j15zHQX+S9GkTBgqJuTuJzYJ4gUyACLhDaJ7kk9ba9iRDmbH2tJU03OiA=="
+    },
     "node_modules/pirates": {
       "version": "4.0.5",
       "license": "MIT",
@@ -23429,6 +23746,11 @@
       "engines": {
         "node": ">=10.0"
       }
+    },
+    "node_modules/process-warning": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/process-warning/-/process-warning-2.2.0.tgz",
+      "integrity": "sha512-/1WZ8+VQjR6avWOgHeEPd7SDQmFQ1B5mC1eRXsCm5TarlNmx/wCsa5GEaxGm05BORRtyG/Ex/3xq3TuRvq57qg=="
     },
     "node_modules/progress": {
       "version": "2.0.3",
@@ -23685,6 +24007,11 @@
         }
       ],
       "license": "MIT"
+    },
+    "node_modules/quick-format-unescaped": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/quick-format-unescaped/-/quick-format-unescaped-4.0.4.tgz",
+      "integrity": "sha512-tYC1Q1hgyRuHgloV/YXs2w15unPVh8qfu/qCTfhTYamaw7fyhumKa2yGpdSo87vY32rIclj+4fWYQXUMs9EHvg=="
     },
     "node_modules/quick-lru": {
       "version": "4.0.1",
@@ -24014,6 +24341,14 @@
       },
       "engines": {
         "node": ">=8.10.0"
+      }
+    },
+    "node_modules/real-require": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/real-require/-/real-require-0.2.0.tgz",
+      "integrity": "sha512-57frrGM/OCTLqLOAh0mhVA9VBMHd+9U7Zb2THMGdBUoZVOtGbJzjxsYGDJ3A9AYYCP4hn6y1TVbaOfzWtm5GFg==",
+      "engines": {
+        "node": ">= 12.13.0"
       }
     },
     "node_modules/rechoir": {
@@ -24735,6 +25070,12 @@
       "engines": {
         "node": ">= 4"
       }
+    },
+    "node_modules/secure-json-parse": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/secure-json-parse/-/secure-json-parse-2.7.0.tgz",
+      "integrity": "sha512-6aU+Rwsezw7VR8/nyvKTx8QpWH9FrcYiXXlqC4z5d5XQBDRqtbfsRjnwGyqbi3gddNtWHuEk9OANUotL26qKUw==",
+      "peer": true
     },
     "node_modules/seedrandom": {
       "version": "3.0.5",
@@ -26037,6 +26378,14 @@
         "node": ">= 10"
       }
     },
+    "node_modules/sonic-boom": {
+      "version": "3.5.0",
+      "resolved": "https://registry.npmjs.org/sonic-boom/-/sonic-boom-3.5.0.tgz",
+      "integrity": "sha512-02A0wEmj4d3aEIW/Sp6LMP1dNcG5cYmQPjhgtytIXa9tNmFZx3ragUPFmyBdgdM0yJJVSWwlLLEVHgrYfA0wtQ==",
+      "dependencies": {
+        "atomic-sleep": "^1.0.0"
+      }
+    },
     "node_modules/sort-keys": {
       "version": "2.0.0",
       "dev": true,
@@ -27063,6 +27412,14 @@
       },
       "engines": {
         "node": ">=0.8"
+      }
+    },
+    "node_modules/thread-stream": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/thread-stream/-/thread-stream-2.4.1.tgz",
+      "integrity": "sha512-d/Ex2iWd1whipbT681JmTINKw0ZwOUBZm7+Gjs64DHuX34mmw8vJL2bFAaNacaW72zYiTJxSHi5abUuOi5nsfg==",
+      "dependencies": {
+        "real-require": "^0.2.0"
       }
     },
     "node_modules/throat": {
@@ -34710,12 +35067,33 @@
     "@discoveryjs/json-ext": {
       "version": "0.5.7"
     },
+    "@dotcom-reliability-kit/app-info": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@dotcom-reliability-kit/app-info/-/app-info-2.1.0.tgz",
+      "integrity": "sha512-u7QicgkUbN58IMywvXmNuXxMK5bHUKfjeDC6s3u7TQg5uTGNicdrpBb8zB2O5K++g5KIlVnAafPcJct3ct9Nfw=="
+    },
     "@dotcom-reliability-kit/eslint-config": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/@dotcom-reliability-kit/eslint-config/-/eslint-config-2.0.0.tgz",
       "integrity": "sha512-h9v1nZ4FRe2iHVm53QGoq4BafbQOWhtb0b/Kuxd3ed+HMvYn/ft8A/Av/Xg8vAnJ7uoJspWgkt8qxgDnwX5vxg==",
       "dev": true,
       "requires": {}
+    },
+    "@dotcom-reliability-kit/logger": {
+      "version": "2.2.9",
+      "resolved": "https://registry.npmjs.org/@dotcom-reliability-kit/logger/-/logger-2.2.9.tgz",
+      "integrity": "sha512-+3KSEdsypnz54VMgSVXnjyXTeJ5ZfyHF4jU3tcNcDrouGHT+JpD1ERkypfRfidwRRGtGup4FC2kjczpPGmecsw==",
+      "requires": {
+        "@dotcom-reliability-kit/app-info": "^2.1.0",
+        "@dotcom-reliability-kit/serialize-error": "^2.1.0",
+        "lodash.clonedeep": "^4.5.0",
+        "pino": "^8.15.1"
+      }
+    },
+    "@dotcom-reliability-kit/serialize-error": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@dotcom-reliability-kit/serialize-error/-/serialize-error-2.1.0.tgz",
+      "integrity": "sha512-JYgnyvds/FZ0KJVRtOAsk9skue5i/vDBkRvQQg5Q/xlbwLdeUSAtD3XXBtlaohHov8kY7/I9UaXcoG6zXZ3a5Q=="
     },
     "@dotcom-tool-kit/babel": {
       "version": "file:plugins/babel",
@@ -37234,7 +37612,7 @@
         "@dotcom-tool-kit/error": "^3.1.0",
         "@dotcom-tool-kit/options": "^3.1.4",
         "@dotcom-tool-kit/types": "^3.4.0",
-        "@financial-times/n-fetch": "^1.0.0-beta.12",
+        "@financial-times/n-fetch": "^1.0.0",
         "@types/jest": "^27.0.2",
         "fs": "0.0.1-security",
         "os": "^0.1.2",
@@ -37244,6 +37622,16 @@
         "winston": "^3.5.1"
       },
       "dependencies": {
+        "@financial-times/n-fetch": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/@financial-times/n-fetch/-/n-fetch-1.0.0.tgz",
+          "integrity": "sha512-6ayYnrlSJZvGU8/ZJEskxYH2kdvwJU/aL9MSXc3FmPj3dft7ecMxsB4p8PsWeJamHyd8EjaL7Mwm63LR2DwePg==",
+          "requires": {
+            "@dotcom-reliability-kit/logger": "^2.2.7",
+            "http-errors": "^1.6.1",
+            "node-fetch": "^2.0.0"
+          }
+        },
         "tslib": {
           "version": "2.4.1",
           "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
@@ -37385,6 +37773,7 @@
       "version": "1.0.0-beta.12",
       "resolved": "https://registry.npmjs.org/@financial-times/n-fetch/-/n-fetch-1.0.0-beta.12.tgz",
       "integrity": "sha512-oF/824kUTuk3TfLtZ9eFfjq3ZJ/+Iwz+Hi5iPeF4lyT3zt+4ES0oJt8u4XxsR++9Z5nIlDV0/bp2m4/ofU+4Yw==",
+      "dev": true,
       "requires": {
         "@financial-times/n-logger": "^10.2.0",
         "http-errors": "^1.6.1",
@@ -37395,6 +37784,7 @@
           "version": "10.3.1",
           "resolved": "https://registry.npmjs.org/@financial-times/n-logger/-/n-logger-10.3.1.tgz",
           "integrity": "sha512-qOy3Mqp10W8tD1hQiO6iuqDRE89gTdylIoxlkySK2/4RXGp8oUJm4ulpoIJzC2aw7ZDAvt8Yx47Z6osDfCBEvw==",
+          "dev": true,
           "requires": {
             "json-stringify-safe": "^5.0.1",
             "node-fetch": "^2.6.7",
@@ -37405,6 +37795,7 @@
           "version": "2.6.4",
           "resolved": "https://registry.npmjs.org/async/-/async-2.6.4.tgz",
           "integrity": "sha512-mzo5dfJYwAn29PeiJ0zvwTo04zj8HDJj0Mn8TD7sno7q12prdbnasKJHhkm2c1LgrhlJ0teaea8860oxi51mGA==",
+          "dev": true,
           "requires": {
             "lodash": "^4.17.14"
           }
@@ -37413,6 +37804,7 @@
           "version": "2.4.7",
           "resolved": "https://registry.npmjs.org/winston/-/winston-2.4.7.tgz",
           "integrity": "sha512-vLB4BqzCKDnnZH9PHGoS2ycawueX4HLqENXQitvFHczhgW2vFpSOn31LZtVr1KU8YTw7DS4tM+cqyovxo8taVg==",
+          "dev": true,
           "requires": {
             "async": "^2.6.4",
             "colors": "1.0.x",
@@ -40482,6 +40874,14 @@
     "abbrev": {
       "version": "1.1.1"
     },
+    "abort-controller": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/abort-controller/-/abort-controller-3.0.0.tgz",
+      "integrity": "sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg==",
+      "requires": {
+        "event-target-shim": "^5.0.0"
+      }
+    },
     "acorn": {
       "version": "7.4.1"
     },
@@ -40871,6 +41271,11 @@
     },
     "atob": {
       "version": "2.1.2"
+    },
+    "atomic-sleep": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/atomic-sleep/-/atomic-sleep-1.0.0.tgz",
+      "integrity": "sha512-kNOjDqAh7px0XWNI+4QbzoiR/nTkHAWNud2uvnJquD1/x5a7EQZMJT0AczqK0Qn67oY/TTQ1LbUKajZpp3I9tQ=="
     },
     "available-typed-arrays": {
       "version": "1.0.5",
@@ -43696,6 +44101,11 @@
         "es5-ext": "~0.10.14"
       }
     },
+    "event-target-shim": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/event-target-shim/-/event-target-shim-5.0.1.tgz",
+      "integrity": "sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ=="
+    },
     "eventemitter3": {
       "version": "4.0.7"
     },
@@ -43904,6 +44314,12 @@
     "eyes": {
       "version": "0.1.8"
     },
+    "fast-copy": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/fast-copy/-/fast-copy-3.0.1.tgz",
+      "integrity": "sha512-Knr7NOtK3HWRYGtHoJrjkaWepqT8thIVGAwt0p0aUs1zqkAzXZV4vo9fFNwyb5fcqK1GKYFYxldQdIDVKhUAfA==",
+      "peer": true
+    },
     "fast-deep-equal": {
       "version": "3.1.3"
     },
@@ -43922,6 +44338,11 @@
     },
     "fast-levenshtein": {
       "version": "2.0.6"
+    },
+    "fast-redact": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/fast-redact/-/fast-redact-3.3.0.tgz",
+      "integrity": "sha512-6T5V1QK1u4oF+ATxs1lWUmlEk6P2T9HqJG3e2DnHOdVgZy2rFJBoEnrIedcTXlkAHU/zKC+7KETJ+KGGKwxgMQ=="
     },
     "fast-safe-stringify": {
       "version": "2.1.1"
@@ -44718,6 +45139,49 @@
     },
     "he": {
       "version": "1.2.0"
+    },
+    "help-me": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/help-me/-/help-me-4.2.0.tgz",
+      "integrity": "sha512-TAOnTB8Tz5Dw8penUuzHVrKNKlCIbwwbHnXraNJxPwf8LRtE2HlM84RYuezMFcwOJmoYOCWVDyJ8TQGxn9PgxA==",
+      "peer": true,
+      "requires": {
+        "glob": "^8.0.0",
+        "readable-stream": "^3.6.0"
+      },
+      "dependencies": {
+        "brace-expansion": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
+          "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+          "peer": true,
+          "requires": {
+            "balanced-match": "^1.0.0"
+          }
+        },
+        "glob": {
+          "version": "8.1.0",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-8.1.0.tgz",
+          "integrity": "sha512-r8hpEjiQEYlF2QU0df3dS+nxxSIreXQS1qRhMJM0Q5NDdR386C7jb7Hwwod8Fgiuex+k0GFjgft18yvxm5XoCQ==",
+          "peer": true,
+          "requires": {
+            "fs.realpath": "^1.0.0",
+            "inflight": "^1.0.4",
+            "inherits": "2",
+            "minimatch": "^5.0.1",
+            "once": "^1.3.0"
+          }
+        },
+        "minimatch": {
+          "version": "5.1.6",
+          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.6.tgz",
+          "integrity": "sha512-lKwV/1brpG6mBUFHtb7NUmtABCb2WZZmm2wNiOA5hAb8VdCS4B3dtMWyvcoViccwAW/COERjXLt0zP1zXUN26g==",
+          "peer": true,
+          "requires": {
+            "brace-expansion": "^2.0.1"
+          }
+        }
+      }
     },
     "heroku-client": {
       "version": "3.1.0",
@@ -45972,6 +46436,12 @@
       "version": "4.11.2",
       "resolved": "https://registry.npmjs.org/jose/-/jose-4.11.2.tgz",
       "integrity": "sha512-njj0VL2TsIxCtgzhO+9RRobBvws4oYyCM8TpvoUQwl/MbIM3NFJRR9+e6x0sS5xXaP1t6OCBkaBME98OV9zU5A==",
+      "peer": true
+    },
+    "joycon": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/joycon/-/joycon-3.1.1.tgz",
+      "integrity": "sha512-34wB/Y7MW7bzjKRjUKTa46I2Z7eV62Rkhva+KkopW7Qvv/OSWBqvkSY7vusOPrNuZcUG3tApvdVgNB8POj3SPw==",
       "peer": true
     },
     "jpeg-js": {
@@ -48082,6 +48552,11 @@
     "omggif": {
       "version": "1.0.10"
     },
+    "on-exit-leak-free": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/on-exit-leak-free/-/on-exit-leak-free-2.1.2.tgz",
+      "integrity": "sha512-0eJJY6hXLGf1udHwfNftBqH+g73EU4B504nZeKpz1sYRKafAghwxEJunB2O7rDZkL4PGfsMVnTXZ2EjibbqcsA=="
+    },
     "on-finished": {
       "version": "2.3.0",
       "requires": {
@@ -48956,6 +49431,119 @@
         "pinkie": "^2.0.0"
       }
     },
+    "pino": {
+      "version": "8.15.4",
+      "resolved": "https://registry.npmjs.org/pino/-/pino-8.15.4.tgz",
+      "integrity": "sha512-3s+SfSxeugMt8QeBVXprIJAgXuGDeGuHBfquXKEXKnpghlXzMGMjoa8tOSyzz00iBfQX3xlZvm2yJQ+d6SrVsg==",
+      "requires": {
+        "atomic-sleep": "^1.0.0",
+        "fast-redact": "^3.1.1",
+        "on-exit-leak-free": "^2.1.0",
+        "pino-abstract-transport": "v1.1.0",
+        "pino-std-serializers": "^6.0.0",
+        "process-warning": "^2.0.0",
+        "quick-format-unescaped": "^4.0.3",
+        "real-require": "^0.2.0",
+        "safe-stable-stringify": "^2.3.1",
+        "sonic-boom": "^3.1.0",
+        "thread-stream": "^2.0.0"
+      }
+    },
+    "pino-abstract-transport": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/pino-abstract-transport/-/pino-abstract-transport-1.1.0.tgz",
+      "integrity": "sha512-lsleG3/2a/JIWUtf9Q5gUNErBqwIu1tUKTT3dUzaf5DySw9ra1wcqKjJjLX1VTY64Wk1eEOYsVGSaGfCK85ekA==",
+      "requires": {
+        "readable-stream": "^4.0.0",
+        "split2": "^4.0.0"
+      },
+      "dependencies": {
+        "buffer": {
+          "version": "6.0.3",
+          "resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
+          "integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
+          "requires": {
+            "base64-js": "^1.3.1",
+            "ieee754": "^1.2.1"
+          }
+        },
+        "readable-stream": {
+          "version": "4.4.2",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-4.4.2.tgz",
+          "integrity": "sha512-Lk/fICSyIhodxy1IDK2HazkeGjSmezAWX2egdtJnYhtzKEsBPJowlI6F6LPb5tqIQILrMbx22S5o3GuJavPusA==",
+          "requires": {
+            "abort-controller": "^3.0.0",
+            "buffer": "^6.0.3",
+            "events": "^3.3.0",
+            "process": "^0.11.10",
+            "string_decoder": "^1.3.0"
+          }
+        },
+        "split2": {
+          "version": "4.2.0",
+          "resolved": "https://registry.npmjs.org/split2/-/split2-4.2.0.tgz",
+          "integrity": "sha512-UcjcJOWknrNkF6PLX83qcHM6KHgVKNkV62Y8a5uYDVv9ydGQVwAHMKqHdJje1VTWpljG0WYpCDhrCdAOYH4TWg=="
+        }
+      }
+    },
+    "pino-pretty": {
+      "version": "10.2.2",
+      "resolved": "https://registry.npmjs.org/pino-pretty/-/pino-pretty-10.2.2.tgz",
+      "integrity": "sha512-RvAdCQAU51MdVsJdvXX4Bipb52wwldXtOzlva1NT8q2d7tmgYWFIMLhoSnfx2Sr+Hi7BLGpR/n8wgrcq5G/ykA==",
+      "peer": true,
+      "requires": {
+        "colorette": "^2.0.7",
+        "dateformat": "^4.6.3",
+        "fast-copy": "^3.0.0",
+        "fast-safe-stringify": "^2.1.1",
+        "help-me": "^4.0.1",
+        "joycon": "^3.1.1",
+        "minimist": "^1.2.6",
+        "on-exit-leak-free": "^2.1.0",
+        "pino-abstract-transport": "^1.0.0",
+        "pump": "^3.0.0",
+        "readable-stream": "^4.0.0",
+        "secure-json-parse": "^2.4.0",
+        "sonic-boom": "^3.0.0",
+        "strip-json-comments": "^3.1.1"
+      },
+      "dependencies": {
+        "buffer": {
+          "version": "6.0.3",
+          "resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
+          "integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
+          "peer": true,
+          "requires": {
+            "base64-js": "^1.3.1",
+            "ieee754": "^1.2.1"
+          }
+        },
+        "dateformat": {
+          "version": "4.6.3",
+          "resolved": "https://registry.npmjs.org/dateformat/-/dateformat-4.6.3.tgz",
+          "integrity": "sha512-2P0p0pFGzHS5EMnhdxQi7aJN+iMheud0UhG4dlE1DLAlvL8JHjJJTX/CSm4JXwV0Ka5nGk3zC5mcb5bUQUxxMA==",
+          "peer": true
+        },
+        "readable-stream": {
+          "version": "4.4.2",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-4.4.2.tgz",
+          "integrity": "sha512-Lk/fICSyIhodxy1IDK2HazkeGjSmezAWX2egdtJnYhtzKEsBPJowlI6F6LPb5tqIQILrMbx22S5o3GuJavPusA==",
+          "peer": true,
+          "requires": {
+            "abort-controller": "^3.0.0",
+            "buffer": "^6.0.3",
+            "events": "^3.3.0",
+            "process": "^0.11.10",
+            "string_decoder": "^1.3.0"
+          }
+        }
+      }
+    },
+    "pino-std-serializers": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/pino-std-serializers/-/pino-std-serializers-6.2.2.tgz",
+      "integrity": "sha512-cHjPPsE+vhj/tnhCy/wiMh3M3z3h/j15zHQX+S9GkTBgqJuTuJzYJ4gUyACLhDaJ7kk9ba9iRDmbH2tJU03OiA=="
+    },
     "pirates": {
       "version": "4.0.5"
     },
@@ -49023,6 +49611,11 @@
         "memoizee": "^0.4.14",
         "type": "^2.1.0"
       }
+    },
+    "process-warning": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/process-warning/-/process-warning-2.2.0.tgz",
+      "integrity": "sha512-/1WZ8+VQjR6avWOgHeEPd7SDQmFQ1B5mC1eRXsCm5TarlNmx/wCsa5GEaxGm05BORRtyG/Ex/3xq3TuRvq57qg=="
     },
     "progress": {
       "version": "2.0.3"
@@ -49191,6 +49784,11 @@
     },
     "queue-microtask": {
       "version": "1.2.3"
+    },
+    "quick-format-unescaped": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/quick-format-unescaped/-/quick-format-unescaped-4.0.4.tgz",
+      "integrity": "sha512-tYC1Q1hgyRuHgloV/YXs2w15unPVh8qfu/qCTfhTYamaw7fyhumKa2yGpdSo87vY32rIclj+4fWYQXUMs9EHvg=="
     },
     "quick-lru": {
       "version": "4.0.1",
@@ -49421,6 +50019,11 @@
       "requires": {
         "picomatch": "^2.2.1"
       }
+    },
+    "real-require": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/real-require/-/real-require-0.2.0.tgz",
+      "integrity": "sha512-57frrGM/OCTLqLOAh0mhVA9VBMHd+9U7Zb2THMGdBUoZVOtGbJzjxsYGDJ3A9AYYCP4hn6y1TVbaOfzWtm5GFg=="
     },
     "rechoir": {
       "version": "0.7.1",
@@ -49919,6 +50522,12 @@
         "ajv-errors": "^1.0.0",
         "ajv-keywords": "^3.1.0"
       }
+    },
+    "secure-json-parse": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/secure-json-parse/-/secure-json-parse-2.7.0.tgz",
+      "integrity": "sha512-6aU+Rwsezw7VR8/nyvKTx8QpWH9FrcYiXXlqC4z5d5XQBDRqtbfsRjnwGyqbi3gddNtWHuEk9OANUotL26qKUw==",
+      "peer": true
     },
     "seedrandom": {
       "version": "3.0.5"
@@ -50821,6 +51430,14 @@
         "socks": "^2.6.2"
       }
     },
+    "sonic-boom": {
+      "version": "3.5.0",
+      "resolved": "https://registry.npmjs.org/sonic-boom/-/sonic-boom-3.5.0.tgz",
+      "integrity": "sha512-02A0wEmj4d3aEIW/Sp6LMP1dNcG5cYmQPjhgtytIXa9tNmFZx3ragUPFmyBdgdM0yJJVSWwlLLEVHgrYfA0wtQ==",
+      "requires": {
+        "atomic-sleep": "^1.0.0"
+      }
+    },
     "sort-keys": {
       "version": "2.0.0",
       "dev": true,
@@ -51552,6 +52169,14 @@
       "integrity": "sha512-RNxQH/qI8/t3thXJDwcstUO4zeqo64+Uy/+sNVRBx4Xn2OX+OZ9oP+iJnNFqplFra2ZUVeKCSa2oVWi3T4uVmA==",
       "requires": {
         "thenify": ">= 3.1.0 < 4"
+      }
+    },
+    "thread-stream": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/thread-stream/-/thread-stream-2.4.1.tgz",
+      "integrity": "sha512-d/Ex2iWd1whipbT681JmTINKw0ZwOUBZm7+Gjs64DHuX34mmw8vJL2bFAaNacaW72zYiTJxSHi5abUuOi5nsfg==",
+      "requires": {
+        "real-require": "^0.2.0"
       }
     },
     "throat": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -6841,6 +6841,18 @@
         "npm": "7.x || 8.x || 9.x"
       }
     },
+    "node_modules/@dotcom-reliability-kit/crash-handler": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@dotcom-reliability-kit/crash-handler/-/crash-handler-3.0.2.tgz",
+      "integrity": "sha512-+o8gfHC4B4RkqEThoiPU29qVeSlmJQ96sr6KDtoSVXg/J03QRK0mnYgvNsY0AonxyIdgZPD9Tteq6tDomTNP1A==",
+      "dependencies": {
+        "@dotcom-reliability-kit/log-error": "^3.1.0"
+      },
+      "engines": {
+        "node": "16.x || 18.x || 20.x",
+        "npm": "7.x || 8.x || 9.x"
+      }
+    },
     "node_modules/@dotcom-reliability-kit/eslint-config": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/@dotcom-reliability-kit/eslint-config/-/eslint-config-2.0.0.tgz",
@@ -6852,6 +6864,21 @@
       },
       "peerDependencies": {
         "eslint": ">=8.27.0"
+      }
+    },
+    "node_modules/@dotcom-reliability-kit/log-error": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@dotcom-reliability-kit/log-error/-/log-error-3.1.0.tgz",
+      "integrity": "sha512-1HAjOQuNXZQkyIQ3A+i0SFUylFMKF+R4sx923RN2NU9DA+f3S4F7Yd+L7ty36ocZJL1YYrUjtcr2Yx9IC+hh7g==",
+      "dependencies": {
+        "@dotcom-reliability-kit/app-info": "^2.1.0",
+        "@dotcom-reliability-kit/logger": "^2.2.9",
+        "@dotcom-reliability-kit/serialize-error": "^2.1.0",
+        "@dotcom-reliability-kit/serialize-request": "^2.2.0"
+      },
+      "engines": {
+        "node": "16.x || 18.x || 20.x",
+        "npm": "7.x || 8.x || 9.x"
       }
     },
     "node_modules/@dotcom-reliability-kit/logger": {
@@ -6876,6 +6903,15 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/@dotcom-reliability-kit/serialize-error/-/serialize-error-2.1.0.tgz",
       "integrity": "sha512-JYgnyvds/FZ0KJVRtOAsk9skue5i/vDBkRvQQg5Q/xlbwLdeUSAtD3XXBtlaohHov8kY7/I9UaXcoG6zXZ3a5Q==",
+      "engines": {
+        "node": "16.x || 18.x || 20.x",
+        "npm": "7.x || 8.x || 9.x"
+      }
+    },
+    "node_modules/@dotcom-reliability-kit/serialize-request": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@dotcom-reliability-kit/serialize-request/-/serialize-request-2.2.0.tgz",
+      "integrity": "sha512-jM8GWWFzBFAXVkv1PPssAFC7mZLoEac9LV5HIINKmhxxe+av3eXJH53MwNQUARMqrIA3Hm7D7khT4L5gnuGcDg==",
       "engines": {
         "node": "16.x || 18.x || 20.x",
         "npm": "7.x || 8.x || 9.x"
@@ -7184,6 +7220,7 @@
     },
     "node_modules/@financial-times/n-flags-client": {
       "version": "9.1.5",
+      "dev": true,
       "dependencies": {
         "@financial-times/n-logger": "^5.4.8",
         "n-eager-fetch": "^2.1.0",
@@ -7195,6 +7232,7 @@
     },
     "node_modules/@financial-times/n-logger": {
       "version": "5.7.2",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "isomorphic-fetch": "^2.2.1",
@@ -7207,6 +7245,7 @@
     },
     "node_modules/@financial-times/n-logger/node_modules/winston": {
       "version": "2.4.6",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "async": "^3.2.3",
@@ -7222,6 +7261,7 @@
     },
     "node_modules/@financial-times/n-raven": {
       "version": "3.0.4",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@financial-times/n-logger": "^5.5.7",
@@ -12615,6 +12655,7 @@
     },
     "node_modules/charenc": {
       "version": "0.0.2",
+      "dev": true,
       "license": "BSD-3-Clause",
       "engines": {
         "node": "*"
@@ -13161,6 +13202,7 @@
     },
     "node_modules/colors": {
       "version": "1.0.3",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.1.90"
@@ -13459,6 +13501,7 @@
     },
     "node_modules/cookie": {
       "version": "0.3.1",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
@@ -13801,6 +13844,7 @@
     },
     "node_modules/crypt": {
       "version": "0.0.2",
+      "dev": true,
       "license": "BSD-3-Clause",
       "engines": {
         "node": "*"
@@ -16534,6 +16578,7 @@
     },
     "node_modules/ft-next-router": {
       "version": "1.0.3",
+      "dev": true,
       "hasInstallScript": true,
       "dependencies": {
         "@financial-times/n-flags-client": "9.1.5",
@@ -16565,6 +16610,7 @@
     },
     "node_modules/ft-next-router/node_modules/@financial-times/n-logger": {
       "version": "6.1.0",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "isomorphic-fetch": "^2.2.1",
@@ -16578,6 +16624,7 @@
     },
     "node_modules/ft-next-router/node_modules/winston": {
       "version": "2.4.6",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "async": "^3.2.3",
@@ -16593,6 +16640,7 @@
     },
     "node_modules/ft-poller": {
       "version": "3.0.1",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "isomorphic-fetch": "^2.0.0",
@@ -20347,6 +20395,7 @@
     },
     "node_modules/md5": {
       "version": "2.3.0",
+      "dev": true,
       "license": "BSD-3-Clause",
       "dependencies": {
         "charenc": "0.0.2",
@@ -21084,6 +21133,7 @@
     },
     "node_modules/n-eager-fetch": {
       "version": "2.2.1",
+      "dev": true,
       "dependencies": {
         "@financial-times/n-logger": "^5.3.0",
         "isomorphic-fetch": "^2.1.1",
@@ -21261,6 +21311,7 @@
     },
     "node_modules/next-metrics": {
       "version": "5.0.6",
+      "dev": true,
       "dependencies": {
         "@financial-times/n-logger": "^5.5.6",
         "lodash": "^4.17.10",
@@ -24038,6 +24089,7 @@
     },
     "node_modules/raven": {
       "version": "2.6.4",
+      "dev": true,
       "license": "BSD-2-Clause",
       "dependencies": {
         "cookie": "0.3.1",
@@ -24055,6 +24107,7 @@
     },
     "node_modules/raven/node_modules/uuid": {
       "version": "3.3.2",
+      "dev": true,
       "license": "MIT",
       "bin": {
         "uuid": "bin/uuid"
@@ -27440,6 +27493,7 @@
     },
     "node_modules/timed-out": {
       "version": "4.0.1",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -30591,7 +30645,7 @@
         "@dotcom-tool-kit/logger": "^3.2.0",
         "@dotcom-tool-kit/state": "^3.1.1",
         "@dotcom-tool-kit/types": "^3.4.0",
-        "ft-next-router": "^1.0.0",
+        "ft-next-router": "^3.0.0",
         "tslib": "^2.3.1"
       },
       "engines": {
@@ -30600,6 +30654,111 @@
       },
       "peerDependencies": {
         "dotcom-tool-kit": "3.x"
+      }
+    },
+    "plugins/next-router/node_modules/@financial-times/n-flags-client": {
+      "version": "14.0.1",
+      "resolved": "https://registry.npmjs.org/@financial-times/n-flags-client/-/n-flags-client-14.0.1.tgz",
+      "integrity": "sha512-gTwqo4Bzu9GQlGgaBF7U9B6cHt4YVPFPSBuyUNbUPB9TJOvdi7wY0TueBFmOOydcfuF1i2HRJeXP6foTfoBoWw==",
+      "dependencies": {
+        "@dotcom-reliability-kit/logger": "^2.2.6",
+        "n-eager-fetch": "^7.0.0",
+        "vary": "^1.1.2"
+      },
+      "engines": {
+        "node": "16.x || 18.x",
+        "npm": "7.x || 8.x || 9.x"
+      }
+    },
+    "plugins/next-router/node_modules/ft-next-router": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/ft-next-router/-/ft-next-router-3.0.0.tgz",
+      "integrity": "sha512-tQ8c45o2xEhbx/OGuWM/xEL5GkBnKg/mJ2+BVkBayHqvf0vFJCokPVq1Rqw84CQZnIRw/WMYe6j+eD9DEr54uA==",
+      "dependencies": {
+        "@dotcom-reliability-kit/crash-handler": "^3.0.2",
+        "@dotcom-reliability-kit/log-error": "^3.1.0",
+        "@dotcom-reliability-kit/logger": "^2.2.9",
+        "@financial-times/n-flags-client": "^14.0.1",
+        "connect": "^3.6.6",
+        "daemonize2": "^0.4.2",
+        "ft-poller": "^9.0.0",
+        "http-proxy": "^1.17.0",
+        "httpolyglot": "^0.1.2",
+        "isomorphic-fetch": "2.2.1",
+        "lodash": "^4.17.10",
+        "metrics": "^0.1.15",
+        "minimist": "^1.2.0",
+        "next-metrics": "^10.0.3",
+        "scarlet": "^2.0.20",
+        "seedrandom": "^3.0.0",
+        "strong-cluster-control": "^2.2.3",
+        "tcp-port-used": "^1.0.1"
+      },
+      "bin": {
+        "next-router": "bin/next-router",
+        "next-router-https": "bin/next-router-https"
+      },
+      "engines": {
+        "node": "18.x"
+      }
+    },
+    "plugins/next-router/node_modules/ft-poller": {
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/ft-poller/-/ft-poller-9.0.0.tgz",
+      "integrity": "sha512-oHo0nICYKdAxsHy66mKBojCddAHfXiR2gcF0hbMoIuDm6tLzXumwUgFcGMQ1EK5R0C2ZVwb20p6kumGP8qLusA==",
+      "dependencies": {
+        "@dotcom-reliability-kit/logger": "^2.2.7",
+        "isomorphic-fetch": "^3.0.0",
+        "n-eager-fetch": "^7.0.0"
+      },
+      "engines": {
+        "node": "16.x || 18.x",
+        "npm": "7.x || 8.x || 9.x"
+      }
+    },
+    "plugins/next-router/node_modules/ft-poller/node_modules/isomorphic-fetch": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/isomorphic-fetch/-/isomorphic-fetch-3.0.0.tgz",
+      "integrity": "sha512-qvUtwJ3j6qwsF3jLxkZ72qCgjMysPzDfeV240JHiGZsANBYd+EEuu35v7dfrJ9Up0Ak07D7GGSkGhCHTqg/5wA==",
+      "dependencies": {
+        "node-fetch": "^2.6.1",
+        "whatwg-fetch": "^3.4.1"
+      }
+    },
+    "plugins/next-router/node_modules/n-eager-fetch": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/n-eager-fetch/-/n-eager-fetch-7.1.0.tgz",
+      "integrity": "sha512-tPlZDKf1Tzir0czXvu63wuZb5RDIP+Lpqq56dfVu06qJqerAedUp2LspFbKQfxBKZdwpnKf5R9NLLZhEfR5tlQ==",
+      "dependencies": {
+        "isomorphic-fetch": "^3.0.0",
+        "npm-prepublish": "^1.2.2"
+      },
+      "engines": {
+        "node": "16.x || 18.x",
+        "npm": "7.x || 8.x || 9.x"
+      }
+    },
+    "plugins/next-router/node_modules/n-eager-fetch/node_modules/isomorphic-fetch": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/isomorphic-fetch/-/isomorphic-fetch-3.0.0.tgz",
+      "integrity": "sha512-qvUtwJ3j6qwsF3jLxkZ72qCgjMysPzDfeV240JHiGZsANBYd+EEuu35v7dfrJ9Up0Ak07D7GGSkGhCHTqg/5wA==",
+      "dependencies": {
+        "node-fetch": "^2.6.1",
+        "whatwg-fetch": "^3.4.1"
+      }
+    },
+    "plugins/next-router/node_modules/next-metrics": {
+      "version": "10.0.3",
+      "resolved": "https://registry.npmjs.org/next-metrics/-/next-metrics-10.0.3.tgz",
+      "integrity": "sha512-HtYrmL0h79Bho3oW423oQFEW9Piu+i++cgUNM/HUtU2xlWkNtOwhhp3gWz906PexfoB7qaLmE7zS+S8SY32Z3w==",
+      "dependencies": {
+        "@dotcom-reliability-kit/logger": "^2.2.6",
+        "lodash": "^4.17.21",
+        "metrics": "^0.1.8"
+      },
+      "engines": {
+        "node": "16.x || 18.x",
+        "npm": "7.x || 8.x || 9.x"
       }
     },
     "plugins/next-router/node_modules/tslib": {
@@ -35072,12 +35231,31 @@
       "resolved": "https://registry.npmjs.org/@dotcom-reliability-kit/app-info/-/app-info-2.1.0.tgz",
       "integrity": "sha512-u7QicgkUbN58IMywvXmNuXxMK5bHUKfjeDC6s3u7TQg5uTGNicdrpBb8zB2O5K++g5KIlVnAafPcJct3ct9Nfw=="
     },
+    "@dotcom-reliability-kit/crash-handler": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@dotcom-reliability-kit/crash-handler/-/crash-handler-3.0.2.tgz",
+      "integrity": "sha512-+o8gfHC4B4RkqEThoiPU29qVeSlmJQ96sr6KDtoSVXg/J03QRK0mnYgvNsY0AonxyIdgZPD9Tteq6tDomTNP1A==",
+      "requires": {
+        "@dotcom-reliability-kit/log-error": "^3.1.0"
+      }
+    },
     "@dotcom-reliability-kit/eslint-config": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/@dotcom-reliability-kit/eslint-config/-/eslint-config-2.0.0.tgz",
       "integrity": "sha512-h9v1nZ4FRe2iHVm53QGoq4BafbQOWhtb0b/Kuxd3ed+HMvYn/ft8A/Av/Xg8vAnJ7uoJspWgkt8qxgDnwX5vxg==",
       "dev": true,
       "requires": {}
+    },
+    "@dotcom-reliability-kit/log-error": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@dotcom-reliability-kit/log-error/-/log-error-3.1.0.tgz",
+      "integrity": "sha512-1HAjOQuNXZQkyIQ3A+i0SFUylFMKF+R4sx923RN2NU9DA+f3S4F7Yd+L7ty36ocZJL1YYrUjtcr2Yx9IC+hh7g==",
+      "requires": {
+        "@dotcom-reliability-kit/app-info": "^2.1.0",
+        "@dotcom-reliability-kit/logger": "^2.2.9",
+        "@dotcom-reliability-kit/serialize-error": "^2.1.0",
+        "@dotcom-reliability-kit/serialize-request": "^2.2.0"
+      }
     },
     "@dotcom-reliability-kit/logger": {
       "version": "2.2.9",
@@ -35094,6 +35272,11 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/@dotcom-reliability-kit/serialize-error/-/serialize-error-2.1.0.tgz",
       "integrity": "sha512-JYgnyvds/FZ0KJVRtOAsk9skue5i/vDBkRvQQg5Q/xlbwLdeUSAtD3XXBtlaohHov8kY7/I9UaXcoG6zXZ3a5Q=="
+    },
+    "@dotcom-reliability-kit/serialize-request": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@dotcom-reliability-kit/serialize-request/-/serialize-request-2.2.0.tgz",
+      "integrity": "sha512-jM8GWWFzBFAXVkv1PPssAFC7mZLoEac9LV5HIINKmhxxe+av3eXJH53MwNQUARMqrIA3Hm7D7khT4L5gnuGcDg=="
     },
     "@dotcom-tool-kit/babel": {
       "version": "file:plugins/babel",
@@ -36487,10 +36670,96 @@
         "@dotcom-tool-kit/logger": "^3.2.0",
         "@dotcom-tool-kit/state": "^3.1.1",
         "@dotcom-tool-kit/types": "^3.4.0",
-        "ft-next-router": "^1.0.0",
+        "ft-next-router": "^3.0.0",
         "tslib": "^2.3.1"
       },
       "dependencies": {
+        "@financial-times/n-flags-client": {
+          "version": "14.0.1",
+          "resolved": "https://registry.npmjs.org/@financial-times/n-flags-client/-/n-flags-client-14.0.1.tgz",
+          "integrity": "sha512-gTwqo4Bzu9GQlGgaBF7U9B6cHt4YVPFPSBuyUNbUPB9TJOvdi7wY0TueBFmOOydcfuF1i2HRJeXP6foTfoBoWw==",
+          "requires": {
+            "@dotcom-reliability-kit/logger": "^2.2.6",
+            "n-eager-fetch": "^7.0.0",
+            "vary": "^1.1.2"
+          }
+        },
+        "ft-next-router": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/ft-next-router/-/ft-next-router-3.0.0.tgz",
+          "integrity": "sha512-tQ8c45o2xEhbx/OGuWM/xEL5GkBnKg/mJ2+BVkBayHqvf0vFJCokPVq1Rqw84CQZnIRw/WMYe6j+eD9DEr54uA==",
+          "requires": {
+            "@dotcom-reliability-kit/crash-handler": "^3.0.2",
+            "@dotcom-reliability-kit/log-error": "^3.1.0",
+            "@dotcom-reliability-kit/logger": "^2.2.9",
+            "@financial-times/n-flags-client": "^14.0.1",
+            "connect": "^3.6.6",
+            "daemonize2": "^0.4.2",
+            "ft-poller": "^9.0.0",
+            "http-proxy": "^1.17.0",
+            "httpolyglot": "^0.1.2",
+            "isomorphic-fetch": "2.2.1",
+            "lodash": "^4.17.10",
+            "metrics": "^0.1.15",
+            "minimist": "^1.2.0",
+            "next-metrics": "^10.0.3",
+            "scarlet": "^2.0.20",
+            "seedrandom": "^3.0.0",
+            "strong-cluster-control": "^2.2.3",
+            "tcp-port-used": "^1.0.1"
+          }
+        },
+        "ft-poller": {
+          "version": "9.0.0",
+          "resolved": "https://registry.npmjs.org/ft-poller/-/ft-poller-9.0.0.tgz",
+          "integrity": "sha512-oHo0nICYKdAxsHy66mKBojCddAHfXiR2gcF0hbMoIuDm6tLzXumwUgFcGMQ1EK5R0C2ZVwb20p6kumGP8qLusA==",
+          "requires": {
+            "@dotcom-reliability-kit/logger": "^2.2.7",
+            "isomorphic-fetch": "^3.0.0",
+            "n-eager-fetch": "^7.0.0"
+          },
+          "dependencies": {
+            "isomorphic-fetch": {
+              "version": "3.0.0",
+              "resolved": "https://registry.npmjs.org/isomorphic-fetch/-/isomorphic-fetch-3.0.0.tgz",
+              "integrity": "sha512-qvUtwJ3j6qwsF3jLxkZ72qCgjMysPzDfeV240JHiGZsANBYd+EEuu35v7dfrJ9Up0Ak07D7GGSkGhCHTqg/5wA==",
+              "requires": {
+                "node-fetch": "^2.6.1",
+                "whatwg-fetch": "^3.4.1"
+              }
+            }
+          }
+        },
+        "n-eager-fetch": {
+          "version": "7.1.0",
+          "resolved": "https://registry.npmjs.org/n-eager-fetch/-/n-eager-fetch-7.1.0.tgz",
+          "integrity": "sha512-tPlZDKf1Tzir0czXvu63wuZb5RDIP+Lpqq56dfVu06qJqerAedUp2LspFbKQfxBKZdwpnKf5R9NLLZhEfR5tlQ==",
+          "requires": {
+            "isomorphic-fetch": "^3.0.0",
+            "npm-prepublish": "^1.2.2"
+          },
+          "dependencies": {
+            "isomorphic-fetch": {
+              "version": "3.0.0",
+              "resolved": "https://registry.npmjs.org/isomorphic-fetch/-/isomorphic-fetch-3.0.0.tgz",
+              "integrity": "sha512-qvUtwJ3j6qwsF3jLxkZ72qCgjMysPzDfeV240JHiGZsANBYd+EEuu35v7dfrJ9Up0Ak07D7GGSkGhCHTqg/5wA==",
+              "requires": {
+                "node-fetch": "^2.6.1",
+                "whatwg-fetch": "^3.4.1"
+              }
+            }
+          }
+        },
+        "next-metrics": {
+          "version": "10.0.3",
+          "resolved": "https://registry.npmjs.org/next-metrics/-/next-metrics-10.0.3.tgz",
+          "integrity": "sha512-HtYrmL0h79Bho3oW423oQFEW9Piu+i++cgUNM/HUtU2xlWkNtOwhhp3gWz906PexfoB7qaLmE7zS+S8SY32Z3w==",
+          "requires": {
+            "@dotcom-reliability-kit/logger": "^2.2.6",
+            "lodash": "^4.17.21",
+            "metrics": "^0.1.8"
+          }
+        },
         "tslib": {
           "version": "2.4.1",
           "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
@@ -37818,6 +38087,7 @@
     },
     "@financial-times/n-flags-client": {
       "version": "9.1.5",
+      "dev": true,
       "requires": {
         "@financial-times/n-logger": "^5.4.8",
         "n-eager-fetch": "^2.1.0",
@@ -37826,6 +38096,7 @@
     },
     "@financial-times/n-logger": {
       "version": "5.7.2",
+      "dev": true,
       "requires": {
         "isomorphic-fetch": "^2.2.1",
         "request": "^2.83.0",
@@ -37834,6 +38105,7 @@
       "dependencies": {
         "winston": {
           "version": "2.4.6",
+          "dev": true,
           "requires": {
             "async": "^3.2.3",
             "colors": "1.0.x",
@@ -37847,6 +38119,7 @@
     },
     "@financial-times/n-raven": {
       "version": "3.0.4",
+      "dev": true,
       "requires": {
         "@financial-times/n-logger": "^5.5.7",
         "raven": "^2.3.0"
@@ -41913,7 +42186,8 @@
       "version": "0.7.0"
     },
     "charenc": {
-      "version": "0.0.2"
+      "version": "0.0.2",
+      "dev": true
     },
     "check-engines": {
       "version": "1.5.0",
@@ -42307,7 +42581,8 @@
       "version": "2.0.16"
     },
     "colors": {
-      "version": "1.0.3"
+      "version": "1.0.3",
+      "dev": true
     },
     "colorspace": {
       "version": "1.1.4",
@@ -42525,7 +42800,8 @@
       }
     },
     "cookie": {
-      "version": "0.3.1"
+      "version": "0.3.1",
+      "dev": true
     },
     "cookiejar": {
       "version": "2.1.4",
@@ -42754,7 +43030,8 @@
       }
     },
     "crypt": {
-      "version": "0.0.2"
+      "version": "0.0.2",
+      "dev": true
     },
     "crypto-browserify": {
       "version": "3.12.0",
@@ -44750,6 +45027,7 @@
     },
     "ft-next-router": {
       "version": "1.0.3",
+      "dev": true,
       "requires": {
         "@financial-times/n-flags-client": "9.1.5",
         "@financial-times/n-logger": "6.1.0",
@@ -44772,6 +45050,7 @@
       "dependencies": {
         "@financial-times/n-logger": {
           "version": "6.1.0",
+          "dev": true,
           "requires": {
             "isomorphic-fetch": "^2.2.1",
             "json-stringify-safe": "^5.0.1",
@@ -44781,6 +45060,7 @@
         },
         "winston": {
           "version": "2.4.6",
+          "dev": true,
           "requires": {
             "async": "^3.2.3",
             "colors": "1.0.x",
@@ -44794,6 +45074,7 @@
     },
     "ft-poller": {
       "version": "3.0.1",
+      "dev": true,
       "requires": {
         "isomorphic-fetch": "^2.0.0",
         "n-eager-fetch": "^2.0.0"
@@ -47254,6 +47535,7 @@
     },
     "md5": {
       "version": "2.3.0",
+      "dev": true,
       "requires": {
         "charenc": "0.0.2",
         "crypt": "0.0.2",
@@ -47771,6 +48053,7 @@
     },
     "n-eager-fetch": {
       "version": "2.2.1",
+      "dev": true,
       "requires": {
         "@financial-times/n-logger": "^5.3.0",
         "isomorphic-fetch": "^2.1.1",
@@ -47902,6 +48185,7 @@
     },
     "next-metrics": {
       "version": "5.0.6",
+      "dev": true,
       "requires": {
         "@financial-times/n-logger": "^5.5.6",
         "lodash": "^4.17.10",
@@ -49809,6 +50093,7 @@
     },
     "raven": {
       "version": "2.6.4",
+      "dev": true,
       "requires": {
         "cookie": "0.3.1",
         "md5": "^2.2.1",
@@ -49818,7 +50103,8 @@
       },
       "dependencies": {
         "uuid": {
-          "version": "3.3.2"
+          "version": "3.3.2",
+          "dev": true
         }
       }
     },
@@ -52193,7 +52479,8 @@
       }
     },
     "timed-out": {
-      "version": "4.0.1"
+      "version": "4.0.1",
+      "dev": true
     },
     "timers-browserify": {
       "version": "2.0.12",

--- a/plugins/next-router/package.json
+++ b/plugins/next-router/package.json
@@ -15,7 +15,7 @@
     "@dotcom-tool-kit/logger": "^3.2.0",
     "@dotcom-tool-kit/types": "^3.4.0",
     "@dotcom-tool-kit/doppler": "^1.0.1",
-    "ft-next-router": "^1.0.0",
+    "ft-next-router": "^3.0.0",
     "tslib": "^2.3.1"
   },
   "repository": {


### PR DESCRIPTION
# Description

This removes n-logger across Tool Kit's non-development dependencies. This means that apps which use Tool Kit will no longer install n-logger as a development dependency.

# Checklist:

- [x] My branch has been rebased onto the latest commit on main (don't merge main into your branch)
- [x] My commit messages are [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/), for example: `feat(circleci): add support for nightly workflows`, `fix: set Heroku app name for staging apps too`
