### PR TITLE
CPP-1722: fix npm publish task

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -47,7 +47,7 @@
     },
     "core/cli": {
       "name": "dotcom-tool-kit",
-      "version": "3.3.2",
+      "version": "3.3.4",
       "license": "MIT",
       "dependencies": {
         "@dotcom-tool-kit/error": "^3.1.0",
@@ -68,12 +68,12 @@
       },
       "devDependencies": {
         "@dotcom-tool-kit/babel": "^3.1.5",
-        "@dotcom-tool-kit/backend-heroku-app": "^3.0.3",
+        "@dotcom-tool-kit/backend-heroku-app": "^3.0.5",
         "@dotcom-tool-kit/circleci": "^5.3.8",
         "@dotcom-tool-kit/circleci-deploy": "^3.2.8",
         "@dotcom-tool-kit/eslint": "^3.1.5",
-        "@dotcom-tool-kit/frontend-app": "^3.1.16",
-        "@dotcom-tool-kit/heroku": "^3.3.6",
+        "@dotcom-tool-kit/frontend-app": "^3.1.18",
+        "@dotcom-tool-kit/heroku": "^3.3.8",
         "@dotcom-tool-kit/mocha": "^3.1.5",
         "@dotcom-tool-kit/n-test": "^3.2.7",
         "@dotcom-tool-kit/npm": "^3.1.6",
@@ -122,12 +122,12 @@
     },
     "core/create": {
       "name": "@dotcom-tool-kit/create",
-      "version": "3.2.7",
+      "version": "3.2.9",
       "license": "ISC",
       "dependencies": {
         "@aws-sdk/client-iam": "^3.282.0",
         "@aws-sdk/client-sts": "^3.282.0",
-        "@dotcom-tool-kit/doppler": "^1.0.5",
+        "@dotcom-tool-kit/doppler": "^1.0.6",
         "@dotcom-tool-kit/error": "^3.1.0",
         "@dotcom-tool-kit/logger": "^3.3.0",
         "@dotcom-tool-kit/types": "^3.4.1",
@@ -158,7 +158,7 @@
         "@types/pacote": "^11.1.3",
         "@types/prompts": "^2.0.14",
         "cosmiconfig": "^7.0.1",
-        "dotcom-tool-kit": "^3.3.2"
+        "dotcom-tool-kit": "^3.3.4"
       },
       "engines": {
         "node": "16.x || 18.x",
@@ -1828,7 +1828,7 @@
     },
     "lib/doppler": {
       "name": "@dotcom-tool-kit/doppler",
-      "version": "1.0.5",
+      "version": "1.0.6",
       "license": "ISC",
       "dependencies": {
         "@dotcom-tool-kit/error": "^3.1.0",
@@ -9217,6 +9217,7 @@
     },
     "node_modules/@npmcli/fs": {
       "version": "1.1.1",
+      "dev": true,
       "license": "ISC",
       "dependencies": {
         "@gar/promisify": "^1.0.1",
@@ -9287,6 +9288,7 @@
     },
     "node_modules/@npmcli/move-file": {
       "version": "1.1.2",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "mkdirp": "^1.0.4",
@@ -9298,10 +9300,12 @@
     },
     "node_modules/@npmcli/node-gyp": {
       "version": "1.0.3",
+      "dev": true,
       "license": "ISC"
     },
     "node_modules/@npmcli/promise-spawn": {
       "version": "1.3.2",
+      "dev": true,
       "license": "ISC",
       "dependencies": {
         "infer-owner": "^1.0.4"
@@ -9309,6 +9313,7 @@
     },
     "node_modules/@npmcli/run-script": {
       "version": "2.0.0",
+      "dev": true,
       "license": "ISC",
       "dependencies": {
         "@npmcli/node-gyp": "^1.0.2",
@@ -10414,17 +10419,6 @@
         "@types/node": "*"
       }
     },
-    "node_modules/@types/libnpmpublish": {
-      "version": "4.0.2",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/node": "*",
-        "@types/node-fetch": "*",
-        "@types/npm-registry-fetch": "*",
-        "@types/pacote": "*"
-      }
-    },
     "node_modules/@types/lodash": {
       "version": "4.14.189",
       "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.189.tgz",
@@ -10444,14 +10438,6 @@
       "version": "1.2.2",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/@types/minipass": {
-      "version": "3.1.2",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/node": "*"
-      }
     },
     "node_modules/@types/mocha": {
       "version": "8.2.3",
@@ -10617,15 +10603,6 @@
       "license": "MIT",
       "dependencies": {
         "@types/cookiejar": "*",
-        "@types/node": "*"
-      }
-    },
-    "node_modules/@types/tar": {
-      "version": "6.1.1",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/minipass": "*",
         "@types/node": "*"
       }
     },
@@ -12405,6 +12382,7 @@
     },
     "node_modules/cacache": {
       "version": "15.3.0",
+      "dev": true,
       "license": "ISC",
       "dependencies": {
         "@npmcli/fs": "^1.0.0",
@@ -12432,6 +12410,7 @@
     },
     "node_modules/cacache/node_modules/lru-cache": {
       "version": "6.0.0",
+      "dev": true,
       "license": "ISC",
       "dependencies": {
         "yallist": "^4.0.0"
@@ -12442,6 +12421,7 @@
     },
     "node_modules/cacache/node_modules/tar": {
       "version": "6.1.11",
+      "dev": true,
       "license": "ISC",
       "dependencies": {
         "chownr": "^2.0.0",
@@ -12457,6 +12437,7 @@
     },
     "node_modules/cacache/node_modules/yallist": {
       "version": "4.0.0",
+      "dev": true,
       "license": "ISC"
     },
     "node_modules/cache-base": {
@@ -17352,6 +17333,7 @@
     },
     "node_modules/hosted-git-info": {
       "version": "4.1.0",
+      "dev": true,
       "license": "ISC",
       "dependencies": {
         "lru-cache": "^6.0.0"
@@ -17362,6 +17344,7 @@
     },
     "node_modules/hosted-git-info/node_modules/lru-cache": {
       "version": "6.0.0",
+      "dev": true,
       "license": "ISC",
       "dependencies": {
         "yallist": "^4.0.0"
@@ -17372,6 +17355,7 @@
     },
     "node_modules/hosted-git-info/node_modules/yallist": {
       "version": "4.0.0",
+      "dev": true,
       "license": "ISC"
     },
     "node_modules/html_codesniffer": {
@@ -19685,6 +19669,7 @@
     },
     "node_modules/libnpmpack": {
       "version": "3.1.0",
+      "dev": true,
       "license": "ISC",
       "dependencies": {
         "@npmcli/run-script": "^2.0.0",
@@ -19697,6 +19682,7 @@
     },
     "node_modules/libnpmpack/node_modules/@npmcli/git": {
       "version": "2.1.0",
+      "dev": true,
       "license": "ISC",
       "dependencies": {
         "@npmcli/promise-spawn": "^1.3.2",
@@ -19711,6 +19697,7 @@
     },
     "node_modules/libnpmpack/node_modules/ignore-walk": {
       "version": "4.0.1",
+      "dev": true,
       "license": "ISC",
       "dependencies": {
         "minimatch": "^3.0.4"
@@ -19721,6 +19708,7 @@
     },
     "node_modules/libnpmpack/node_modules/lru-cache": {
       "version": "6.0.0",
+      "dev": true,
       "license": "ISC",
       "dependencies": {
         "yallist": "^4.0.0"
@@ -19731,6 +19719,7 @@
     },
     "node_modules/libnpmpack/node_modules/npm-install-checks": {
       "version": "4.0.0",
+      "dev": true,
       "license": "BSD-2-Clause",
       "dependencies": {
         "semver": "^7.1.1"
@@ -19741,6 +19730,7 @@
     },
     "node_modules/libnpmpack/node_modules/npm-packlist": {
       "version": "3.0.0",
+      "dev": true,
       "license": "ISC",
       "dependencies": {
         "glob": "^7.1.6",
@@ -19757,6 +19747,7 @@
     },
     "node_modules/libnpmpack/node_modules/npm-pick-manifest": {
       "version": "6.1.1",
+      "dev": true,
       "license": "ISC",
       "dependencies": {
         "npm-install-checks": "^4.0.0",
@@ -19767,6 +19758,7 @@
     },
     "node_modules/libnpmpack/node_modules/pacote": {
       "version": "12.0.3",
+      "dev": true,
       "license": "ISC",
       "dependencies": {
         "@npmcli/git": "^2.1.0",
@@ -19798,6 +19790,7 @@
     },
     "node_modules/libnpmpack/node_modules/tar": {
       "version": "6.1.11",
+      "dev": true,
       "license": "ISC",
       "dependencies": {
         "chownr": "^2.0.0",
@@ -19813,6 +19806,7 @@
     },
     "node_modules/libnpmpack/node_modules/which": {
       "version": "2.0.2",
+      "dev": true,
       "license": "ISC",
       "dependencies": {
         "isexe": "^2.0.0"
@@ -19826,10 +19820,12 @@
     },
     "node_modules/libnpmpack/node_modules/yallist": {
       "version": "4.0.0",
+      "dev": true,
       "license": "ISC"
     },
     "node_modules/libnpmpublish": {
       "version": "5.0.1",
+      "dev": true,
       "license": "ISC",
       "dependencies": {
         "normalize-package-data": "^3.0.2",
@@ -20321,6 +20317,7 @@
     },
     "node_modules/make-fetch-happen": {
       "version": "9.1.0",
+      "dev": true,
       "license": "ISC",
       "dependencies": {
         "agentkeepalive": "^4.1.3",
@@ -20346,6 +20343,7 @@
     },
     "node_modules/make-fetch-happen/node_modules/lru-cache": {
       "version": "6.0.0",
+      "dev": true,
       "license": "ISC",
       "dependencies": {
         "yallist": "^4.0.0"
@@ -20356,6 +20354,7 @@
     },
     "node_modules/make-fetch-happen/node_modules/yallist": {
       "version": "4.0.0",
+      "dev": true,
       "license": "ISC"
     },
     "node_modules/makeerror": {
@@ -20646,6 +20645,7 @@
     },
     "node_modules/minipass-fetch": {
       "version": "1.4.1",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "minipass": "^3.1.0",
@@ -21407,6 +21407,7 @@
     },
     "node_modules/node-gyp": {
       "version": "8.4.1",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "env-paths": "^2.2.0",
@@ -21429,6 +21430,7 @@
     },
     "node_modules/node-gyp/node_modules/tar": {
       "version": "6.1.11",
+      "dev": true,
       "license": "ISC",
       "dependencies": {
         "chownr": "^2.0.0",
@@ -21444,6 +21446,7 @@
     },
     "node_modules/node-gyp/node_modules/which": {
       "version": "2.0.2",
+      "dev": true,
       "license": "ISC",
       "dependencies": {
         "isexe": "^2.0.0"
@@ -21457,6 +21460,7 @@
     },
     "node_modules/node-gyp/node_modules/yallist": {
       "version": "4.0.0",
+      "dev": true,
       "license": "ISC"
     },
     "node_modules/node-html-parser": {
@@ -21640,6 +21644,7 @@
     },
     "node_modules/normalize-package-data": {
       "version": "3.0.3",
+      "dev": true,
       "license": "BSD-2-Clause",
       "dependencies": {
         "hosted-git-info": "^4.0.1",
@@ -21688,6 +21693,7 @@
     },
     "node_modules/npm-package-arg": {
       "version": "8.1.5",
+      "dev": true,
       "license": "ISC",
       "dependencies": {
         "hosted-git-info": "^4.0.1",
@@ -21863,6 +21869,7 @@
     },
     "node_modules/npm-registry-fetch": {
       "version": "12.0.2",
+      "dev": true,
       "license": "ISC",
       "dependencies": {
         "make-fetch-happen": "^10.0.1",
@@ -21878,6 +21885,7 @@
     },
     "node_modules/npm-registry-fetch/node_modules/@npmcli/fs": {
       "version": "2.1.0",
+      "dev": true,
       "license": "ISC",
       "dependencies": {
         "@gar/promisify": "^1.1.3",
@@ -21889,6 +21897,7 @@
     },
     "node_modules/npm-registry-fetch/node_modules/@npmcli/move-file": {
       "version": "2.0.0",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "mkdirp": "^1.0.4",
@@ -21900,6 +21909,7 @@
     },
     "node_modules/npm-registry-fetch/node_modules/@tootallnate/once": {
       "version": "2.0.0",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 10"
@@ -21907,6 +21917,7 @@
     },
     "node_modules/npm-registry-fetch/node_modules/brace-expansion": {
       "version": "2.0.1",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0"
@@ -21914,6 +21925,7 @@
     },
     "node_modules/npm-registry-fetch/node_modules/cacache": {
       "version": "16.0.7",
+      "dev": true,
       "license": "ISC",
       "dependencies": {
         "@npmcli/fs": "^2.1.0",
@@ -21941,6 +21953,7 @@
     },
     "node_modules/npm-registry-fetch/node_modules/glob": {
       "version": "8.0.1",
+      "dev": true,
       "license": "ISC",
       "dependencies": {
         "fs.realpath": "^1.0.0",
@@ -21959,6 +21972,7 @@
     },
     "node_modules/npm-registry-fetch/node_modules/http-proxy-agent": {
       "version": "5.0.0",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@tootallnate/once": "2",
@@ -21971,6 +21985,7 @@
     },
     "node_modules/npm-registry-fetch/node_modules/lru-cache": {
       "version": "7.9.0",
+      "dev": true,
       "license": "ISC",
       "engines": {
         "node": ">=12"
@@ -21978,6 +21993,7 @@
     },
     "node_modules/npm-registry-fetch/node_modules/make-fetch-happen": {
       "version": "10.1.2",
+      "dev": true,
       "license": "ISC",
       "dependencies": {
         "agentkeepalive": "^4.2.1",
@@ -22003,6 +22019,7 @@
     },
     "node_modules/npm-registry-fetch/node_modules/make-fetch-happen/node_modules/minipass-fetch": {
       "version": "2.1.0",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "minipass": "^3.1.6",
@@ -22018,6 +22035,7 @@
     },
     "node_modules/npm-registry-fetch/node_modules/minimatch": {
       "version": "5.0.1",
+      "dev": true,
       "license": "ISC",
       "dependencies": {
         "brace-expansion": "^2.0.1"
@@ -22028,6 +22046,7 @@
     },
     "node_modules/npm-registry-fetch/node_modules/ssri": {
       "version": "9.0.0",
+      "dev": true,
       "license": "ISC",
       "dependencies": {
         "minipass": "^3.1.1"
@@ -22038,6 +22057,7 @@
     },
     "node_modules/npm-registry-fetch/node_modules/tar": {
       "version": "6.1.11",
+      "dev": true,
       "license": "ISC",
       "dependencies": {
         "chownr": "^2.0.0",
@@ -22053,6 +22073,7 @@
     },
     "node_modules/npm-registry-fetch/node_modules/yallist": {
       "version": "4.0.0",
+      "dev": true,
       "license": "ISC"
     },
     "node_modules/npm-registry-utilities": {
@@ -26644,6 +26665,7 @@
     },
     "node_modules/ssri": {
       "version": "8.0.1",
+      "dev": true,
       "license": "ISC",
       "dependencies": {
         "minipass": "^3.1.1"
@@ -27172,6 +27194,7 @@
     },
     "node_modules/tar": {
       "version": "4.4.19",
+      "dev": true,
       "license": "ISC",
       "dependencies": {
         "chownr": "^1.1.4",
@@ -27218,10 +27241,12 @@
     },
     "node_modules/tar/node_modules/chownr": {
       "version": "1.1.4",
+      "dev": true,
       "license": "ISC"
     },
     "node_modules/tar/node_modules/fs-minipass": {
       "version": "1.2.7",
+      "dev": true,
       "license": "ISC",
       "dependencies": {
         "minipass": "^2.6.0"
@@ -27229,6 +27254,7 @@
     },
     "node_modules/tar/node_modules/minipass": {
       "version": "2.9.0",
+      "dev": true,
       "license": "ISC",
       "dependencies": {
         "safe-buffer": "^5.1.2",
@@ -27237,6 +27263,7 @@
     },
     "node_modules/tar/node_modules/minizlib": {
       "version": "1.3.3",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "minipass": "^2.9.0"
@@ -27244,6 +27271,7 @@
     },
     "node_modules/tar/node_modules/mkdirp": {
       "version": "0.5.6",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "minimist": "^1.2.6"
@@ -27254,6 +27282,7 @@
     },
     "node_modules/tar/node_modules/safe-buffer": {
       "version": "5.2.1",
+      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -27272,6 +27301,7 @@
     },
     "node_modules/tar/node_modules/yallist": {
       "version": "3.1.1",
+      "dev": true,
       "license": "ISC"
     },
     "node_modules/tcp-port-used": {
@@ -29782,10 +29812,10 @@
     },
     "plugins/backend-app": {
       "name": "@dotcom-tool-kit/backend-app",
-      "version": "3.1.15",
+      "version": "3.1.17",
       "license": "ISC",
       "dependencies": {
-        "@dotcom-tool-kit/backend-heroku-app": "^3.0.3"
+        "@dotcom-tool-kit/backend-heroku-app": "^3.0.5"
       },
       "engines": {
         "node": "16.x || 18.x",
@@ -29797,12 +29827,12 @@
     },
     "plugins/backend-heroku-app": {
       "name": "@dotcom-tool-kit/backend-heroku-app",
-      "version": "3.0.3",
+      "version": "3.0.5",
       "license": "ISC",
       "dependencies": {
         "@dotcom-tool-kit/circleci-deploy": "^3.2.8",
-        "@dotcom-tool-kit/heroku": "^3.3.6",
-        "@dotcom-tool-kit/node": "^3.3.5",
+        "@dotcom-tool-kit/heroku": "^3.3.8",
+        "@dotcom-tool-kit/node": "^3.3.6",
         "@dotcom-tool-kit/npm": "^3.1.6"
       },
       "engines": {
@@ -29815,13 +29845,13 @@
     },
     "plugins/backend-serverless-app": {
       "name": "@dotcom-tool-kit/backend-serverless-app",
-      "version": "3.0.3",
+      "version": "3.0.4",
       "license": "ISC",
       "dependencies": {
         "@dotcom-tool-kit/circleci-deploy": "^3.2.8",
-        "@dotcom-tool-kit/node": "^3.3.5",
+        "@dotcom-tool-kit/node": "^3.3.6",
         "@dotcom-tool-kit/npm": "^3.1.6",
-        "@dotcom-tool-kit/serverless": "^2.2.6"
+        "@dotcom-tool-kit/serverless": "^2.2.7"
       },
       "engines": {
         "node": "16.x || 18.x",
@@ -29887,11 +29917,11 @@
     },
     "plugins/circleci-heroku": {
       "name": "@dotcom-tool-kit/circleci-heroku",
-      "version": "3.1.15",
+      "version": "3.1.17",
       "license": "ISC",
       "dependencies": {
         "@dotcom-tool-kit/circleci-deploy": "^3.2.8",
-        "@dotcom-tool-kit/heroku": "^3.3.6",
+        "@dotcom-tool-kit/heroku": "^3.3.8",
         "tslib": "^2.3.1"
       },
       "engines": {
@@ -30284,10 +30314,10 @@
     },
     "plugins/frontend-app": {
       "name": "@dotcom-tool-kit/frontend-app",
-      "version": "3.1.16",
+      "version": "3.1.18",
       "license": "ISC",
       "dependencies": {
-        "@dotcom-tool-kit/backend-heroku-app": "^3.0.3",
+        "@dotcom-tool-kit/backend-heroku-app": "^3.0.5",
         "@dotcom-tool-kit/upload-assets-to-s3": "^3.1.6",
         "@dotcom-tool-kit/webpack": "^3.1.6"
       },
@@ -30301,10 +30331,10 @@
     },
     "plugins/heroku": {
       "name": "@dotcom-tool-kit/heroku",
-      "version": "3.3.6",
+      "version": "3.3.8",
       "license": "ISC",
       "dependencies": {
-        "@dotcom-tool-kit/doppler": "^1.0.5",
+        "@dotcom-tool-kit/doppler": "^1.0.6",
         "@dotcom-tool-kit/error": "^3.1.0",
         "@dotcom-tool-kit/logger": "^3.3.0",
         "@dotcom-tool-kit/npm": "^3.1.6",
@@ -30638,10 +30668,10 @@
     },
     "plugins/next-router": {
       "name": "@dotcom-tool-kit/next-router",
-      "version": "3.3.5",
+      "version": "3.3.6",
       "license": "ISC",
       "dependencies": {
-        "@dotcom-tool-kit/doppler": "^1.0.5",
+        "@dotcom-tool-kit/doppler": "^1.0.6",
         "@dotcom-tool-kit/error": "^3.1.0",
         "@dotcom-tool-kit/logger": "^3.3.0",
         "@dotcom-tool-kit/state": "^3.1.1",
@@ -30769,10 +30799,10 @@
     },
     "plugins/node": {
       "name": "@dotcom-tool-kit/node",
-      "version": "3.3.5",
+      "version": "3.3.6",
       "license": "ISC",
       "dependencies": {
-        "@dotcom-tool-kit/doppler": "^1.0.5",
+        "@dotcom-tool-kit/doppler": "^1.0.6",
         "@dotcom-tool-kit/error": "^3.1.0",
         "@dotcom-tool-kit/state": "^3.1.1",
         "@dotcom-tool-kit/types": "^3.4.1",
@@ -30795,10 +30825,10 @@
     },
     "plugins/nodemon": {
       "name": "@dotcom-tool-kit/nodemon",
-      "version": "3.3.5",
+      "version": "3.3.6",
       "license": "ISC",
       "dependencies": {
-        "@dotcom-tool-kit/doppler": "^1.0.5",
+        "@dotcom-tool-kit/doppler": "^1.0.6",
         "@dotcom-tool-kit/error": "^3.1.0",
         "@dotcom-tool-kit/state": "^3.1.1",
         "@dotcom-tool-kit/types": "^3.4.1",
@@ -30832,16 +30862,9 @@
         "@dotcom-tool-kit/package-json-hook": "^4.1.0",
         "@dotcom-tool-kit/state": "^3.1.1",
         "@dotcom-tool-kit/types": "^3.4.1",
-        "libnpmpack": "^3.1.0",
-        "libnpmpublish": "^5.0.1",
-        "pacote": "^12.0.3",
-        "tar": "^4.4.16",
         "tslib": "^2.3.1"
       },
       "devDependencies": {
-        "@types/libnpmpublish": "^4.0.1",
-        "@types/pacote": "^11.1.3",
-        "@types/tar": "^6.1.1",
         "winston": "^3.5.1"
       },
       "engines": {
@@ -30852,143 +30875,10 @@
         "dotcom-tool-kit": "3.x"
       }
     },
-    "plugins/npm/node_modules/@npmcli/git": {
-      "version": "2.1.0",
-      "license": "ISC",
-      "dependencies": {
-        "@npmcli/promise-spawn": "^1.3.2",
-        "lru-cache": "^6.0.0",
-        "mkdirp": "^1.0.4",
-        "npm-pick-manifest": "^6.1.1",
-        "promise-inflight": "^1.0.1",
-        "promise-retry": "^2.0.1",
-        "semver": "^7.3.5",
-        "which": "^2.0.2"
-      }
-    },
-    "plugins/npm/node_modules/ignore-walk": {
-      "version": "4.0.1",
-      "license": "ISC",
-      "dependencies": {
-        "minimatch": "^3.0.4"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "plugins/npm/node_modules/lru-cache": {
-      "version": "6.0.0",
-      "license": "ISC",
-      "dependencies": {
-        "yallist": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "plugins/npm/node_modules/npm-install-checks": {
-      "version": "4.0.0",
-      "license": "BSD-2-Clause",
-      "dependencies": {
-        "semver": "^7.1.1"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "plugins/npm/node_modules/npm-packlist": {
-      "version": "3.0.0",
-      "license": "ISC",
-      "dependencies": {
-        "glob": "^7.1.6",
-        "ignore-walk": "^4.0.1",
-        "npm-bundled": "^1.1.1",
-        "npm-normalize-package-bin": "^1.0.1"
-      },
-      "bin": {
-        "npm-packlist": "bin/index.js"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "plugins/npm/node_modules/npm-pick-manifest": {
-      "version": "6.1.1",
-      "license": "ISC",
-      "dependencies": {
-        "npm-install-checks": "^4.0.0",
-        "npm-normalize-package-bin": "^1.0.1",
-        "npm-package-arg": "^8.1.2",
-        "semver": "^7.3.4"
-      }
-    },
-    "plugins/npm/node_modules/pacote": {
-      "version": "12.0.3",
-      "license": "ISC",
-      "dependencies": {
-        "@npmcli/git": "^2.1.0",
-        "@npmcli/installed-package-contents": "^1.0.6",
-        "@npmcli/promise-spawn": "^1.2.0",
-        "@npmcli/run-script": "^2.0.0",
-        "cacache": "^15.0.5",
-        "chownr": "^2.0.0",
-        "fs-minipass": "^2.1.0",
-        "infer-owner": "^1.0.4",
-        "minipass": "^3.1.3",
-        "mkdirp": "^1.0.3",
-        "npm-package-arg": "^8.0.1",
-        "npm-packlist": "^3.0.0",
-        "npm-pick-manifest": "^6.0.0",
-        "npm-registry-fetch": "^12.0.0",
-        "promise-retry": "^2.0.1",
-        "read-package-json-fast": "^2.0.1",
-        "rimraf": "^3.0.2",
-        "ssri": "^8.0.1",
-        "tar": "^6.1.0"
-      },
-      "bin": {
-        "pacote": "lib/bin.js"
-      },
-      "engines": {
-        "node": "^12.13.0 || ^14.15.0 || >=16"
-      }
-    },
-    "plugins/npm/node_modules/pacote/node_modules/tar": {
-      "version": "6.1.11",
-      "license": "ISC",
-      "dependencies": {
-        "chownr": "^2.0.0",
-        "fs-minipass": "^2.0.0",
-        "minipass": "^3.0.0",
-        "minizlib": "^2.1.1",
-        "mkdirp": "^1.0.3",
-        "yallist": "^4.0.0"
-      },
-      "engines": {
-        "node": ">= 10"
-      }
-    },
     "plugins/npm/node_modules/tslib": {
       "version": "2.4.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
       "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA=="
-    },
-    "plugins/npm/node_modules/which": {
-      "version": "2.0.2",
-      "license": "ISC",
-      "dependencies": {
-        "isexe": "^2.0.0"
-      },
-      "bin": {
-        "node-which": "bin/node-which"
-      },
-      "engines": {
-        "node": ">= 8"
-      }
-    },
-    "plugins/npm/node_modules/yallist": {
-      "version": "4.0.0",
-      "license": "ISC"
     },
     "plugins/pa11y": {
       "name": "@dotcom-tool-kit/pa11y",
@@ -31069,10 +30959,10 @@
     },
     "plugins/serverless": {
       "name": "@dotcom-tool-kit/serverless",
-      "version": "2.2.6",
+      "version": "2.2.7",
       "license": "ISC",
       "dependencies": {
-        "@dotcom-tool-kit/doppler": "^1.0.5",
+        "@dotcom-tool-kit/doppler": "^1.0.6",
         "@dotcom-tool-kit/error": "^3.1.0",
         "@dotcom-tool-kit/state": "^3.1.1",
         "@dotcom-tool-kit/types": "^3.4.1",
@@ -35302,15 +35192,15 @@
     "@dotcom-tool-kit/backend-app": {
       "version": "file:plugins/backend-app",
       "requires": {
-        "@dotcom-tool-kit/backend-heroku-app": "^3.0.3"
+        "@dotcom-tool-kit/backend-heroku-app": "^3.0.5"
       }
     },
     "@dotcom-tool-kit/backend-heroku-app": {
       "version": "file:plugins/backend-heroku-app",
       "requires": {
         "@dotcom-tool-kit/circleci-deploy": "^3.2.8",
-        "@dotcom-tool-kit/heroku": "^3.3.6",
-        "@dotcom-tool-kit/node": "^3.3.5",
+        "@dotcom-tool-kit/heroku": "^3.3.8",
+        "@dotcom-tool-kit/node": "^3.3.6",
         "@dotcom-tool-kit/npm": "^3.1.6"
       }
     },
@@ -35318,9 +35208,9 @@
       "version": "file:plugins/backend-serverless-app",
       "requires": {
         "@dotcom-tool-kit/circleci-deploy": "^3.2.8",
-        "@dotcom-tool-kit/node": "^3.3.5",
+        "@dotcom-tool-kit/node": "^3.3.6",
         "@dotcom-tool-kit/npm": "^3.1.6",
-        "@dotcom-tool-kit/serverless": "^2.2.6"
+        "@dotcom-tool-kit/serverless": "^2.2.7"
       }
     },
     "@dotcom-tool-kit/circleci": {
@@ -35432,7 +35322,7 @@
       "version": "file:plugins/circleci-heroku",
       "requires": {
         "@dotcom-tool-kit/circleci-deploy": "^3.2.8",
-        "@dotcom-tool-kit/heroku": "^3.3.6",
+        "@dotcom-tool-kit/heroku": "^3.3.8",
         "tslib": "^2.3.1"
       },
       "dependencies": {
@@ -35471,7 +35361,7 @@
       "requires": {
         "@aws-sdk/client-iam": "^3.282.0",
         "@aws-sdk/client-sts": "^3.282.0",
-        "@dotcom-tool-kit/doppler": "^1.0.5",
+        "@dotcom-tool-kit/doppler": "^1.0.6",
         "@dotcom-tool-kit/error": "^3.1.0",
         "@dotcom-tool-kit/logger": "^3.3.0",
         "@dotcom-tool-kit/types": "^3.4.1",
@@ -35487,7 +35377,7 @@
         "cli-highlight": "^2.1.11",
         "code-suggester": "^4.3.0",
         "cosmiconfig": "^7.0.1",
-        "dotcom-tool-kit": "^3.3.2",
+        "dotcom-tool-kit": "^3.3.4",
         "import-cwd": "^3.0.0",
         "komatsu": "^1.3.0",
         "lodash": "^4.17.21",
@@ -36404,7 +36294,7 @@
     "@dotcom-tool-kit/frontend-app": {
       "version": "file:plugins/frontend-app",
       "requires": {
-        "@dotcom-tool-kit/backend-heroku-app": "^3.0.3",
+        "@dotcom-tool-kit/backend-heroku-app": "^3.0.5",
         "@dotcom-tool-kit/upload-assets-to-s3": "^3.1.6",
         "@dotcom-tool-kit/webpack": "^3.1.6"
       }
@@ -36412,7 +36302,7 @@
     "@dotcom-tool-kit/heroku": {
       "version": "file:plugins/heroku",
       "requires": {
-        "@dotcom-tool-kit/doppler": "^1.0.5",
+        "@dotcom-tool-kit/doppler": "^1.0.6",
         "@dotcom-tool-kit/error": "^3.1.0",
         "@dotcom-tool-kit/logger": "^3.3.0",
         "@dotcom-tool-kit/npm": "^3.1.6",
@@ -36667,7 +36557,7 @@
     "@dotcom-tool-kit/next-router": {
       "version": "file:plugins/next-router",
       "requires": {
-        "@dotcom-tool-kit/doppler": "^1.0.5",
+        "@dotcom-tool-kit/doppler": "^1.0.6",
         "@dotcom-tool-kit/error": "^3.1.0",
         "@dotcom-tool-kit/logger": "^3.3.0",
         "@dotcom-tool-kit/state": "^3.1.1",
@@ -36772,7 +36662,7 @@
     "@dotcom-tool-kit/node": {
       "version": "file:plugins/node",
       "requires": {
-        "@dotcom-tool-kit/doppler": "^1.0.5",
+        "@dotcom-tool-kit/doppler": "^1.0.6",
         "@dotcom-tool-kit/error": "^3.1.0",
         "@dotcom-tool-kit/state": "^3.1.1",
         "@dotcom-tool-kit/types": "^3.4.1",
@@ -36791,7 +36681,7 @@
     "@dotcom-tool-kit/nodemon": {
       "version": "file:plugins/nodemon",
       "requires": {
-        "@dotcom-tool-kit/doppler": "^1.0.5",
+        "@dotcom-tool-kit/doppler": "^1.0.6",
         "@dotcom-tool-kit/error": "^3.1.0",
         "@dotcom-tool-kit/state": "^3.1.1",
         "@dotcom-tool-kit/types": "^3.4.1",
@@ -36815,116 +36705,14 @@
         "@dotcom-tool-kit/package-json-hook": "^4.1.0",
         "@dotcom-tool-kit/state": "^3.1.1",
         "@dotcom-tool-kit/types": "^3.4.1",
-        "@types/libnpmpublish": "^4.0.1",
-        "@types/pacote": "^11.1.3",
-        "@types/tar": "^6.1.1",
-        "libnpmpack": "^3.1.0",
-        "libnpmpublish": "^5.0.1",
-        "pacote": "^12.0.3",
-        "tar": "^4.4.16",
         "tslib": "^2.3.1",
         "winston": "^3.5.1"
       },
       "dependencies": {
-        "@npmcli/git": {
-          "version": "2.1.0",
-          "requires": {
-            "@npmcli/promise-spawn": "^1.3.2",
-            "lru-cache": "^6.0.0",
-            "mkdirp": "^1.0.4",
-            "npm-pick-manifest": "^6.1.1",
-            "promise-inflight": "^1.0.1",
-            "promise-retry": "^2.0.1",
-            "semver": "^7.3.5",
-            "which": "^2.0.2"
-          }
-        },
-        "ignore-walk": {
-          "version": "4.0.1",
-          "requires": {
-            "minimatch": "^3.0.4"
-          }
-        },
-        "lru-cache": {
-          "version": "6.0.0",
-          "requires": {
-            "yallist": "^4.0.0"
-          }
-        },
-        "npm-install-checks": {
-          "version": "4.0.0",
-          "requires": {
-            "semver": "^7.1.1"
-          }
-        },
-        "npm-packlist": {
-          "version": "3.0.0",
-          "requires": {
-            "glob": "^7.1.6",
-            "ignore-walk": "^4.0.1",
-            "npm-bundled": "^1.1.1",
-            "npm-normalize-package-bin": "^1.0.1"
-          }
-        },
-        "npm-pick-manifest": {
-          "version": "6.1.1",
-          "requires": {
-            "npm-install-checks": "^4.0.0",
-            "npm-normalize-package-bin": "^1.0.1",
-            "npm-package-arg": "^8.1.2",
-            "semver": "^7.3.4"
-          }
-        },
-        "pacote": {
-          "version": "12.0.3",
-          "requires": {
-            "@npmcli/git": "^2.1.0",
-            "@npmcli/installed-package-contents": "^1.0.6",
-            "@npmcli/promise-spawn": "^1.2.0",
-            "@npmcli/run-script": "^2.0.0",
-            "cacache": "^15.0.5",
-            "chownr": "^2.0.0",
-            "fs-minipass": "^2.1.0",
-            "infer-owner": "^1.0.4",
-            "minipass": "^3.1.3",
-            "mkdirp": "^1.0.3",
-            "npm-package-arg": "^8.0.1",
-            "npm-packlist": "^3.0.0",
-            "npm-pick-manifest": "^6.0.0",
-            "npm-registry-fetch": "^12.0.0",
-            "promise-retry": "^2.0.1",
-            "read-package-json-fast": "^2.0.1",
-            "rimraf": "^3.0.2",
-            "ssri": "^8.0.1",
-            "tar": "^6.1.0"
-          },
-          "dependencies": {
-            "tar": {
-              "version": "6.1.11",
-              "requires": {
-                "chownr": "^2.0.0",
-                "fs-minipass": "^2.0.0",
-                "minipass": "^3.0.0",
-                "minizlib": "^2.1.1",
-                "mkdirp": "^1.0.3",
-                "yallist": "^4.0.0"
-              }
-            }
-          }
-        },
         "tslib": {
           "version": "2.4.1",
           "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
           "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA=="
-        },
-        "which": {
-          "version": "2.0.2",
-          "requires": {
-            "isexe": "^2.0.0"
-          }
-        },
-        "yallist": {
-          "version": "4.0.0"
         }
       }
     },
@@ -37640,7 +37428,7 @@
     "@dotcom-tool-kit/serverless": {
       "version": "file:plugins/serverless",
       "requires": {
-        "@dotcom-tool-kit/doppler": "^1.0.5",
+        "@dotcom-tool-kit/doppler": "^1.0.6",
         "@dotcom-tool-kit/error": "^3.1.0",
         "@dotcom-tool-kit/state": "^3.1.1",
         "@dotcom-tool-kit/types": "^3.4.1",
@@ -39657,6 +39445,7 @@
     },
     "@npmcli/fs": {
       "version": "1.1.1",
+      "dev": true,
       "requires": {
         "@gar/promisify": "^1.0.1",
         "semver": "^7.3.5"
@@ -39702,22 +39491,26 @@
     },
     "@npmcli/move-file": {
       "version": "1.1.2",
+      "dev": true,
       "requires": {
         "mkdirp": "^1.0.4",
         "rimraf": "^3.0.2"
       }
     },
     "@npmcli/node-gyp": {
-      "version": "1.0.3"
+      "version": "1.0.3",
+      "dev": true
     },
     "@npmcli/promise-spawn": {
       "version": "1.3.2",
+      "dev": true,
       "requires": {
         "infer-owner": "^1.0.4"
       }
     },
     "@npmcli/run-script": {
       "version": "2.0.0",
+      "dev": true,
       "requires": {
         "@npmcli/node-gyp": "^1.0.2",
         "@npmcli/promise-spawn": "^1.3.2",
@@ -40615,16 +40408,6 @@
         "@types/node": "*"
       }
     },
-    "@types/libnpmpublish": {
-      "version": "4.0.2",
-      "dev": true,
-      "requires": {
-        "@types/node": "*",
-        "@types/node-fetch": "*",
-        "@types/npm-registry-fetch": "*",
-        "@types/pacote": "*"
-      }
-    },
     "@types/lodash": {
       "version": "4.14.189",
       "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.189.tgz",
@@ -40641,13 +40424,6 @@
     "@types/minimist": {
       "version": "1.2.2",
       "dev": true
-    },
-    "@types/minipass": {
-      "version": "3.1.2",
-      "dev": true,
-      "requires": {
-        "@types/node": "*"
-      }
     },
     "@types/mocha": {
       "version": "8.2.3",
@@ -40793,14 +40569,6 @@
       "version": "4.1.15",
       "requires": {
         "@types/cookiejar": "*",
-        "@types/node": "*"
-      }
-    },
-    "@types/tar": {
-      "version": "6.1.1",
-      "dev": true,
-      "requires": {
-        "@types/minipass": "*",
         "@types/node": "*"
       }
     },
@@ -42026,6 +41794,7 @@
     },
     "cacache": {
       "version": "15.3.0",
+      "dev": true,
       "requires": {
         "@npmcli/fs": "^1.0.0",
         "@npmcli/move-file": "^1.0.1",
@@ -42049,12 +41818,14 @@
       "dependencies": {
         "lru-cache": {
           "version": "6.0.0",
+          "dev": true,
           "requires": {
             "yallist": "^4.0.0"
           }
         },
         "tar": {
           "version": "6.1.11",
+          "dev": true,
           "requires": {
             "chownr": "^2.0.0",
             "fs-minipass": "^2.0.0",
@@ -42065,7 +41836,8 @@
           }
         },
         "yallist": {
-          "version": "4.0.0"
+          "version": "4.0.0",
+          "dev": true
         }
       }
     },
@@ -43594,13 +43366,13 @@
       "version": "file:core/cli",
       "requires": {
         "@dotcom-tool-kit/babel": "^3.1.5",
-        "@dotcom-tool-kit/backend-heroku-app": "^3.0.3",
+        "@dotcom-tool-kit/backend-heroku-app": "^3.0.5",
         "@dotcom-tool-kit/circleci": "^5.3.8",
         "@dotcom-tool-kit/circleci-deploy": "^3.2.8",
         "@dotcom-tool-kit/error": "^3.1.0",
         "@dotcom-tool-kit/eslint": "^3.1.5",
-        "@dotcom-tool-kit/frontend-app": "^3.1.16",
-        "@dotcom-tool-kit/heroku": "^3.3.6",
+        "@dotcom-tool-kit/frontend-app": "^3.1.18",
+        "@dotcom-tool-kit/heroku": "^3.3.8",
         "@dotcom-tool-kit/logger": "^3.3.0",
         "@dotcom-tool-kit/mocha": "^3.1.5",
         "@dotcom-tool-kit/n-test": "^3.2.7",
@@ -45526,18 +45298,21 @@
     },
     "hosted-git-info": {
       "version": "4.1.0",
+      "dev": true,
       "requires": {
         "lru-cache": "^6.0.0"
       },
       "dependencies": {
         "lru-cache": {
           "version": "6.0.0",
+          "dev": true,
           "requires": {
             "yallist": "^4.0.0"
           }
         },
         "yallist": {
-          "version": "4.0.0"
+          "version": "4.0.0",
+          "dev": true
         }
       }
     },
@@ -47045,6 +46820,7 @@
     },
     "libnpmpack": {
       "version": "3.1.0",
+      "dev": true,
       "requires": {
         "@npmcli/run-script": "^2.0.0",
         "npm-package-arg": "^8.1.0",
@@ -47053,6 +46829,7 @@
       "dependencies": {
         "@npmcli/git": {
           "version": "2.1.0",
+          "dev": true,
           "requires": {
             "@npmcli/promise-spawn": "^1.3.2",
             "lru-cache": "^6.0.0",
@@ -47066,24 +46843,28 @@
         },
         "ignore-walk": {
           "version": "4.0.1",
+          "dev": true,
           "requires": {
             "minimatch": "^3.0.4"
           }
         },
         "lru-cache": {
           "version": "6.0.0",
+          "dev": true,
           "requires": {
             "yallist": "^4.0.0"
           }
         },
         "npm-install-checks": {
           "version": "4.0.0",
+          "dev": true,
           "requires": {
             "semver": "^7.1.1"
           }
         },
         "npm-packlist": {
           "version": "3.0.0",
+          "dev": true,
           "requires": {
             "glob": "^7.1.6",
             "ignore-walk": "^4.0.1",
@@ -47093,6 +46874,7 @@
         },
         "npm-pick-manifest": {
           "version": "6.1.1",
+          "dev": true,
           "requires": {
             "npm-install-checks": "^4.0.0",
             "npm-normalize-package-bin": "^1.0.1",
@@ -47102,6 +46884,7 @@
         },
         "pacote": {
           "version": "12.0.3",
+          "dev": true,
           "requires": {
             "@npmcli/git": "^2.1.0",
             "@npmcli/installed-package-contents": "^1.0.6",
@@ -47126,6 +46909,7 @@
         },
         "tar": {
           "version": "6.1.11",
+          "dev": true,
           "requires": {
             "chownr": "^2.0.0",
             "fs-minipass": "^2.0.0",
@@ -47137,17 +46921,20 @@
         },
         "which": {
           "version": "2.0.2",
+          "dev": true,
           "requires": {
             "isexe": "^2.0.0"
           }
         },
         "yallist": {
-          "version": "4.0.0"
+          "version": "4.0.0",
+          "dev": true
         }
       }
     },
     "libnpmpublish": {
       "version": "5.0.1",
+      "dev": true,
       "requires": {
         "normalize-package-data": "^3.0.2",
         "npm-package-arg": "^8.1.2",
@@ -47486,6 +47273,7 @@
     },
     "make-fetch-happen": {
       "version": "9.1.0",
+      "dev": true,
       "requires": {
         "agentkeepalive": "^4.1.3",
         "cacache": "^15.2.0",
@@ -47507,12 +47295,14 @@
       "dependencies": {
         "lru-cache": {
           "version": "6.0.0",
+          "dev": true,
           "requires": {
             "yallist": "^4.0.0"
           }
         },
         "yallist": {
-          "version": "4.0.0"
+          "version": "4.0.0",
+          "dev": true
         }
       }
     },
@@ -47716,6 +47506,7 @@
     },
     "minipass-fetch": {
       "version": "1.4.1",
+      "dev": true,
       "requires": {
         "encoding": "^0.1.12",
         "minipass": "^3.1.0",
@@ -48249,6 +48040,7 @@
     },
     "node-gyp": {
       "version": "8.4.1",
+      "dev": true,
       "requires": {
         "env-paths": "^2.2.0",
         "glob": "^7.1.4",
@@ -48264,6 +48056,7 @@
       "dependencies": {
         "tar": {
           "version": "6.1.11",
+          "dev": true,
           "requires": {
             "chownr": "^2.0.0",
             "fs-minipass": "^2.0.0",
@@ -48275,12 +48068,14 @@
         },
         "which": {
           "version": "2.0.2",
+          "dev": true,
           "requires": {
             "isexe": "^2.0.0"
           }
         },
         "yallist": {
-          "version": "4.0.0"
+          "version": "4.0.0",
+          "dev": true
         }
       }
     },
@@ -48423,6 +48218,7 @@
     },
     "normalize-package-data": {
       "version": "3.0.3",
+      "dev": true,
       "requires": {
         "hosted-git-info": "^4.0.1",
         "is-core-module": "^2.5.0",
@@ -48453,6 +48249,7 @@
     },
     "npm-package-arg": {
       "version": "8.1.5",
+      "dev": true,
       "requires": {
         "hosted-git-info": "^4.0.1",
         "semver": "^7.3.4",
@@ -48575,6 +48372,7 @@
     },
     "npm-registry-fetch": {
       "version": "12.0.2",
+      "dev": true,
       "requires": {
         "make-fetch-happen": "^10.0.1",
         "minipass": "^3.1.6",
@@ -48586,6 +48384,7 @@
       "dependencies": {
         "@npmcli/fs": {
           "version": "2.1.0",
+          "dev": true,
           "requires": {
             "@gar/promisify": "^1.1.3",
             "semver": "^7.3.5"
@@ -48593,22 +48392,26 @@
         },
         "@npmcli/move-file": {
           "version": "2.0.0",
+          "dev": true,
           "requires": {
             "mkdirp": "^1.0.4",
             "rimraf": "^3.0.2"
           }
         },
         "@tootallnate/once": {
-          "version": "2.0.0"
+          "version": "2.0.0",
+          "dev": true
         },
         "brace-expansion": {
           "version": "2.0.1",
+          "dev": true,
           "requires": {
             "balanced-match": "^1.0.0"
           }
         },
         "cacache": {
           "version": "16.0.7",
+          "dev": true,
           "requires": {
             "@npmcli/fs": "^2.1.0",
             "@npmcli/move-file": "^2.0.0",
@@ -48632,6 +48435,7 @@
         },
         "glob": {
           "version": "8.0.1",
+          "dev": true,
           "requires": {
             "fs.realpath": "^1.0.0",
             "inflight": "^1.0.4",
@@ -48643,6 +48447,7 @@
         },
         "http-proxy-agent": {
           "version": "5.0.0",
+          "dev": true,
           "requires": {
             "@tootallnate/once": "2",
             "agent-base": "6",
@@ -48650,10 +48455,12 @@
           }
         },
         "lru-cache": {
-          "version": "7.9.0"
+          "version": "7.9.0",
+          "dev": true
         },
         "make-fetch-happen": {
           "version": "10.1.2",
+          "dev": true,
           "requires": {
             "agentkeepalive": "^4.2.1",
             "cacache": "^16.0.2",
@@ -48675,6 +48482,7 @@
           "dependencies": {
             "minipass-fetch": {
               "version": "2.1.0",
+              "dev": true,
               "requires": {
                 "encoding": "^0.1.13",
                 "minipass": "^3.1.6",
@@ -48686,18 +48494,21 @@
         },
         "minimatch": {
           "version": "5.0.1",
+          "dev": true,
           "requires": {
             "brace-expansion": "^2.0.1"
           }
         },
         "ssri": {
           "version": "9.0.0",
+          "dev": true,
           "requires": {
             "minipass": "^3.1.1"
           }
         },
         "tar": {
           "version": "6.1.11",
+          "dev": true,
           "requires": {
             "chownr": "^2.0.0",
             "fs-minipass": "^2.0.0",
@@ -48708,7 +48519,8 @@
           }
         },
         "yallist": {
-          "version": "4.0.0"
+          "version": "4.0.0",
+          "dev": true
         }
       }
     },
@@ -51879,6 +51691,7 @@
     },
     "ssri": {
       "version": "8.0.1",
+      "dev": true,
       "requires": {
         "minipass": "^3.1.1"
       }
@@ -52244,6 +52057,7 @@
     },
     "tar": {
       "version": "4.4.19",
+      "dev": true,
       "requires": {
         "chownr": "^1.1.4",
         "fs-minipass": "^1.2.7",
@@ -52255,16 +52069,19 @@
       },
       "dependencies": {
         "chownr": {
-          "version": "1.1.4"
+          "version": "1.1.4",
+          "dev": true
         },
         "fs-minipass": {
           "version": "1.2.7",
+          "dev": true,
           "requires": {
             "minipass": "^2.6.0"
           }
         },
         "minipass": {
           "version": "2.9.0",
+          "dev": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -52272,21 +52089,25 @@
         },
         "minizlib": {
           "version": "1.3.3",
+          "dev": true,
           "requires": {
             "minipass": "^2.9.0"
           }
         },
         "mkdirp": {
           "version": "0.5.6",
+          "dev": true,
           "requires": {
             "minimist": "^1.2.6"
           }
         },
         "safe-buffer": {
-          "version": "5.2.1"
+          "version": "5.2.1",
+          "dev": true
         },
         "yallist": {
-          "version": "3.1.1"
+          "version": "3.1.1",
+          "dev": true
         }
       }
     },

--- a/plugins/npm/package.json
+++ b/plugins/npm/package.json
@@ -15,10 +15,6 @@
     "@dotcom-tool-kit/package-json-hook": "^4.1.0",
     "@dotcom-tool-kit/state": "^3.1.1",
     "@dotcom-tool-kit/types": "^3.4.1",
-    "libnpmpack": "^3.1.0",
-    "libnpmpublish": "^5.0.1",
-    "pacote": "^12.0.3",
-    "tar": "^4.4.16",
     "tslib": "^2.3.1"
   },
   "repository": {
@@ -29,9 +25,6 @@
   "bugs": "https://github.com/financial-times/dotcom-tool-kit/issues",
   "homepage": "https://github.com/financial-times/dotcom-tool-kit/tree/main/plugins/npm",
   "devDependencies": {
-    "@types/libnpmpublish": "^4.0.1",
-    "@types/pacote": "^11.1.3",
-    "@types/tar": "^6.1.1",
     "winston": "^3.5.1"
   },
   "files": [

--- a/plugins/npm/src/tasks/npm-publish.ts
+++ b/plugins/npm/src/tasks/npm-publish.ts
@@ -7,24 +7,28 @@ import pack from 'libnpmpack'
 import { publish } from 'libnpmpublish'
 import { styles } from '@dotcom-tool-kit/logger'
 import tar from 'tar'
-import { PassThrough as PassThroughStream } from 'stream';
+import { PassThrough as PassThroughStream } from 'stream'
 
-type TagType = "prerelease" | "latest"
+type TagType = 'prerelease' | 'latest'
 
 export default class NpmPublish extends Task {
   static description = ''
 
   getNpmTag(tag: string): TagType {
-    if(!tag) {
-        throw new ToolKitError('CIRCLE_TAG environment variable not found. Make sure you are running this on a release version!')
+    if (!tag) {
+      throw new ToolKitError(
+        'CIRCLE_TAG environment variable not found. Make sure you are running this on a release version!'
+      )
     }
-    if(prereleaseRegex.test(tag)) {
+    if (prereleaseRegex.test(tag)) {
       return 'prerelease'
     }
-    if(releaseRegex.test(tag)) {
+    if (releaseRegex.test(tag)) {
       return 'latest'
     }
-    throw new ToolKitError(`CIRCLE_TAG does not match regex ${semVerRegex}. Configure your release version to match the regex eg. v1.2.3-beta.8`)
+    throw new ToolKitError(
+      `CIRCLE_TAG does not match regex ${semVerRegex}. Configure your release version to match the regex eg. v1.2.3-beta.8`
+    )
   }
 
   async listPackedFiles(tarball: Buffer): Promise<void> {
@@ -32,7 +36,7 @@ export default class NpmPublish extends Task {
 
     new PassThroughStream()
       .end(tarball)
-      .pipe(tar.t({onentry: entry => this.logger.info(`- ${styles.filepath(entry.header.path)}`)}))
+      .pipe(tar.t({ onentry: (entry) => this.logger.info(`- ${styles.filepath(entry.header.path)}`) }))
   }
 
   async run(): Promise<void> {
@@ -43,10 +47,8 @@ export default class NpmPublish extends Task {
 
     const ci = readState('ci')
 
-    if(!ci) {
-      throw new ToolKitError(
-        `Could not find state for ci, check that you are running this task on circleci`
-      )
+    if (!ci) {
+      throw new ToolKitError(`Could not find state for ci, check that you are running this task on circleci`)
     }
 
     const tag = ci.tag
@@ -56,7 +58,9 @@ export default class NpmPublish extends Task {
     this.logger.info(`version ${tag} ready to be published with ${npmTag} tag`)
 
     if (!process.env.NPM_AUTH_TOKEN) {
-        throw new ToolKitError('NPM_AUTH_TOKEN environment variable not found! Make sure you have added the npm-publish-token context under toolkit/publish job in your circleci config')
+      throw new ToolKitError(
+        'NPM_AUTH_TOKEN environment variable not found! Make sure you have added the npm-publish-token context under toolkit/publish job in your circleci config'
+      )
     }
 
     // overwrite version from the package.json with the version from e.g. the git tag
@@ -67,11 +71,11 @@ export default class NpmPublish extends Task {
     await this.listPackedFiles(tarball)
 
     await publish(manifest, tarball, {
-        access: 'public',
-        defaultTag: npmTag,
-        forceAuth: {
-            token: process.env.NPM_AUTH_TOKEN
-        }
+      access: 'public',
+      defaultTag: npmTag,
+      forceAuth: {
+        token: process.env.NPM_AUTH_TOKEN
+      }
     })
 
     this.logger.info(`✅ npm package published`)

--- a/plugins/npm/src/tasks/npm-publish.ts
+++ b/plugins/npm/src/tasks/npm-publish.ts
@@ -3,7 +3,7 @@ import { ToolKitError } from '@dotcom-tool-kit/error'
 import { Task } from '@dotcom-tool-kit/types'
 import { semVerRegex, prereleaseRegex, releaseRegex } from '@dotcom-tool-kit/types/lib/npm'
 import { readState } from '@dotcom-tool-kit/state'
-import { waitOnExit } from '@dotcom-tool-kit/logger'
+import { hookFork, waitOnExit } from '@dotcom-tool-kit/logger'
 
 type TagType = 'prerelease' | 'latest'
 
@@ -31,6 +31,7 @@ export default class NpmPublish extends Task {
     try {
       this.logger.verbose(`running \`npm ${npmTask} ${options.join(' ')}\``)
       const task = spawn('npm', [npmTask, ...options])
+      hookFork(this.logger, `npm ${task}`, task)
       await waitOnExit(`npm ${task}`, task)
     } catch (err) {
       const error = new ToolKitError(`unable to ${npmTask} package`)

--- a/plugins/npm/test/npm-publish.test.ts
+++ b/plugins/npm/test/npm-publish.test.ts
@@ -9,63 +9,77 @@ import pack from 'libnpmpack'
 
 const logger = (winston as unknown) as Logger
 
-const readStateMock = jest.spyOn(state, 'readState');
+const readStateMock = jest.spyOn(state, 'readState')
 jest.spyOn(pacote, 'manifest').mockImplementation(() => Promise.resolve({} as ManifestResult))
 jest.spyOn(process, 'cwd').mockImplementation(() => '')
 jest.mock('libnpmpack', () => {
-    return jest.fn(() => Promise.resolve())
+  return jest.fn(() => Promise.resolve())
 })
 jest.mock('libnpmpublish', () => {
-    return {
-        publish: jest.fn(() => Promise.resolve())
-    }
+  return {
+    publish: jest.fn(() => Promise.resolve())
+  }
 })
 
 describe('NpmPublish', () => {
-    it('should throw an error if ci is not found in state', async () => {
-        readStateMock.mockReturnValue(null)
+  it('should throw an error if ci is not found in state', async () => {
+    readStateMock.mockReturnValue(null)
 
-        const task = new NpmPublish(logger)
-        await expect(async () => { await task.run() }).rejects.toThrow(new ToolKitError(
-          `Could not find state for ci, check that you are running this task on circleci`
-        ))
-    })
+    const task = new NpmPublish(logger)
+    await expect(async () => {
+      await task.run()
+    }).rejects.toThrow(
+      new ToolKitError(`Could not find state for ci, check that you are running this task on circleci`)
+    )
+  })
 
-    it('should throw error if tag is not found', async () => {
-        readStateMock.mockReturnValue({tag: '', repo: '', branch: '', version: ''})
+  it('should throw error if tag is not found', async () => {
+    readStateMock.mockReturnValue({ tag: '', repo: '', branch: '', version: '' })
 
-        const task = new NpmPublish(logger)
-        await expect(async () => { await task.run() }).rejects.toThrow(new ToolKitError('CIRCLE_TAG environment variable not found. Make sure you are running this on a release version!'))
-    })
+    const task = new NpmPublish(logger)
+    await expect(async () => {
+      await task.run()
+    }).rejects.toThrow(
+      new ToolKitError(
+        'CIRCLE_TAG environment variable not found. Make sure you are running this on a release version!'
+      )
+    )
+  })
 
-    it('should return prerelease if match prerelease regex in getNpmTag', () => {
-        const task = new NpmPublish(logger)
-        expect(task.getNpmTag('v1.6.0-beta.1')).toEqual('prerelease')
-    })
+  it('should return prerelease if match prerelease regex in getNpmTag', () => {
+    const task = new NpmPublish(logger)
+    expect(task.getNpmTag('v1.6.0-beta.1')).toEqual('prerelease')
+  })
 
-    it('should return latest if match latest regex in getNpmTag', () => {
-        const task = new NpmPublish(logger)
-        expect(task.getNpmTag('v1.6.0')).toEqual('latest')
-    })
+  it('should return latest if match latest regex in getNpmTag', () => {
+    const task = new NpmPublish(logger)
+    expect(task.getNpmTag('v1.6.0')).toEqual('latest')
+  })
 
-    it('should throw error if tag does not match semver regex', async () => {
-        readStateMock.mockReturnValue({tag: 'random-branch', repo: '', branch: '', version: ''})
+  it('should throw error if tag does not match semver regex', async () => {
+    readStateMock.mockReturnValue({ tag: 'random-branch', repo: '', branch: '', version: '' })
 
-        const task = new NpmPublish(logger)
-        await expect(async () => { await task.run() }).rejects.toThrow(new ToolKitError(`CIRCLE_TAG does not match regex ${semVerRegex}. Configure your release version to match the regex eg. v1.2.3-beta.8`))
-    })
+    const task = new NpmPublish(logger)
+    await expect(async () => {
+      await task.run()
+    }).rejects.toThrow(
+      new ToolKitError(
+        `CIRCLE_TAG does not match regex ${semVerRegex}. Configure your release version to match the regex eg. v1.2.3-beta.8`
+      )
+    )
+  })
 
-    it('should call listPackedFiles, pack and publish if tag matches semver regex', async () => {
-        process.env.NPM_AUTH_TOKEN = process.env.NPM_AUTH_TOKEN || 'dummy_value'
-        readStateMock.mockReturnValue({tag: 'v1.2.3-beta.2', repo: '', branch: '', version: ''})
-        const listPackedFilesSpy = jest.spyOn(NpmPublish.prototype, 'listPackedFiles')
-        listPackedFilesSpy.mockImplementation(() => Promise.resolve())
+  it('should call listPackedFiles, pack and publish if tag matches semver regex', async () => {
+    process.env.NPM_AUTH_TOKEN = process.env.NPM_AUTH_TOKEN || 'dummy_value'
+    readStateMock.mockReturnValue({ tag: 'v1.2.3-beta.2', repo: '', branch: '', version: '' })
+    const listPackedFilesSpy = jest.spyOn(NpmPublish.prototype, 'listPackedFiles')
+    listPackedFilesSpy.mockImplementation(() => Promise.resolve())
 
-        const task = new NpmPublish(logger)
-        await task.run()
+    const task = new NpmPublish(logger)
+    await task.run()
 
-        expect(listPackedFilesSpy).toBeCalled()
-        expect(pack).toBeCalled()
-        expect(publish).toBeCalled()
-    })
+    expect(listPackedFilesSpy).toBeCalled()
+    expect(pack).toBeCalled()
+    expect(publish).toBeCalled()
+  })
 })

--- a/plugins/npm/test/npm-publish.test.ts
+++ b/plugins/npm/test/npm-publish.test.ts
@@ -9,12 +9,8 @@ import { spawn } from 'node:child_process'
 const logger = (winston as unknown) as Logger
 
 const readStateMock = jest.spyOn(state, 'readState')
-jest.mock('node:child_process', () => ({
-  spawn: jest.fn(() => Promise.resolve())
-}))
-jest.mock('@dotcom-tool-kit/logger', () => ({
-  waitOnExit: jest.fn(() => Promise.resolve())
-}))
+jest.mock('node:child_process')
+jest.mock('@dotcom-tool-kit/logger')
 
 describe('NpmPublish', () => {
   it('should throw an error if ci is not found in state', async () => {

--- a/plugins/npm/test/npm-publish.test.ts
+++ b/plugins/npm/test/npm-publish.test.ts
@@ -3,29 +3,24 @@ import NpmPublish from '../src/tasks/npm-publish'
 import winston, { Logger } from 'winston'
 import { ToolKitError } from '../../../lib/error/lib'
 import * as state from '@dotcom-tool-kit/state'
-import pacote, { ManifestResult } from 'pacote'
-import { publish } from 'libnpmpublish'
-import pack from 'libnpmpack'
+import { waitOnExit } from '@dotcom-tool-kit/logger'
+import { spawn } from 'node:child_process'
 
 const logger = (winston as unknown) as Logger
 
 const readStateMock = jest.spyOn(state, 'readState')
-jest.spyOn(pacote, 'manifest').mockImplementation(() => Promise.resolve({} as ManifestResult))
-jest.spyOn(process, 'cwd').mockImplementation(() => '')
-jest.mock('libnpmpack', () => {
-  return jest.fn(() => Promise.resolve())
-})
-jest.mock('libnpmpublish', () => {
-  return {
-    publish: jest.fn(() => Promise.resolve())
-  }
-})
+jest.mock('node:child_process', () => ({
+  spawn: jest.fn(() => Promise.resolve())
+}))
+jest.mock('@dotcom-tool-kit/logger', () => ({
+  waitOnExit: jest.fn(() => Promise.resolve())
+}))
 
 describe('NpmPublish', () => {
   it('should throw an error if ci is not found in state', async () => {
     readStateMock.mockReturnValue(null)
 
-    const task = new NpmPublish(logger)
+    const task = new NpmPublish(logger, {})
     await expect(async () => {
       await task.run()
     }).rejects.toThrow(
@@ -36,7 +31,7 @@ describe('NpmPublish', () => {
   it('should throw error if tag is not found', async () => {
     readStateMock.mockReturnValue({ tag: '', repo: '', branch: '', version: '' })
 
-    const task = new NpmPublish(logger)
+    const task = new NpmPublish(logger, {})
     await expect(async () => {
       await task.run()
     }).rejects.toThrow(
@@ -47,19 +42,19 @@ describe('NpmPublish', () => {
   })
 
   it('should return prerelease if match prerelease regex in getNpmTag', () => {
-    const task = new NpmPublish(logger)
+    const task = new NpmPublish(logger, {})
     expect(task.getNpmTag('v1.6.0-beta.1')).toEqual('prerelease')
   })
 
   it('should return latest if match latest regex in getNpmTag', () => {
-    const task = new NpmPublish(logger)
+    const task = new NpmPublish(logger, {})
     expect(task.getNpmTag('v1.6.0')).toEqual('latest')
   })
 
   it('should throw error if tag does not match semver regex', async () => {
     readStateMock.mockReturnValue({ tag: 'random-branch', repo: '', branch: '', version: '' })
 
-    const task = new NpmPublish(logger)
+    const task = new NpmPublish(logger, {})
     await expect(async () => {
       await task.run()
     }).rejects.toThrow(
@@ -69,17 +64,16 @@ describe('NpmPublish', () => {
     )
   })
 
-  it('should call listPackedFiles, pack and publish if tag matches semver regex', async () => {
-    process.env.NPM_AUTH_TOKEN = process.env.NPM_AUTH_TOKEN || 'dummy_value'
-    readStateMock.mockReturnValue({ tag: 'v1.2.3-beta.2', repo: '', branch: '', version: '' })
-    const listPackedFilesSpy = jest.spyOn(NpmPublish.prototype, 'listPackedFiles')
-    listPackedFilesSpy.mockImplementation(() => Promise.resolve())
+  it('should call exec to run npm version and npm publish if tag matches semver regex', async () => {
+    process.env.NPM_AUTH_TOKEN = process.env.NPM_AUTH_TOKEN || 'MOCK_NPM_AUTH_TOKEN'
+    const tag = 'v1.2.3-beta.2'
+    readStateMock.mockReturnValue({ tag: tag, repo: '', branch: '', version: '' })
 
-    const task = new NpmPublish(logger)
+    const task = new NpmPublish(logger, {})
     await task.run()
 
-    expect(listPackedFilesSpy).toBeCalled()
-    expect(pack).toBeCalled()
-    expect(publish).toBeCalled()
+    expect(spawn).toHaveBeenNthCalledWith(1, 'npm', ['version', tag])
+    expect(spawn).toHaveBeenNthCalledWith(2, 'npm', ['publish', '--tag', 'prerelease'])
+    expect(waitOnExit).toHaveBeenCalledTimes(2)
   })
 })


### PR DESCRIPTION
# Description

npm has started rejecting packages that attempt to publish with a different version defined in its' package.json. Turns out our plugin attempted to set the version in package.json but it wasn't saved. Packages have been publishing with a version number in package.json that differs to the version we state on npm.
 
This fix removes the use of the internal npm libraries and replaces it with using the cli directly.

# Checklist:

- [x] My branch has been rebased onto the latest commit on main (don't merge main into your branch)
- [x] My commit messages are [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/), for example: `feat(circleci): add support for nightly workflows`, `fix: set Heroku app name for staging apps too`
