### PR TITLE
fix: minor tweaks to documentation

### DIFF
--- a/core/create/src/prompts/options.ts
+++ b/core/create/src/prompts/options.ts
@@ -26,7 +26,7 @@ async function optionsPromptForPlugin(
   }
 
   for (const { name: optionName, type: optionType, default: optionDefault } of options) {
-    const typeDescription = optionType.description ?? ''
+    const typeDescription = optionType.description ? ` (${optionType.description})` : ''
     const defaultSuffix = optionDefault
       ? ` (leave blank to use default value ${styles.code(JSON.stringify(optionDefault))})`
       : ''
@@ -45,8 +45,7 @@ async function optionsPromptForPlugin(
             {
               name: 'stringOption',
               type: 'text',
-              message:
-                `Set a value for '${styles.option(optionName)}'` + ` (${typeDescription})` + defaultSuffix
+              message: `Set a value for '${styles.option(optionName)}'` + typeDescription + defaultSuffix
             },
             { onCancel }
           )
@@ -59,7 +58,10 @@ async function optionsPromptForPlugin(
             {
               name: 'boolOption',
               type: 'confirm',
-              message: `Would you like to enable option '${styles.option(optionName)}'?` + defaultSuffix
+              message:
+                `Would you like to enable option '${styles.option(optionName)}'?` +
+                typeDescription +
+                defaultSuffix
             },
             { onCancel }
           )
@@ -72,7 +74,8 @@ async function optionsPromptForPlugin(
             {
               name: 'numberOption',
               type: 'text',
-              message: `Set a numerical value for '${styles.option(optionName)}'` + defaultSuffix
+              message:
+                `Set a numerical value for '${styles.option(optionName)}'` + typeDescription + defaultSuffix
             },
             { onCancel }
           )
@@ -126,7 +129,8 @@ async function optionsPromptForPlugin(
                       value: choice
                     })
                   ),
-                  message: `Select options for '${styles.option(optionName)}'` + defaultSuffix
+                  message:
+                    `Select options for '${styles.option(optionName)}'` + typeDescription + defaultSuffix
                 },
                 { onCancel }
               )
@@ -145,7 +149,7 @@ async function optionsPromptForPlugin(
                 title: choice,
                 value: choice
               })),
-              message: `Select an option for '${styles.option(optionName)}'` + defaultSuffix
+              message: `Select an option for '${styles.option(optionName)}'` + typeDescription + defaultSuffix
             },
             { onCancel }
           )

--- a/docs/migrating-to-tool-kit.md
+++ b/docs/migrating-to-tool-kit.md
@@ -222,23 +222,40 @@ Please check what they're doing:
 - ${makefile target}
 ```
 
-Finally, the tool will give guidance on what the do with the Makefile in your
+Finally, the tool will give guidance on what the do with the `Makefile` in your
 project that was integrated with n-gage. It will try and recommend equivalent
-hooks based on the name of the targets within the Makefile (the `test:local`
+hooks based on the name of the targets within the `Makefile` (the `test:local`
 hook for a `test` target, for example,) but sometimes you'll want to leave some
 of the targets in at the beginning of the migration and gradually transition
 everything over to Tool Kit. Regardless, this step just provides some
 suggestions and the migration tool doesn't perform any actions so you'll need to
-delete the Makefile yourself if you don't think it's needed anymore.
+delete the `Makefile` yourself if you don't think it's needed anymore.
 
 Remember that – assuming you didn't delete it in the earlier step – some of the `make`
-commands come from `n-gage` itself and won't necessarily be in the Makefile,
+commands come from `n-gage` itself and won't necessarily be in the `Makefile`,
 such as `make install`.
 
 You'll also want to ensure that:
 
-- You use the same node entry point of the app on `npm start`
-- You pull through any env set in the Makefile to an .rc file eg. for tests
+1. You have configured the same entry point in `.toolkitrc.yml` as in your `Makefile`. This must be set as an option (if it is not the default `server/app.js`).
+
+   eg.
+
+   ```
+   nht run --script server/cluster.js
+   ```
+
+   in your `Makefile` would become
+
+   ```
+   options:
+      "@dotcom-tool-kit/node":
+         entry: server/cluster.js
+   ```
+
+   in `.toolkitrc.yml`
+
+2. You have moved any environment variables explicitly set in your `Makefile` to the appropriate rc file, eg. `.mocharc.js` for mocha unit tests
 
 ## Migrating Your Heroku Pipeline
 
@@ -260,7 +277,7 @@ A step-by-step guide with screenshots can be found
 
 To ensure the migration has succeeded, you can run the following commands locally:
 
-`npm build` \
+`npm run build` \
 `npm start` \
 `npm test`
 


### PR DESCRIPTION
# Description

fixing the below which were missed in the last PR:

- add `typeDescription` to all zod types
- add examples to ambiguous documentation
- fix invalid `npm build` command

# Checklist:

- [ ] My branch has been rebased onto the latest commit on main (don't merge main into your branch)
- [ ] My commit messages are [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/), for example: `feat(circleci): add support for nightly workflows`, `fix: set Heroku app name for staging apps too`
