### PR TITLE
Rename hooks to commands

### DIFF
--- a/core/cli/src/command.ts
+++ b/core/cli/src/command.ts
@@ -1,6 +1,6 @@
 import type { Plugin } from '@dotcom-tool-kit/types'
 
-export interface HookTask {
+export interface CommandTask {
   id: string
   plugin: Plugin
   tasks: string[]

--- a/core/cli/src/help.ts
+++ b/core/cli/src/help.ts
@@ -43,7 +43,7 @@ ${
     const Hook = config.hooks[hook]
 
     if (Hook) {
-      const tasks = config.hookTasks[hook]
+      const tasks = config.commandTasks[hook]
       /* eslint-disable @typescript-eslint/no-explicit-any -- Object.constructor does not consider static properties */
       logger.info(`${styles.heading(hook)}
 ${(Hook.constructor as any).description ? (Hook.constructor as any).description + '\n' : ''}

--- a/core/cli/src/index.ts
+++ b/core/cli/src/index.ts
@@ -91,18 +91,18 @@ ${availableHooks}`
     process.execArgv.push('--no-experimental-fetch')
   }
 
-  const taskNames = hooks.flatMap((hook) => config.hookTasks[hook]?.tasks ?? [])
+  const taskNames = hooks.flatMap((hook) => config.commandTasks[hook]?.tasks ?? [])
   const tasks = unwrapValidated(await loadTasks(logger, taskNames, config), 'tasks are invalid')
 
   for (const hook of hooks) {
     const errors: ErrorSummary[] = []
 
-    if (!config.hookTasks[hook]) {
+    if (!config.commandTasks[hook]) {
       logger.warn(`no task configured for ${hook}: skipping assignment...`)
       continue
     }
 
-    for (const id of config.hookTasks[hook].tasks) {
+    for (const id of config.commandTasks[hook].tasks) {
       try {
         logger.info(styles.taskHeader(`running ${styles.task(id)} task`))
         await tasks[id].run(files)

--- a/core/cli/src/messages.ts
+++ b/core/cli/src/messages.ts
@@ -4,7 +4,7 @@ import type { z } from 'zod'
 import { fromZodError } from 'zod-validation-error'
 import type { PluginOptions } from './config'
 import type { Conflict } from './conflict'
-import type { HookTask } from './hook'
+import type { CommandTask } from './command'
 
 const formatTaskConflict = ([key, conflict]: [string, Conflict<string>]): string =>
   `- ${s.task(key ?? 'unknown task')} ${s.dim('from plugins')} ${conflict.conflicting
@@ -30,22 +30,22 @@ ${conflicts.map(formatHookConflict).join('\n')}
 
 You must resolve this conflict by removing all but one of these plugins.`
 
-const formatHookTaskConflict = (conflict: Conflict<HookTask>): string => `${s.hook(
+const formatCommandTaskConflict = (conflict: Conflict<CommandTask>): string => `${s.hook(
   conflict.conflicting[0].id
 )}:
 ${conflict.conflicting
   .map(
-    (hook) =>
-      `- ${hook.tasks.map(s.task).join(s.dim(', '))} ${s.dim('by plugin')} ${s.plugin(hook.plugin.id)}`
+    (command) =>
+      `- ${command.tasks.map(s.task).join(s.dim(', '))} ${s.dim('by plugin')} ${s.plugin(command.plugin.id)}`
   )
   .join('\n')}
 `
 
-export const formatHookTaskConflicts = (conflicts: Conflict<HookTask>[]): string => `${s.heading(
-  'These hooks are configured to run different tasks by multiple plugins'
+export const formatCommandTaskConflicts = (conflicts: Conflict<CommandTask>[]): string => `${s.heading(
+  'These commands are configured to run different tasks by multiple plugins'
 )}:
-${conflicts.map(formatHookTaskConflict).join('\n')}
-You must resolve this conflict by explicitly configuring which task to run for these hooks. See ${s.URL(
+${conflicts.map(formatCommandTaskConflict).join('\n')}
+You must resolve this conflict by explicitly configuring which task to run for these commands. See ${s.URL(
   'https://github.com/financial-times/dotcom-tool-kit/tree/main/docs/resolving-hook-conflicts.md'
 )} for more details.
 
@@ -72,10 +72,10 @@ const formatPlugin = (plugin: Plugin): string =>
   plugin.id === 'app root' ? s.app('your app') : `plugin ${s.plugin(plugin.id)}`
 
 // TODO text similarity "did you mean...?"
-export const formatUndefinedHookTasks = (
-  undefinedHooks: HookTask[],
+export const formatUndefinedCommandTasks = (
+  undefinedHooks: CommandTask[],
   definedHooks: string[]
-): string => `Hooks must be defined by a plugin before you can configure a task to run for them. In your Tool Kit configuration you've configured hooks that aren't defined:
+): string => `TODO Hooks must be defined by a plugin before you can configure a task to run for them. In your Tool Kit configuration you've configured hooks that aren't defined:
 
 ${undefinedHooks.map((hook) => `- ${s.hook(hook.id)}`).join('\n')}
 
@@ -126,7 +126,7 @@ ${uninstalledHooks.map((hook) => `- ${s.hook(hook.id || 'unknown event')}`).join
 Run ${s.task('dotcom-tool-kit --install')} to install these hooks.
 `
 
-type Missing = { hook: HookTask; tasks: string[] }
+type Missing = { hook: CommandTask; tasks: string[] }
 
 const formatMissingTask = (missing: Missing): string =>
   `- ${missing.tasks.map(s.task).join(', ')} ${s.dim(

--- a/core/cli/src/plugin.ts
+++ b/core/cli/src/plugin.ts
@@ -14,7 +14,7 @@ import resolveFrom from 'resolve-from'
 import type { Logger } from 'winston'
 import { PluginOptions, RawConfig, ValidPluginsConfig } from './config'
 import { Conflict, isConflict } from './conflict'
-import type { HookTask } from './hook'
+import type { CommandTask } from './command'
 import { loadToolKitRC } from './rc-file'
 import { isPlainObject } from 'lodash'
 
@@ -213,45 +213,47 @@ export function resolvePlugin(plugin: Plugin, config: ValidPluginsConfig, logger
       }
     }
 
-    // load plugin hook tasks. do this after loading child plugins, so
-    // parent hooks get assigned after child hooks and can override them
-    for (const [id, configHookTask] of Object.entries(plugin.rcFile.commands)) {
-      // handle conflicts between hooks from different plugins
-      const existingHookTask = config.hookTasks[id]
-      const newHookTask: HookTask = {
+    // load plugin command tasks. do this after loading child plugins, so
+    // parent commands get assigned after child commands and can override them
+    for (const [id, configCommandTask] of Object.entries(plugin.rcFile.commands)) {
+      // handle conflicts between commands from different plugins
+      const existingCommandTask = config.commandTasks[id]
+      const newCommandTask: CommandTask = {
         id,
         plugin,
-        tasks: Array.isArray(configHookTask) ? configHookTask : [configHookTask]
+        tasks: Array.isArray(configCommandTask) ? configCommandTask : [configCommandTask]
       }
 
-      if (existingHookTask) {
-        const existingFromDescendent = isDescendent(plugin, existingHookTask.plugin)
+      if (existingCommandTask) {
+        const existingFromDescendent = isDescendent(plugin, existingCommandTask.plugin)
 
-        // plugins can only override hook tasks from their descendents, otherwise that's a conflict
-        // return a conflict either listing this hook and the siblings,
-        // or merging in a previously-generated hook
+        // plugins can only override command tasks from their descendents, otherwise that's a conflict
+        // return a conflict either listing this command and the siblings,
+        // or merging in a previously-generated command
         if (!existingFromDescendent) {
-          const conflicting = isConflict(existingHookTask) ? existingHookTask.conflicting : [existingHookTask]
+          const conflicting = isConflict(existingCommandTask)
+            ? existingCommandTask.conflicting
+            : [existingCommandTask]
 
-          const conflict: Conflict<HookTask> = {
+          const conflict: Conflict<CommandTask> = {
             plugin,
-            conflicting: conflicting.concat(newHookTask)
+            conflicting: conflicting.concat(newCommandTask)
           }
 
-          config.hookTasks[id] = conflict
+          config.commandTasks[id] = conflict
         } else {
-          // if we're here, any existing hook is from a child plugin,
+          // if we're here, any existing command is from a child plugin,
           // so the parent always overrides it
-          config.hookTasks[id] = newHookTask
+          config.commandTasks[id] = newCommandTask
         }
       } else {
-        // this hook task might not have been set yet, in which case use the new one
-        config.hookTasks[id] = newHookTask
+        // this command task might not have been set yet, in which case use the new one
+        config.commandTasks[id] = newCommandTask
       }
     }
 
     // merge options from this plugin's config with any options we've collected already
-    // TODO this is almost the exact same code as for hooks, refactor
+    // TODO this is almost the exact same code as for command tasks, refactor
     for (const [id, configOptions] of Object.entries(plugin.rcFile.options)) {
       // users can specify root options with the dotcom-tool-kit key to mirror
       // the name of the root npm package

--- a/core/cli/src/plugin.ts
+++ b/core/cli/src/plugin.ts
@@ -215,7 +215,7 @@ export function resolvePlugin(plugin: Plugin, config: ValidPluginsConfig, logger
 
     // load plugin hook tasks. do this after loading child plugins, so
     // parent hooks get assigned after child hooks and can override them
-    for (const [id, configHookTask] of Object.entries(plugin.rcFile.hooks)) {
+    for (const [id, configHookTask] of Object.entries(plugin.rcFile.commands)) {
       // handle conflicts between hooks from different plugins
       const existingHookTask = config.hookTasks[id]
       const newHookTask: HookTask = {

--- a/core/cli/src/rc-file.ts
+++ b/core/cli/src/rc-file.ts
@@ -5,7 +5,7 @@ import * as path from 'path'
 import type { Logger } from 'winston'
 
 export const explorer = cosmiconfig('toolkit', { ignoreEmptySearchPlaces: false })
-const emptyConfig = { plugins: [], installs: [], tasks: [], hooks: {}, options: {} }
+const emptyConfig = { plugins: [], installs: [], tasks: [], commands: {}, options: {} }
 let rootConfig: string | undefined
 
 type RawRCFile = {
@@ -37,7 +37,7 @@ export async function loadToolKitRC(logger: Logger, root: string, isAppRoot: boo
     plugins: config.plugins ?? [],
     installs: config.installs ?? [],
     tasks: config.tasks ?? [],
-    hooks: config.hooks ?? {},
+    commands: config.commands ?? {},
     options: config.options ?? {}
   }
 }

--- a/core/cli/test/files/conflict-resolution/.toolkitrc.yml
+++ b/core/cli/test/files/conflict-resolution/.toolkitrc.yml
@@ -17,7 +17,7 @@ options:
     team: platforms
     app: tool-kit-test
 
-hooks:
+commands:
   build:local:
     - WebpackDevelopment
     - BabelDevelopment

--- a/core/cli/test/files/conflicted/.toolkitrc.yml
+++ b/core/cli/test/files/conflicted/.toolkitrc.yml
@@ -6,4 +6,4 @@ plugins:
 
 options:
 
-hooks:
+commands:

--- a/core/cli/test/files/cousins/.toolkitrc.yml
+++ b/core/cli/test/files/cousins/.toolkitrc.yml
@@ -6,4 +6,4 @@ plugins:
 
 options:
 
-hooks:
+commands:

--- a/core/cli/test/files/duplicate/.toolkitrc.yml
+++ b/core/cli/test/files/duplicate/.toolkitrc.yml
@@ -15,4 +15,4 @@ options:
     team: platforms
     app: tool-kit-test
 
-hooks:
+commands:

--- a/core/cli/test/files/successful/.toolkitrc.yml
+++ b/core/cli/test/files/successful/.toolkitrc.yml
@@ -13,7 +13,7 @@ options:
   '@dotcom-tool-kit/n-test':
     host: 'https://example.com'
 
-hooks:
+commands:
   'test:local':
     - Mocha
     - Eslint

--- a/core/cli/test/index.test.ts
+++ b/core/cli/test/index.test.ts
@@ -28,9 +28,9 @@ describe('cli', () => {
     resolvePlugin((plugin as Valid<Plugin>).value, validPluginConfig, logger)
 
     expect(() => validateConfig(validPluginConfig, logger)).toThrow(ToolKitError)
-    expect(validPluginConfig).toHaveProperty('hookTasks.build:ci.conflicting')
-    expect(validPluginConfig).toHaveProperty('hookTasks.build:remote.conflicting')
-    expect(validPluginConfig).toHaveProperty('hookTasks.build:local.conflicting')
+    expect(validPluginConfig).toHaveProperty('commandTasks.build:ci.conflicting')
+    expect(validPluginConfig).toHaveProperty('commandTasks.build:remote.conflicting')
+    expect(validPluginConfig).toHaveProperty('commandTasks.build:local.conflicting')
   })
 
   it('should indicate when there are conflicts between plugins that are cousins in the tree', async () => {
@@ -49,9 +49,9 @@ describe('cli', () => {
     resolvePlugin((plugin as Valid<Plugin>).value, validPluginConfig, logger)
 
     expect(() => validateConfig(validPluginConfig, logger)).toThrow(ToolKitError)
-    expect(config).toHaveProperty('hookTasks.build:ci.conflicting')
-    expect(config).toHaveProperty('hookTasks.build:remote.conflicting')
-    expect(config).toHaveProperty('hookTasks.build:local.conflicting')
+    expect(config).toHaveProperty('commandTasks.build:ci.conflicting')
+    expect(config).toHaveProperty('commandTasks.build:remote.conflicting')
+    expect(config).toHaveProperty('commandTasks.build:local.conflicting')
   })
 
   it('should not have conflicts between multiple of the same plugin', async () => {
@@ -99,8 +99,11 @@ describe('cli', () => {
     try {
       const validConfig = validateConfig(validPluginConfig, logger)
 
-      expect(validConfig).not.toHaveProperty('hookTasks.build:local.conflicting')
-      expect(validConfig.hookTasks['build:local'].tasks).toEqual(['WebpackDevelopment', 'BabelDevelopment'])
+      expect(validConfig).not.toHaveProperty('commandTasks.build:local.conflicting')
+      expect(validConfig.commandTasks['build:local'].tasks).toEqual([
+        'WebpackDevelopment',
+        'BabelDevelopment'
+      ])
     } catch (e) {
       if (e instanceof ToolKitError) {
         e.message += '\n' + e.details

--- a/core/create/src/index.ts
+++ b/core/create/src/index.ts
@@ -98,7 +98,7 @@ async function main() {
     plugins: [],
     installs: [],
     tasks: [],
-    hooks: {},
+    commands: {},
     options: {}
   }
 

--- a/core/create/src/prompts/conflicts.ts
+++ b/core/create/src/prompts/conflicts.ts
@@ -62,7 +62,7 @@ Please select the ${ordinal(i)} package to run.`,
     }
   }
 
-  toolKitConfig.hooks = orderedHooks
+  toolKitConfig.commands = orderedHooks
   const configFile = YAML.stringify(toolKitConfig)
 
   const { confirm } = await prompt({

--- a/core/create/src/prompts/conflicts.ts
+++ b/core/create/src/prompts/conflicts.ts
@@ -31,7 +31,7 @@ export default async ({ error, logger, toolKitConfig, configPath }: ConflictsPar
 
   for (const conflict of error.conflicts) {
     const remainingTasks = conflict.conflictingTasks
-    orderedHooks[conflict.hook] = []
+    orderedHooks[conflict.command] = []
 
     const totalTasks = remainingTasks.length
     for (let i = 1; i <= totalTasks; i++) {
@@ -39,7 +39,7 @@ export default async ({ error, logger, toolKitConfig, configPath }: ConflictsPar
         name: 'order',
         type: 'select',
         message: `Hook ${styles.hook(
-          conflict.hook
+          conflict.command
         )} has multiple tasks configured for it, so an order must be specified. \
 Please select the ${ordinal(i)} package to run.`,
         choices: [
@@ -57,7 +57,7 @@ Please select the ${ordinal(i)} package to run.`,
         break
       } else {
         const { task } = remainingTasks.splice(nextIdx, 1)[0]
-        orderedHooks[conflict.hook].push(task)
+        orderedHooks[conflict.command].push(task)
       }
     }
   }

--- a/lib/error/src/index.ts
+++ b/lib/error/src/index.ts
@@ -8,15 +8,15 @@ export interface ConflictingTask {
   plugin: string
 }
 
-export interface HookTaskConflict {
-  hook: string
+export interface CommandTaskConflict {
+  command: string
   conflictingTasks: ConflictingTask[]
 }
 
 export class ToolKitConflictError extends ToolKitError {
-  conflicts: HookTaskConflict[]
+  conflicts: CommandTaskConflict[]
 
-  constructor(message: string, conflicts: HookTaskConflict[]) {
+  constructor(message: string, conflicts: CommandTaskConflict[]) {
     super(message)
     this.conflicts = conflicts
   }

--- a/lib/types/src/index.ts
+++ b/lib/types/src/index.ts
@@ -9,7 +9,7 @@ export type RCFile = {
   plugins: string[]
   installs: string[]
   tasks: string[]
-  hooks: { [id: string]: string | string[] }
+  commands: { [id: string]: string | string[] }
   options: { [id: string]: Record<string, unknown> }
 }
 

--- a/plugins/babel/.toolkitrc.yml
+++ b/plugins/babel/.toolkitrc.yml
@@ -2,7 +2,7 @@ tasks:
   - BabelDevelopment
   - BabelProduction
 
-hooks:
+commands:
   'build:local': BabelDevelopment
   'build:ci': BabelProduction
   'build:remote': BabelProduction

--- a/plugins/backend-heroku-app/.toolkitrc.yml
+++ b/plugins/backend-heroku-app/.toolkitrc.yml
@@ -4,7 +4,7 @@ plugins:
   - '@dotcom-tool-kit/heroku'
   - '@dotcom-tool-kit/node'
 
-hooks:
+commands:
   'run:local': Node
   'deploy:review': HerokuReview
   'deploy:staging': HerokuStaging

--- a/plugins/backend-serverless-app/.toolkitrc.yml
+++ b/plugins/backend-serverless-app/.toolkitrc.yml
@@ -4,7 +4,7 @@ plugins:
   - '@dotcom-tool-kit/serverless'
   - '@dotcom-tool-kit/node'
 
-hooks:
+commands:
   'run:local': ServerlessRun
   'deploy:review': ServerlessProvision
   'deploy:production': ServerlessDeploy

--- a/plugins/circleci-heroku/.toolkitrc.yml
+++ b/plugins/circleci-heroku/.toolkitrc.yml
@@ -2,7 +2,7 @@ plugins:
   - '@dotcom-tool-kit/circleci-deploy'
   - '@dotcom-tool-kit/heroku'
 
-hooks:
+commands:
   'deploy:review': HerokuReview
   'deploy:staging': HerokuStaging
   'deploy:production': HerokuProduction

--- a/plugins/circleci-npm/.toolkitrc.yml
+++ b/plugins/circleci-npm/.toolkitrc.yml
@@ -5,5 +5,5 @@ plugins:
 installs:
   - 'publish:tag'
 
-hooks:
+commands:
   'publish:tag': NpmPublish

--- a/plugins/cypress/.toolkitrc.yml
+++ b/plugins/cypress/.toolkitrc.yml
@@ -5,8 +5,7 @@ tasks:
   - CypressCi
   - CypressLocal
 
-hooks:
+commands:
   'test:review': CypressCi
   'test:staging': CypressCi
   'e2e:local': CypressLocal
-

--- a/plugins/eslint/.toolkitrc.yml
+++ b/plugins/eslint/.toolkitrc.yml
@@ -1,7 +1,7 @@
 tasks:
   - Eslint
 
-hooks:
+commands:
   'test:local': Eslint
   'test:ci': Eslint
   'test:staged': Eslint

--- a/plugins/frontend-app/.toolkitrc.yml
+++ b/plugins/frontend-app/.toolkitrc.yml
@@ -3,7 +3,7 @@ plugins:
   - '@dotcom-tool-kit/backend-heroku-app'
   - '@dotcom-tool-kit/upload-assets-to-s3'
 
-hooks:
+commands:
   'run:local':
     - WebpackDevelopment # run a webpack compile before starting the server because dotcom-server-asset-loader expects a manifest to exist
     - Node

--- a/plugins/heroku/.toolkitrc.yml
+++ b/plugins/heroku/.toolkitrc.yml
@@ -13,5 +13,5 @@ tasks:
   - HerokuReview
   - HerokuTeardown
 
-hooks:
+commands:
   'cleanup:remote': NpmPrune

--- a/plugins/jest/.toolkitrc.yml
+++ b/plugins/jest/.toolkitrc.yml
@@ -2,6 +2,6 @@ tasks:
   - JestLocal
   - JestCI
 
-hooks:
+commands:
   'test:local': JestLocal
   'test:ci': JestCI

--- a/plugins/lint-staged/.toolkitrc.yml
+++ b/plugins/lint-staged/.toolkitrc.yml
@@ -1,5 +1,5 @@
 tasks:
   - LintStaged
 
-hooks:
+commands:
   'git:precommit': LintStaged

--- a/plugins/mocha/.toolkitrc.yml
+++ b/plugins/mocha/.toolkitrc.yml
@@ -1,6 +1,6 @@
 tasks:
   - Mocha
 
-hooks:
+commands:
   'test:local': Mocha
   'test:ci': Mocha

--- a/plugins/n-test/.toolkitrc.yml
+++ b/plugins/n-test/.toolkitrc.yml
@@ -1,6 +1,6 @@
 tasks:
   - NTest
 
-hooks:
+commands:
   'test:review': NTest
   'test:staging': NTest

--- a/plugins/next-router/.toolkitrc.yml
+++ b/plugins/next-router/.toolkitrc.yml
@@ -4,6 +4,6 @@ plugins:
 tasks:
   - NextRouter
 
-hooks:
+commands:
   run:local:
     - NextRouter

--- a/plugins/node/.toolkitrc.yml
+++ b/plugins/node/.toolkitrc.yml
@@ -4,5 +4,5 @@ plugins:
 tasks:
   - Node
 
-hooks:
+commands:
   'run:local': Node

--- a/plugins/nodemon/.toolkitrc.yml
+++ b/plugins/nodemon/.toolkitrc.yml
@@ -4,5 +4,5 @@ plugins:
 tasks:
   - Nodemon
 
-hooks:
+commands:
   'run:local': Nodemon

--- a/plugins/pa11y/.toolkitrc.yml
+++ b/plugins/pa11y/.toolkitrc.yml
@@ -4,5 +4,5 @@ plugins:
 tasks:
   - Pa11y
 
-hooks:
+commands:
   'test:review': Pa11y

--- a/plugins/prettier/.toolkitrc.yml
+++ b/plugins/prettier/.toolkitrc.yml
@@ -1,9 +1,9 @@
 installs:
-  - "format:local"
+  - 'format:local'
 
 tasks:
   - Prettier
 
-hooks:
+commands:
   'format:local': Prettier
   'format:staged': Prettier

--- a/plugins/typescript/.toolkitrc.yml
+++ b/plugins/typescript/.toolkitrc.yml
@@ -3,7 +3,7 @@ tasks:
   - TypeScriptWatch
   - TypeScriptTest
 
-hooks:
+commands:
   'build:local': TypeScriptBuild
   'run:local': TypeScriptWatch
   'test:local': TypeScriptTest

--- a/plugins/upload-assets-to-s3/.toolkitrc.yml
+++ b/plugins/upload-assets-to-s3/.toolkitrc.yml
@@ -1,5 +1,5 @@
 tasks:
   - UploadAssetsToS3
 
-hooks:
+commands:
   'release:remote': UploadAssetsToS3

--- a/plugins/webpack/.toolkitrc.yml
+++ b/plugins/webpack/.toolkitrc.yml
@@ -3,7 +3,7 @@ tasks:
   - WebpackProduction
   - WebpackWatch
 
-hooks:
+commands:
   'build:local': WebpackDevelopment
   'build:ci': WebpackProduction
   'build:remote': WebpackProduction


### PR DESCRIPTION
renames `hooks` to `command` for `.toolkitrc` files and in the internal config as groundwork for `hook-options`. this is a breaking change.