### PR TITLE
Strip ANSI escape codes that mess with terminal state, starting with RIS

### DIFF
--- a/lib/logger/src/helpers.ts
+++ b/lib/logger/src/helpers.ts
@@ -116,7 +116,7 @@ export function hookFork(
           transform: (message, _enc, callback) => {
             // add the log level and wrap the message for the winston stream to
             // consume
-            callback(null, { level, message })
+            callback(null, { level, message: cleanupLogs(message) })
           }
         })
       )


### PR DESCRIPTION
# Description

The [`RIS`](https://en.wikipedia.org/wiki/ANSI_escape_code#Fs_Escape_sequences) escape code is [used](https://github.com/microsoft/TypeScript/blob/61a96b1641abe24c4adc3633eb936df89eb991f2/src/compiler/sys.ts#L1604C39-L1604C44) by TypeScript's watch mode to clear the terminal before printing its watch logs. Rather than stripping all the (mostly useful) ANSI escape codes, let's just remove this one that can interfere when Tool Kit is printing logs from multiple tasks.

# Checklist:

- [x] My branch has been rebased onto the latest commit on main (don't merge main into your branch)
- [x] My commit messages are [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/), for example: `feat(circleci): add support for nightly workflows`, `fix: set Heroku app name for staging apps too`
