### PR TITLE
fix: add newline after ruler in error output

### DIFF
--- a/core/cli/bin/run
+++ b/core/cli/bin/run
@@ -34,7 +34,7 @@ async function main() {
     if (error.details) {
       rootLogger.error('', { skipformat: true })
       rootLogger.error(error.message)
-      rootLogger.error(styles.ruler(), { skipformat: true })
+      rootLogger.error(styles.ruler() + '\n', { skipformat: true })
       rootLogger.error(error.details, { skipformat: true })
     } else {
       rootLogger.error(error.stack)


### PR DESCRIPTION
idk how long this has been broken but it looks horrible
