### PR TITLE
Confirm Serverless deployments have been successful before completing task

### DIFF
--- a/plugins/serverless/src/tasks/deploy.ts
+++ b/plugins/serverless/src/tasks/deploy.ts
@@ -1,5 +1,5 @@
 import { ToolKitError } from '@dotcom-tool-kit/error'
-import { hookFork, styles } from '@dotcom-tool-kit/logger'
+import { hookFork, styles, waitOnExit } from '@dotcom-tool-kit/logger'
 import { Task } from '@dotcom-tool-kit/types'
 import { ServerlessSchema } from '@dotcom-tool-kit/types/lib/schema/serverless'
 import { DopplerEnvVars } from '@dotcom-tool-kit/doppler'
@@ -27,7 +27,7 @@ export default class ServerlessDeploy extends Task<typeof ServerlessSchema> {
       dopplerEnv = await doppler.get()
     }
 
-    regions.forEach((region) => {
+    for (const region of regions) {
       this.logger.verbose('starting the child serverless process...')
       const args = ['deploy', '--region', region, '--stage', 'prod']
       if (configPath) {
@@ -42,6 +42,7 @@ export default class ServerlessDeploy extends Task<typeof ServerlessSchema> {
       })
 
       hookFork(this.logger, 'serverless', child)
-    })
+      await waitOnExit('serverless', child)
+    }
   }
 }

--- a/plugins/serverless/src/tasks/provision.ts
+++ b/plugins/serverless/src/tasks/provision.ts
@@ -1,5 +1,5 @@
 import { ToolKitError } from '@dotcom-tool-kit/error'
-import { hookFork, styles } from '@dotcom-tool-kit/logger'
+import { hookFork, styles, waitOnExit } from '@dotcom-tool-kit/logger'
 import { Task } from '@dotcom-tool-kit/types'
 import { ServerlessSchema } from '@dotcom-tool-kit/types/lib/schema/serverless'
 import { DopplerEnvVars } from '@dotcom-tool-kit/doppler'
@@ -49,5 +49,6 @@ export default class ServerlessProvision extends Task<typeof ServerlessSchema> {
     })
 
     hookFork(this.logger, 'serverless', child)
+    await waitOnExit('serverless', child)
   }
 }


### PR DESCRIPTION
# Description

Previously was not awaiting on the spawned serverless processes so didn't throw an error if the child returned a non-zero exit code. Would prevent CI jobs like [this](https://app.circleci.com/pipelines/github/Financial-Times/next-url-management-api/1848/workflows/cff76aa5-90df-4465-80c0-7836571b7a48/jobs/7549?invite=true#step-106-1123_456) from incorrectly passing.

# Checklist:

- [x] My branch has been rebased onto the latest commit on main (don't merge main into your branch)
- [x] My commit messages are [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/), for example: `feat(circleci): add support for nightly workflows`, `fix: set Heroku app name for staging apps too`
