### PR TITLE
feat(orb): setup npm auth for publish job

### DIFF
--- a/orb/src/jobs/publish-tag.yml
+++ b/orb/src/jobs/publish-tag.yml
@@ -8,5 +8,9 @@ executor: << parameters.executor >>
 steps:
   - attach-workspace
   - run:
+      name: Set npm auth token
+      command: echo "//registry.npmjs.org/:_authToken=${NPM_AUTH_TOKEN}" >
+        ${HOME}/.npmrc
+  - run:
       name: Publish to npm
       command: npx dotcom-tool-kit publish:tag

--- a/orb/src/jobs/publish.yml
+++ b/orb/src/jobs/publish.yml
@@ -8,5 +8,9 @@ executor: << parameters.executor >>
 steps:
   - attach-workspace
   - run:
+      name: Set npm auth token
+      command: echo "//registry.npmjs.org/:_authToken=${NPM_AUTH_TOKEN}" >
+        ${HOME}/.npmrc
+  - run:
       name: Publish to npm
       command: npx dotcom-tool-kit publish:tag


### PR DESCRIPTION
# Description

Now the we use the npm CLI for #501, we need let the CLI known of the auth token. This method was taken from https://github.com/Financial-Times/dotcom-page-kit/blob/6f77ab771c8a915dc58e4535ad8a3735dc57cf67/.circleci/config.yml#L137-L140

# Checklist:

- [x] My branch has been rebased onto the latest commit on main (don't merge main into your branch)
- [x] My commit messages are [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/), for example: `feat(circleci): add support for nightly workflows`, `fix: set Heroku app name for staging apps too`
