### PR TITLE
Install doppler CLI for orb jobs that use it

### DIFF
--- a/orb/src/@orb.yml
+++ b/orb/src/@orb.yml
@@ -6,12 +6,13 @@ description: >
 
 # This information will be displayed in the orb registry and is not mandatory.
 display:
-  home_url: "https://www.ft.com"
-  source_url: "https://www.github.com/financial-times/dotcom-tool-kit"
+  home_url: 'https://www.ft.com'
+  source_url: 'https://www.github.com/financial-times/dotcom-tool-kit'
 
 # If your orb requires other orbs, you can import them like this. Otherwise remove the "orbs" stanza.
 orbs:
   node: circleci/node@5.0.2
+  doppler-circleci: ft-circleci-orbs/doppler-circleci@1.3.0
   change-api: financial-times/change-api@1.0.9
   aws-cli: circleci/aws-cli@3.1.4
   serverless-framework: circleci/serverless-framework@2.0.1

--- a/orb/src/jobs/deploy-production.yml
+++ b/orb/src/jobs/deploy-production.yml
@@ -16,6 +16,7 @@ executor: << parameters.executor >>
 
 steps:
   - attach-workspace
+  - doppler-circleci/install
   - when:
       condition:
         and:

--- a/orb/src/jobs/deploy-review.yml
+++ b/orb/src/jobs/deploy-review.yml
@@ -13,6 +13,7 @@ executor: << parameters.executor >>
 
 steps:
   - attach-workspace
+  - doppler-circleci/install
   - when:
       condition:
         and:

--- a/orb/src/jobs/deploy-staging.yml
+++ b/orb/src/jobs/deploy-staging.yml
@@ -7,6 +7,7 @@ executor: << parameters.executor >>
 
 steps:
   - attach-workspace
+  - doppler-circleci/install
   - run:
       name: Deploy to staging
       command: npx dotcom-tool-kit deploy:staging


### PR DESCRIPTION
# Description

Technically every hook could have tasks that use the Doppler CLI via the doppler library, though we don't really want to have to spend time installing it for every job if we can help it and in (our current) reality only the hooks that deploy to Heroku need it in CI.

Fixes the `ENOENT` error we're currently [seeing](https://app.circleci.com/pipelines/github/Financial-Times/next-static/3054/workflows/a445164f-e884-40fd-a11d-c3470ac16c9d/jobs/11467/parallel-runs/0/steps/0-102) when deploying to Heroku in next-static.

# Checklist:

- [x] My branch has been rebased onto the latest commit on main (don't merge main into your branch)
- [x] My commit messages are [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/), for example: `feat(circleci): add support for nightly workflows`, `fix: set Heroku app name for staging apps too`
