### PR TITLE
Use local doppler executable in CI

### DIFF
--- a/lib/doppler/src/index.ts
+++ b/lib/doppler/src/index.ts
@@ -70,7 +70,10 @@ export class DopplerEnvVars {
     let errorMsg = ''
     try {
       let secrets = ''
-      const dopplerChild = spawn('doppler', [
+      // the command we use to install Doppler in CircleCI only installs it in
+      // the local directory, not in $PATH
+      const dopplerExec = process.env.CIRCLECI ? './doppler' : 'doppler'
+      const dopplerChild = spawn(dopplerExec, [
         'secrets',
         'download',
         '--no-file',

--- a/lib/doppler/test/index.test.ts
+++ b/lib/doppler/test/index.test.ts
@@ -11,6 +11,7 @@ spawk.preventUnmatched()
 
 const environment = 'dev'
 const project = 'test-project'
+const dopplerExec = process.env.CIRCLECI ? './doppler' : 'doppler'
 const doppler = new DopplerEnvVars(logger, environment, {
   project
 })
@@ -22,7 +23,7 @@ const expectedArgs = ['secrets', 'download', '--no-file', '--project', project, 
 
 describe(`Doppler CLI invocations`, () => {
   it('should set environment variables downloaded from the CLI', async () => {
-    const interceptor = spawk.spawn('doppler', expectedArgs)
+    const interceptor = spawk.spawn(dopplerExec, expectedArgs)
     interceptor.stdout(JSON.stringify(testEnvironment))
     const env = await doppler.get()
     expect(env).toEqual(testEnvironment)
@@ -30,7 +31,7 @@ describe(`Doppler CLI invocations`, () => {
   })
 
   it("should fall back to Vault when Doppler isn't installed", async () => {
-    const interceptor = spawk.spawn('doppler', expectedArgs)
+    const interceptor = spawk.spawn(dopplerExec, expectedArgs)
     /* eslint-disable-next-line @typescript-eslint/no-explicit-any --
      * spawk type definitions are out of date
      **/
@@ -42,7 +43,7 @@ describe(`Doppler CLI invocations`, () => {
   })
 
   it('should fall back to Vault when Doppler prints an error', async () => {
-    const interceptor = spawk.spawn('doppler', expectedArgs)
+    const interceptor = spawk.spawn(dopplerExec, expectedArgs)
     interceptor.stderr('doppler had an issue')
     const env = await doppler.get()
     expect(env).toBeUndefined()
@@ -51,7 +52,7 @@ describe(`Doppler CLI invocations`, () => {
   })
 
   it('should fall back to Vault when the JSON is unparseable', async () => {
-    const interceptor = spawk.spawn('doppler', expectedArgs)
+    const interceptor = spawk.spawn(dopplerExec, expectedArgs)
     interceptor.stdout(JSON.stringify(testEnvironment).slice(0, 20))
     const env = await doppler.get()
     expect(env).toBeUndefined()


### PR DESCRIPTION
# Description

We're still [failing](https://app.circleci.com/pipelines/github/Financial-Times/next-static/3070/workflows/600941b8-236f-4f6f-9039-b4831216d426/jobs/11488?invite=true#step-103-986_86) to find Doppler in CI as the command we're using to install the CLI only installs it [locally](https://github.com/ft-circleci-orbs/doppler-circleci-orb/blob/a156fa0809694c0d7ee0dba40224aef960a9f02a/src/scripts/install_doppler.sh#L23C148-L23C160) and not in your `$PATH`. I believe they avoid installing the binary as not all CircleCI images give you permission to do so. Rather than adding an option to the command (and potentially breaking some custom Customer Products projects if they run into those permissions issues), let's just check the local directory for the binary if we're running in CircleCI.

# Checklist:

- [x] My branch has been rebased onto the latest commit on main (don't merge main into your branch)
- [x] My commit messages are [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/), for example: `feat(circleci): add support for nightly workflows`, `fix: set Heroku app name for staging apps too`
