### PR TITLE
refactor: use an EntryPoint object for tasks and hooks in the config

### DIFF
--- a/core/cli/src/index.ts
+++ b/core/cli/src/index.ts
@@ -43,15 +43,15 @@ const loadTasks = async (
 ): Promise<Validated<Record<string, Task>>> => {
   const taskResults = await Promise.all(
     taskNames.map(async (taskName) => {
-      const pluginId = config.tasks[taskName]
-      const taskPlugin = await importPlugin(pluginId)
+      const entryPoint = config.tasks[taskName]
+      const taskPlugin = await importPlugin(entryPoint.modulePath)
 
       return flatMapValidated(taskPlugin, (plugin) => {
         const pluginTasks = validatePluginTasks(plugin as RawPluginModule)
 
         return mapValidated(pluginTasks, (tasks) => [
           taskName,
-          new tasks[taskName](logger, taskName, getOptions(pluginId as OptionKey) ?? {})
+          new tasks[taskName](logger, taskName, getOptions(entryPoint.plugin.id as OptionKey) ?? {})
         ])
       })
     })

--- a/core/cli/src/messages.ts
+++ b/core/cli/src/messages.ts
@@ -2,28 +2,28 @@ import { styles as s, styles } from '@dotcom-tool-kit/logger'
 import type { Hook, Plugin } from '@dotcom-tool-kit/types'
 import type { z } from 'zod'
 import { fromZodError } from 'zod-validation-error'
-import type { PluginOptions } from './config'
+import type { EntryPoint, PluginOptions } from './config'
 import type { Conflict } from './conflict'
 import type { CommandTask } from './command'
 
-const formatTaskConflict = ([key, conflict]: [string, Conflict<string>]): string =>
+const formatTaskConflict = ([key, conflict]: [string, Conflict<EntryPoint>]): string =>
   `- ${s.task(key ?? 'unknown task')} ${s.dim('from plugins')} ${conflict.conflicting
-    .map((task) => s.plugin(task ?? 'unknown plugin'))
+    .map((entryPoint) => s.plugin(entryPoint.plugin.id ?? 'unknown plugin'))
     .join(s.dim(', '))}`
 
-export const formatTaskConflicts = (conflicts: [string, Conflict<string>][]): string => `${s.heading(
+export const formatTaskConflicts = (conflicts: [string, Conflict<EntryPoint>][]): string => `${s.heading(
   'There are multiple plugins that include the same tasks'
 )}:
 ${conflicts.map(formatTaskConflict).join('\n')}
 
 You must resolve this conflict by removing all but one of these plugins.`
 
-const formatHookConflict = ([key, conflict]: [string, Conflict<string>]): string =>
+const formatHookConflict = ([key, conflict]: [string, Conflict<EntryPoint>]): string =>
   `- ${s.hook(key ?? 'unknown hook')} ${s.dim('from plugins')} ${conflict.conflicting
-    .map((task) => s.plugin(task ?? 'unknown plugin'))
+    .map((entryPoint) => s.plugin(entryPoint.plugin.id ?? 'unknown plugin'))
     .join(s.dim(', '))}`
 
-export const formatHookConflicts = (conflicts: [string, Conflict<string>][]): string => `${s.heading(
+export const formatHookConflicts = (conflicts: [string, Conflict<EntryPoint>][]): string => `${s.heading(
   'There are multiple plugins that include the same hooks'
 )}:
 ${conflicts.map(formatHookConflict).join('\n')}

--- a/core/cli/src/plugin.ts
+++ b/core/cli/src/plugin.ts
@@ -12,7 +12,7 @@ import {
 } from '@dotcom-tool-kit/types'
 import resolveFrom from 'resolve-from'
 import type { Logger } from 'winston'
-import { PluginOptions, RawConfig, ValidPluginsConfig } from './config'
+import { EntryPoint, PluginOptions, RawConfig, ValidPluginsConfig } from './config'
 import { Conflict, isConflict } from './conflict'
 import type { CommandTask } from './command'
 import { loadToolKitRC } from './rc-file'
@@ -183,16 +183,20 @@ export function resolvePlugin(plugin: Plugin, config: ValidPluginsConfig, logger
     // add plugin tasks to our task registry, handling any conflicts
     for (const taskName of plugin.rcFile.tasks || []) {
       const existingTaskId = config.tasks[taskName]
+      const entryPoint: EntryPoint = {
+        plugin,
+        modulePath: plugin.id
+      }
 
       if (existingTaskId) {
         const conflicting = isConflict(existingTaskId) ? existingTaskId.conflicting : [existingTaskId]
 
         config.tasks[taskName] = {
           plugin,
-          conflicting: conflicting.concat(plugin.id)
+          conflicting: conflicting.concat(entryPoint)
         }
       } else {
-        config.tasks[taskName] = plugin.id
+        config.tasks[taskName] = entryPoint
       }
     }
 
@@ -200,16 +204,20 @@ export function resolvePlugin(plugin: Plugin, config: ValidPluginsConfig, logger
     // TODO refactor with command conflict handler
     for (const hookName of plugin.rcFile.installs || []) {
       const existingHookId = config.hooks[hookName]
+      const entryPoint: EntryPoint = {
+        plugin,
+        modulePath: plugin.id
+      }
 
       if (existingHookId) {
         const conflicting = isConflict(existingHookId) ? existingHookId.conflicting : [existingHookId]
 
         config.hooks[hookName] = {
           plugin,
-          conflicting: conflicting.concat(plugin.id)
+          conflicting: conflicting.concat(entryPoint)
         }
       } else {
-        config.hooks[hookName] = plugin.id
+        config.hooks[hookName] = entryPoint
       }
     }
 


### PR DESCRIPTION
instead of just strings, which can easily be confused for strings from somewhere else.

in the very near future the entry point is not just going to be the plugin root; this refactor makes that easier.
