### PR TITLE
fix(npm): run npm version with --no-git-tag option

### DIFF
--- a/plugins/npm/src/tasks/npm-publish.ts
+++ b/plugins/npm/src/tasks/npm-publish.ts
@@ -63,7 +63,7 @@ export default class NpmPublish extends Task {
       )
     }
 
-    await this.executeNpmTask('version', [tag])
+    await this.executeNpmTask('version', [tag, '--no-git-tag-version'])
     await this.executeNpmTask('publish', ['--tag', npmTag])
 
     this.logger.info(`✅ npm package published`)

--- a/plugins/npm/test/npm-publish.test.ts
+++ b/plugins/npm/test/npm-publish.test.ts
@@ -68,7 +68,7 @@ describe('NpmPublish', () => {
     const task = new NpmPublish(logger, {})
     await task.run()
 
-    expect(spawn).toHaveBeenNthCalledWith(1, 'npm', ['version', tag])
+    expect(spawn).toHaveBeenNthCalledWith(1, 'npm', ['version', tag, '--no-git-tag-version'])
     expect(spawn).toHaveBeenNthCalledWith(2, 'npm', ['publish', '--tag', 'prerelease'])
     expect(waitOnExit).toHaveBeenCalledTimes(2)
   })


### PR DESCRIPTION
npm will try to set a git tag when running npm version. This is causing issues in CI as CircleCI is not setup with a git config (thankfully). We do not need npm to set a git tag and commit as this job will be running in response to a release tag being created on GitHub.

# Checklist:

- [x] My branch has been rebased onto the latest commit on main (don't merge main into your branch)
- [x] My commit messages are [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/), for example: `feat(circleci): add support for nightly workflows`, `fix: set Heroku app name for staging apps too`
