### PR TITLE
fix(npm): add npmTask string to logger not task object

### DIFF
--- a/plugins/npm/src/tasks/npm-publish.ts
+++ b/plugins/npm/src/tasks/npm-publish.ts
@@ -31,8 +31,8 @@ export default class NpmPublish extends Task {
     try {
       this.logger.verbose(`running \`npm ${npmTask} ${options.join(' ')}\``)
       const task = spawn('npm', [npmTask, ...options])
-      hookFork(this.logger, `npm ${task}`, task)
-      await waitOnExit(`npm ${task}`, task)
+      hookFork(this.logger, `npm ${npmTask}`, task)
+      await waitOnExit(`npm ${npmTask}`, task)
     } catch (err) {
       const error = new ToolKitError(`unable to ${npmTask} package`)
       if (err instanceof Error) {


### PR DESCRIPTION
# Description

The npm publish task was giving the grouped logs heading as `npm [object Object]` which doesn't make it clear which of the tasks is currently happening.

This PR makes sure the correct npmTask value is being logged as the group heading.

## before

<img width="648" alt="image" src="https://github.com/Financial-Times/dotcom-tool-kit/assets/893208/da2b86c0-c5e9-408f-8f07-2a9479d1b574">

## after

<img width="696" alt="image" src="https://github.com/Financial-Times/dotcom-tool-kit/assets/893208/182612a9-8d37-4d24-bcc4-4510cead4d6c">

# Checklist:

- [x] My branch has been rebased onto the latest commit on main (don't merge main into your branch)
- [x] My commit messages are [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/), for example: `feat(circleci): add support for nightly workflows`, `fix: set Heroku app name for staging apps too`
