### PR TITLE
CPP-1664: deprecate pa11y

### DIFF
--- a/plugins/pa11y/.toolkitrc.yml
+++ b/plugins/pa11y/.toolkitrc.yml
@@ -2,4 +2,4 @@ plugins:
   - '@dotcom-tool-kit/doppler'
 
 hooks:
-  'test:review': Pa11y
+  'test:local': Pa11y

--- a/plugins/pa11y/readme.md
+++ b/plugins/pa11y/readme.md
@@ -27,7 +27,7 @@ plugins:
 
 | Task | Description | Preconfigured hook |
 |-|-|-|
-| `Pa11y` | runs `pa11y-ci` to execute Pa11y tests | `test:review` |
+| `Pa11y` | runs `pa11y-ci` to execute Pa11y tests | `test:local` |
 
 ## To note
 

--- a/plugins/pa11y/readme.md
+++ b/plugins/pa11y/readme.md
@@ -1,6 +1,12 @@
-# @dotcom-tool-kit/pa11y
+# @dotcom-tool-kit/pa11y [DEPRECATED]
 
 A plugin to run [Pa11y](https://github.com/pa11y/pa11y) accessibility tests. This plugin uses [Pa11y CI](https://github.com/pa11y/pa11y-ci) to run the tests.
+
+## Deprecation warning (04/10/2023)
+
+Customer Products no longer recommends using Pa11y for Accessibility testing. This package will be deleted by the end of the year ([CPP-1719](https://financialtimes.atlassian.net/browse/CPP-1719)). We suggest flowing the [Accessibility Guidance in Tech Hub](https://tech.in.ft.com/tech-topics/front-end-development/accessibility) to setup Accessibility testing.
+
+Read more about this decision here: https://financialtimes.atlassian.net/wiki/spaces/CPP/blog/2023/10/04/8161493012/Deprecation+of+Pa11y+in+Customer+Products
 
 ## Installation
 

--- a/plugins/pa11y/src/tasks/pa11y.ts
+++ b/plugins/pa11y/src/tasks/pa11y.ts
@@ -15,9 +15,7 @@ export default class Pa11y extends Task<typeof Pa11ySchema> {
 
     if (localState) {
       process.env.TEST_URL = `https://local.ft.com:${localState.port}`
-    }
-
-    if (reviewState) {
+    } else if (reviewState) {
       process.env.TEST_URL = `https://${reviewState.appName}.herokuapp.com`
     }
 

--- a/plugins/pa11y/src/tasks/pa11y.ts
+++ b/plugins/pa11y/src/tasks/pa11y.ts
@@ -10,7 +10,13 @@ export default class Pa11y extends Task<typeof Pa11ySchema> {
   static description = ''
 
   async run(): Promise<void> {
+    const localState = readState('local')
     const reviewState = readState('review')
+
+    if (localState) {
+      process.env.TEST_URL = `https://local.ft.com:${localState.port}`
+    }
+
     if (reviewState) {
       process.env.TEST_URL = `https://${reviewState.appName}.herokuapp.com`
     }

--- a/plugins/pa11y/test/pa11y.test.ts
+++ b/plugins/pa11y/test/pa11y.test.ts
@@ -21,12 +21,31 @@ jest.mock('@dotcom-tool-kit/logger')
 jest.mock('@dotcom-tool-kit/state')
 
 describe('pa11y', () => {
-  it("sets process.env.TEST_URL if readState('review') is truthy", async () => {
-    jest.mocked(state.readState).mockReturnValue({ appName } as state.ReviewState)
-
+  let MOCK_ENV: 'local' | 'ci' = 'local'
+  beforeEach(() => {
+    jest.mocked(state.readState).mockImplementation((stateType) => {
+      let returnState
+      if (stateType === 'local' && MOCK_ENV === 'local') {
+        returnState = { port: 5050 } as state.LocalState
+      }
+      if (stateType === 'review' && MOCK_ENV === 'ci') {
+        returnState = { appName } as state.ReviewState
+      }
+      return returnState
+    })
+  })
+  it("sets process.env.TEST_URL as a herokuapp url if readState('review') is truthy", async () => {
+    MOCK_ENV = 'ci'
     const pa11y = new Pa11y(logger, {})
     await pa11y.run()
 
     expect(process.env.TEST_URL).toBe(`https://${appName}.herokuapp.com`)
+  })
+  it("sets process.env.TEST_URL as a local env url if readState('local') is truthy", async () => {
+    MOCK_ENV = 'local'
+    const pa11y = new Pa11y(logger, {})
+    await pa11y.run()
+
+    expect(process.env.TEST_URL).toBe(`https://local.ft.com:5050`)
   })
 })

--- a/plugins/pa11y/test/pa11y.test.ts
+++ b/plugins/pa11y/test/pa11y.test.ts
@@ -27,8 +27,7 @@ describe('pa11y', () => {
       let returnState
       if (stateType === 'local' && MOCK_ENV === 'local') {
         returnState = { port: 5050 } as state.LocalState
-      }
-      if (stateType === 'review' && MOCK_ENV === 'ci') {
+      } else if (stateType === 'review' && MOCK_ENV === 'ci') {
         returnState = { appName } as state.ReviewState
       }
       return returnState


### PR DESCRIPTION
# Description

We are deprecating the Pa11y plugin as it is no longer recommended for accessibility testing within Customer Products. This PR adds the ability to run Pa11y locally (as an immediate step to support teams relying on the tool for now) then a deprecation warning along with suggestions for next steps.

# Checklist:

- [x] My branch has been rebased onto the latest commit on main (don't merge main into your branch)
- [x] My commit messages are [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/), for example: `feat(circleci): add support for nightly workflows`, `fix: set Heroku app name for staging apps too`
