### PR TITLE
Fix eslint no-unused-vars

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -11,6 +11,8 @@ module.exports = {
   rules: {
     // We use winston's logging instead
     'no-console': 'error',
+    // conflicts with @typescript-eslint/no-unused-vars
+    'no-unused-vars': 'off',
     // Necessary to allow us to define arguments in a method that only subclasses use
     // https://github.com/typescript-eslint/typescript-eslint/issues/586#issuecomment-510099609
     '@typescript-eslint/no-unused-vars': ['warn', { argsIgnorePattern: '^_' }]

--- a/lib/types/src/hook.ts
+++ b/lib/types/src/hook.ts
@@ -29,8 +29,6 @@ export abstract class Hook<State = void> extends Base {
 
   abstract check(): Promise<boolean>
   abstract install(state?: State): Promise<State>
-  // Intentional unused parameter as pre-fixed with an underscore
-  // eslint-disable-next-line no-unused-vars
   async commitInstall(_state: State): Promise<void> {
     return
   }

--- a/plugins/heroku/test/setConfigVars.test.ts
+++ b/plugins/heroku/test/setConfigVars.test.ts
@@ -4,7 +4,6 @@ import { DopplerEnvVars } from '@dotcom-tool-kit/doppler'
 import heroku from '../src/herokuClient'
 import winston, { Logger } from 'winston'
 const logger = (winston as unknown) as Logger
-/* eslint-disable @typescript-eslint/no-unused-vars */
 type DopplerPath = {
   project: string
 }
@@ -38,8 +37,6 @@ const reviewPatchBody = {
 }
 class DopplerEnvVarsMock {
   dopplerPath: DopplerPath
-  // Intentional unused parameter as pre-fixed with an underscore
-  // eslint-disable-next-line no-unused-vars
   constructor(_dopplerPath: DopplerPath, public environment: string, private migrated: boolean) {
     this.dopplerPath = dopplerPath
   }


### PR DESCRIPTION
option was always configured intending `_` prefixed vars to be allowed as unused but this conflicted with the Typescript plugin rule