### PR TITLE
Match new name for production configs in Doppler

### DIFF
--- a/core/create/src/prompts/oidc.ts
+++ b/core/create/src/prompts/oidc.ts
@@ -152,7 +152,7 @@ export default async function oidcPrompt(): Promise<boolean> {
   }
 
   // access keys are pulled from Tool Kit's doppler project
-  const dopplerEnvVars = new DopplerEnvVars(winstonLogger, 'prd', {
+  const dopplerEnvVars = new DopplerEnvVars(winstonLogger, 'prod', {
     project: 'dotcom-tool-kit'
   })
   const dopplerSecretsSchema = z.object({

--- a/lib/doppler/src/index.ts
+++ b/lib/doppler/src/index.ts
@@ -8,7 +8,7 @@ import { getOptions } from '@dotcom-tool-kit/options'
 import * as Vault from '@dotcom-tool-kit/vault'
 import type { DopplerOptions as ConfiguredDopplerOptions } from '@dotcom-tool-kit/types/lib/schema/doppler'
 
-export type Environment = 'prd' | 'ci' | 'dev'
+export type Environment = 'prod' | 'ci' | 'dev'
 
 type DopplerOptions = Required<ConfiguredDopplerOptions>
 export type DopplerSecrets = Record<string, string>
@@ -19,7 +19,7 @@ export interface SecretsWithSource {
 }
 
 const dopplerEnvToVaultMap: Record<Environment, Vault.Environment> = {
-  prd: 'production',
+  prod: 'production',
   ci: 'continuous-integration',
   dev: 'development'
 }

--- a/plugins/heroku/src/promoteStagingToProduction.ts
+++ b/plugins/heroku/src/promoteStagingToProduction.ts
@@ -33,7 +33,7 @@ async function promoteStagingToProduction(
   )
 
   for (const id of appIds) {
-    await setAppConfigVars(logger, id, 'prd', systemCode)
+    await setAppConfigVars(logger, id, 'prod', systemCode)
   }
 
   return Promise.all(latestRelease)

--- a/plugins/heroku/src/tasks/review.ts
+++ b/plugins/heroku/src/tasks/review.ts
@@ -17,7 +17,7 @@ export default class HerokuReview extends Task<typeof HerokuSchema> {
       const pipeline = await herokuClient
         .get<HerokuApiResPipeline>(`/pipelines/${this.options.pipeline}`)
         .catch(extractHerokuError(`getting pipeline ${this.options.pipeline}`))
-      await setStageConfigVars(this.logger, 'review', 'prd', pipeline.id)
+      await setStageConfigVars(this.logger, 'review', 'prod', pipeline.id)
 
       let reviewAppId = await getHerokuReviewApp(this.logger, pipeline.id)
 

--- a/plugins/heroku/src/tasks/staging.ts
+++ b/plugins/heroku/src/tasks/staging.ts
@@ -22,7 +22,7 @@ export default class HerokuStaging extends Task<typeof HerokuSchema> {
       const appName = await getHerokuStagingApp()
 
       // setting config vars on staging from the doppler production directory
-      await setAppConfigVars(this.logger, appName, 'prd', this.options.systemCode)
+      await setAppConfigVars(this.logger, appName, 'prod', this.options.systemCode)
 
       // create build from latest commit, even on no change
       const buildDetails = await createBuild(this.logger, appName)

--- a/plugins/heroku/test/promoteStagingToProduction.test.ts
+++ b/plugins/heroku/test/promoteStagingToProduction.test.ts
@@ -40,8 +40,8 @@ describe('promoteStagingToProduction', () => {
     mockHerokuPost.mockImplementationOnce(async () => Promise.resolve(goodHerokuResponse[1]))
     const systemCode = 'test-app'
     await promoteStagingToProduction(logger, slugId, systemCode)
-    expect(setAppConfigVars).toHaveBeenNthCalledWith(1, logger, 'app-id-1', 'prd', systemCode)
-    expect(setAppConfigVars).toHaveBeenNthCalledWith(2, logger, 'app-id-2', 'prd', systemCode)
+    expect(setAppConfigVars).toHaveBeenNthCalledWith(1, logger, 'app-id-1', 'prod', systemCode)
+    expect(setAppConfigVars).toHaveBeenNthCalledWith(2, logger, 'app-id-2', 'prod', systemCode)
   })
 
   it('calls heroku api for each app', async () => {

--- a/plugins/heroku/test/setConfigVars.test.ts
+++ b/plugins/heroku/test/setConfigVars.test.ts
@@ -8,7 +8,7 @@ const logger = (winston as unknown) as Logger
 type DopplerPath = {
   project: string
 }
-const environment = 'prd'
+const environment = 'prod'
 const appName = 'test-staging-app-name'
 const dopplerPath: DopplerPath = {
   project: 'doppler-app'
@@ -97,7 +97,7 @@ describe('setConfigVars', () => {
   })
 
   it('sends an update to the app with the correct path and body for review-app', async () => {
-    await setStageConfigVars(logger, 'review', 'prd', pipelineName)
+    await setStageConfigVars(logger, 'review', 'prod', pipelineName)
 
     expect(heroku.patch).toBeCalledWith(`/pipelines/${pipeline.id}/stage/review/config-vars`, reviewPatchBody)
   })

--- a/plugins/heroku/test/tasks/review.test.ts
+++ b/plugins/heroku/test/tasks/review.test.ts
@@ -110,7 +110,7 @@ describe('review', () => {
 
     await task.run()
 
-    expect(setStageConfigVars).toBeCalledWith(expect.anything(), 'review', 'prd', 'test-pipeline-id')
+    expect(setStageConfigVars).toBeCalledWith(expect.anything(), 'review', 'prod', 'test-pipeline-id')
   })
 
   it('should write app id to state', async () => {

--- a/plugins/heroku/test/tasks/staging.test.ts
+++ b/plugins/heroku/test/tasks/staging.test.ts
@@ -126,7 +126,7 @@ describe('staging', () => {
 
     await task.run()
 
-    expect(setAppConfigVars).toBeCalledWith(expect.anything(), 'test-appName', 'prd', systemCode)
+    expect(setAppConfigVars).toBeCalledWith(expect.anything(), 'test-appName', 'prod', systemCode)
   })
 
   it('should call createBuild with app name', async () => {

--- a/plugins/serverless/src/tasks/deploy.ts
+++ b/plugins/serverless/src/tasks/deploy.ts
@@ -22,7 +22,7 @@ export default class ServerlessDeploy extends Task<typeof ServerlessSchema> {
 
     let dopplerEnv = {}
     if (useVault) {
-      const doppler = new DopplerEnvVars(this.logger, 'prd')
+      const doppler = new DopplerEnvVars(this.logger, 'prod')
 
       dopplerEnv = await doppler.get()
     }


### PR DESCRIPTION
# Description

Follow up to https://financialtimes.slack.com/archives/C04B0SADVNJ/p1696258930072679 and https://github.com/Financial-Times/platform-scripts/commit/97cd07faa80afcf3076196dcb54650ad152fbfb2

# Checklist:

- [x] My branch has been rebased onto the latest commit on main (don't merge main into your branch)
- [x] My commit messages are [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/), for example: `feat(circleci): add support for nightly workflows`, `fix: set Heroku app name for staging apps too`
