### PR TITLE
Print when a task is run to aid user visibility

### DIFF
--- a/core/cli/src/index.ts
+++ b/core/cli/src/index.ts
@@ -77,6 +77,7 @@ ${availableHooks}`
        **/
       const task = new (Task as any)(logger, options)
 
+      logger.info(styles.taskHeader(`running ${styles.task(id)} task`))
       try {
         await task.run(files)
       } catch (error) {

--- a/lib/logger/src/styles.ts
+++ b/lib/logger/src/styles.ts
@@ -15,6 +15,7 @@ export const styles = {
   code: colours.grey.italic,
   dim: colours.grey,
   title: colours.bold.underline,
+  taskHeader: colours.bgWhite.black,
   errorHighlight: colours.red,
   error: (string: string): string => `${styles.errorHighlight.bold('‼︎')} ${styles.title(string)}`,
   warningHighlight: colours.yellow,


### PR DESCRIPTION
# Description

Good to remove some of the abstraction magic from Tool Kit and also particularly useful when multiple tasks are run within a hook. Open to feedback on how this logger message should be formatted.
![Screenshot 2023-10-09 at 16 05 13](https://github.com/Financial-Times/dotcom-tool-kit/assets/7020796/81cacb31-e95e-4176-b042-14f1bcc3fc7f)


# Checklist:

- [x] My branch has been rebased onto the latest commit on main (don't merge main into your branch)
- [x] My commit messages are [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/), for example: `feat(circleci): add support for nightly workflows`, `fix: set Heroku app name for staging apps too`
