### PR TITLE
Improve behaviour after testing runaway Jest tests

### DIFF
--- a/lib/logger/src/helpers.ts
+++ b/lib/logger/src/helpers.ts
@@ -144,11 +144,15 @@ export function waitOnExit(process: string, child: ChildProcess): Promise<void> 
     child.on('error', (error) => {
       reject(error)
     })
-    child.on('exit', (code) => {
+    child.on('exit', (code, signal) => {
       if (code === 0) {
         resolve()
       } else {
-        const error = new ToolKitError(`${process} process returned a non-zero exit code (${code})`)
+        const error = new ToolKitError(
+          `${process} process ${
+            code ? `returned a non-zero exit code (${code})` : `was terminated by a ${signal} signal`
+          }`
+        )
         error.details = 'error output has been logged above ☝️'
         error.exitCode = code ?? undefined
         reject(error)

--- a/plugins/jest/src/run-jest.ts
+++ b/plugins/jest/src/run-jest.ts
@@ -1,15 +1,48 @@
-import { fork } from 'child_process'
+import { fork } from 'node:child_process'
+import { readFile } from 'node:fs/promises'
 import type { JestOptions, JestMode } from '@dotcom-tool-kit/types/lib/schema/jest'
 import { hookFork, waitOnExit } from '@dotcom-tool-kit/logger'
 import type { Logger } from 'winston'
 const jestCLIPath = require.resolve('jest-cli/bin/jest')
 
-export default function runJest(logger: Logger, mode: JestMode, options: JestOptions): Promise<void> {
-  const args = [
-    '--colors',
-    mode === 'ci' ? '--ci' : '',
-    options.configPath ? `--config=${options.configPath}` : ''
-  ]
+// By default Jest will choose the number of worker threads based on the number
+// of reported CPUs. However, when running within Docker in CircleCI, the
+// number of reported CPUs is taken from the host machine rather than the
+// number of virtual CPUs your CircleCI resource class has allocated for you.
+// This means that Jest will typically create far more worker threads than is
+// appropriate for the CPU time that is allocated to the container, slowing
+// down test times.
+async function guessVCpus(): Promise<number> {
+  try {
+    // We can guess the number of vCPUs by reading this virtual file in the
+    // cimg images running on Linux. This is a non-standard path so may well
+    // not be present in other images/execution contexts so wrap everything in
+    // a try/catch statement.
+    const cpuShare = await readFile('/sys/fs/cgroup/cpu/cpu.shares', 'utf8')
+    // the CPU share should be a multiple of 1024
+    return Math.max(Math.floor(Number(cpuShare) / 1024), 2)
+  } catch {
+    // assume we're running on a medium resource class execution environment
+    // with 2 vCPUs if we fail to find the CPU share
+    return 2
+  }
+}
+
+export default async function runJest(logger: Logger, mode: JestMode, options: JestOptions): Promise<void> {
+  const args = ['--colors', options.configPath ? `--config=${options.configPath}` : '']
+  // TODO:20231107:IM we should probably refactor this plugin to move
+  // CI-specific logic to be within the CI task module
+  if (mode === 'ci') {
+    args.push('--ci')
+    // only relevant if running on CircleCI, other CI environments might handle
+    // virtualisation completely differently
+    if (process.env.CIRCLECI) {
+      // leave one vCPU free for the main thread, same as the default Jest
+      // logic
+      const maxWorkers = (await guessVCpus()) - 1
+      args.push(`--max-workers=${maxWorkers}`)
+    }
+  }
   logger.info(`running jest ${args.join(' ')}`)
   const child = fork(jestCLIPath, args, { silent: true })
   hookFork(logger, 'jest', child)

--- a/plugins/jest/tests/jest-plugin.test.ts
+++ b/plugins/jest/tests/jest-plugin.test.ts
@@ -1,4 +1,4 @@
-import { fork } from 'child_process'
+import { fork } from 'node:child_process'
 import JestLocal from '../src/tasks/local'
 import JestCI from '../src/tasks/ci'
 import EventEmitter from 'events'
@@ -6,7 +6,7 @@ import winston, { Logger } from 'winston'
 
 const logger = (winston as unknown) as Logger
 
-jest.mock('child_process', () => ({
+jest.mock('node:child_process', () => ({
   fork: jest.fn(() => {
     // return a fake emitter that immediately sends an "exit" event, so the jest task resolves
     const emitter = new EventEmitter()
@@ -24,16 +24,24 @@ describe('jest plugin', () => {
       const jestLocal = new JestLocal(logger, { configPath: './src/jest.config.js' })
       await jestLocal.run()
 
-      expect(fork).toBeCalledWith(expect.any(String), ['--colors', '', '--config=./src/jest.config.js'], {
-        silent: true
-      })
+      expect(fork).toBeCalledWith(
+        expect.any(String),
+        expect.arrayContaining(['--config=./src/jest.config.js']),
+        {
+          silent: true
+        }
+      )
     })
 
     it('should call jest cli without configPath by default', async () => {
       const jestLocal = new JestLocal(logger, {})
       await jestLocal.run()
 
-      expect(fork).toBeCalledWith(expect.any(String), ['--colors', '', ''], { silent: true })
+      expect(fork).toBeCalledWith(
+        expect.any(String),
+        expect.not.arrayContaining([expect.stringContaining('--config')]),
+        { silent: true }
+      )
     })
   })
 
@@ -42,16 +50,24 @@ describe('jest plugin', () => {
       const jestCI = new JestCI(logger, { configPath: './src/jest.config.js' })
       await jestCI.run()
 
-      expect(fork).toBeCalledWith(expect.any(String), ['--colors', '--ci', '--config=./src/jest.config.js'], {
-        silent: true
-      })
+      expect(fork).toBeCalledWith(
+        expect.any(String),
+        expect.arrayContaining(['--ci', '--config=./src/jest.config.js']),
+        {
+          silent: true
+        }
+      )
     })
 
     it('should call jest cli without configPath by default', async () => {
       const jestCI = new JestCI(logger, {})
       await jestCI.run()
 
-      expect(fork).toBeCalledWith(expect.any(String), ['--colors', '--ci', ''], { silent: true })
+      expect(fork).toBeCalledWith(
+        expect.any(String),
+        expect.not.arrayContaining([expect.stringContaining('--config')]),
+        { silent: true }
+      )
     })
   })
 })


### PR DESCRIPTION
# Description

Have been trying to debug an issue that @GlynnPhillips raised a few months ago about the `jest` plugin [failing](https://app.circleci.com/pipelines/github/Financial-Times/next-profile/12460/workflows/50fe1cd9-b326-45d6-87b7-cb15abd9469c/jobs/50449?invite=true#step-102-198909_49) unexpectedly with an unhelpful error message. Ultimately, it looks like the underlying problem is a memory leak within their test suite causing the CircleCI executor to kill the process due to an out-of-memory exception (with Tool Kit running causing the memory usage in the container to be tipped over the edge.) This can't be solved from Tool Kit, however I spotted a few issues which could be fixed by us:
1. log terminations of sub processes by signals properly
2. limit the number of spawned worker threads to the number of vCPUs allocated by CircleCI to avoid [task overload](https://discuss.circleci.com/t/debugging-random-node-js-build-failures/39667) (spotted when running [`htop`](https://htop.dev) to verify the OOM exception). this should result in performance improvements for most test suites.

# Checklist:

- [x] My branch has been rebased onto the latest commit on main (don't merge main into your branch)
- [x] My commit messages are [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/), for example: `feat(circleci): add support for nightly workflows`, `fix: set Heroku app name for staging apps too`
