### PR TITLE
Allow sandbox directory to stay without package.json

### DIFF
--- a/scripts/clean-up-packages.sh
+++ b/scripts/clean-up-packages.sh
@@ -6,7 +6,7 @@ readonly isBranchMove="$3"
 if [ "$isBranchMove" = "1" ]; then
 	echo "changed branches, cleaning up zombie packages..."
 	for package in core/* plugins/* lib/*; do
-		if ! [ -f "$package/package.json" ]; then
+		if ! [ -f "$package/package.json" ] && [ "$package" != "core/sandbox" ]; then
 			echo "deleting $package"
 			rm -rf "$package"
 		fi


### PR DESCRIPTION
# Description

This package is just a place to test Tool Kit code now and thus doesn't have a `package.json` of its own (though one can be added by the tester and it won't be tracked by git). Our clean up script [automatically](https://github.com/Financial-Times/dotcom-tool-kit/pull/64) removes any package without a `package.json` script to avoid 'zombie packages' but we can make an exception for the sandbox. 

# Checklist:

- [x] My branch has been rebased onto the latest commit on main (don't merge main into your branch)
- [x] My commit messages are [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/), for example: `feat(circleci): add support for nightly workflows`, `fix: set Heroku app name for staging apps too`
