### PR TITLE
reinstate hook options

### DIFF
--- a/core/cli/src/config.ts
+++ b/core/cli/src/config.ts
@@ -6,7 +6,7 @@ import type { Logger } from 'winston'
 import { z } from 'zod'
 
 import type { CommandTask } from './command'
-import { importEntryPoint, loadPlugin, resolvePlugin } from './plugin'
+import { importEntryPoint, loadPlugin, reducePluginHookInstallations, resolvePlugin } from './plugin'
 import {
   Conflict,
   findConflicts,
@@ -17,11 +17,14 @@ import {
 import { ToolKitConflictError, ToolKitError } from '@dotcom-tool-kit/error'
 import { readState, configPaths, writeState } from '@dotcom-tool-kit/state'
 import {
+  flatMapValidated,
   Hook,
+  HookClass,
   HookConstructor,
   mapValidated,
   Plugin,
   reduceValidated,
+  sequenceValidated,
   unwrapValidated,
   Validated
 } from '@dotcom-tool-kit/types'
@@ -46,12 +49,6 @@ export interface PluginOptions {
   forPlugin: Plugin
 }
 
-export interface HookInstallation {
-  options: Record<string, unknown>
-  plugin: Plugin
-  forHook: string
-}
-
 export interface EntryPoint {
   plugin: Plugin
   modulePath: string
@@ -65,7 +62,6 @@ export interface RawConfig {
   commandTasks: { [id: string]: CommandTask | Conflict<CommandTask> }
   options: { [id: string]: PluginOptions | Conflict<PluginOptions> | undefined }
   hooks: { [id: string]: EntryPoint | Conflict<EntryPoint> }
-  hookInstallations: HookInstallation[]
 }
 
 export type ValidPluginsConfig = Omit<RawConfig, 'plugins'> & {
@@ -89,24 +85,56 @@ export type ValidConfig = Omit<ValidPluginsConfig, 'tasks' | 'commandTasks' | 'o
 
 const coreRoot = path.resolve(__dirname, '../')
 
-export const loadHooks = async (
+const loadHookEntrypoints = async (
+  logger: Logger,
+  config: ValidConfig
+): Promise<Validated<Record<string, HookClass>>> => {
+  const hookResultEntries = reduceValidated(
+    await Promise.all(
+      Object.entries(config.hooks).map(async ([hookName, entryPoint]) => {
+        const hookResult = await importEntryPoint(Hook, entryPoint)
+        return mapValidated(hookResult, (hookClass) => [hookName, hookClass as HookClass] as const)
+      })
+    )
+  )
+
+  return mapValidated(hookResultEntries, (hookEntries) => Object.fromEntries(hookEntries))
+}
+
+export const loadHookInstallations = async (
   logger: Logger,
   config: ValidConfig
 ): Promise<Validated<Hook<z.ZodType, unknown>[]>> => {
-  const hookResults = await Promise.all(
-    config.hookInstallations.map(async ({ forHook, options }) => {
-      const entryPoint = config.hooks[forHook]
-      const hookResult = (await importEntryPoint(Hook, entryPoint)) as Validated<HookConstructor>
-
-      return mapValidated(hookResult, (Hook) => {
-        const schema = HookSchemas[forHook as keyof HookSchemaOptions]
-        const parsedOptions = schema ? schema.parse(options) : {}
-        return new Hook(logger, forHook, parsedOptions)
-      })
-    })
+  const hookClassResults = await loadHookEntrypoints(logger, config)
+  const installationResults = await sequenceValidated(
+    mapValidated(hookClassResults, (hookClasses) =>
+      reducePluginHookInstallations(logger, config, hookClasses, config.plugins['app root'])
+    )
   )
 
-  return reduceValidated(hookResults)
+  const installationsWithoutConflicts = flatMapValidated(installationResults, (installations) => {
+    const conflicts = findConflicts(installations)
+
+    if (conflicts.length) {
+      return {
+        valid: false,
+        reasons: []
+      }
+    }
+
+    return {
+      valid: true,
+      value: withoutConflicts(installations)
+    }
+  })
+
+  return mapValidated(installationsWithoutConflicts, (installations) => {
+    return installations.map(({ hookConstructor, forHook, options }) => {
+      const schema = HookSchemas[forHook as keyof HookSchemaOptions]
+      const parsedOptions = schema ? schema.parse(options) : {}
+      return new hookConstructor(logger, forHook, parsedOptions)
+    })
+  })
 }
 
 export async function fileHash(path: string): Promise<string> {
@@ -150,7 +178,7 @@ export async function checkInstall(logger: Logger, config: ValidConfig): Promise
     return
   }
 
-  const hooks = unwrapValidated(await loadHooks(logger, config), 'hooks are invalid')
+  const hooks = unwrapValidated(await loadHookInstallations(logger, config), 'hooks are invalid')
 
   const uninstalledHooks = await asyncFilter(hooks, async (hook) => {
     return !(await hook.check())
@@ -172,8 +200,7 @@ export const createConfig = (): RawConfig => ({
   tasks: {},
   commandTasks: {},
   options: {},
-  hooks: {},
-  hookInstallations: []
+  hooks: {}
 })
 
 async function asyncFilter<T>(items: T[], predicate: (item: T) => Promise<boolean>): Promise<T[]> {

--- a/core/cli/src/install.ts
+++ b/core/cli/src/install.ts
@@ -2,7 +2,7 @@ import { ToolKitError } from '@dotcom-tool-kit/error'
 import { OptionKey, setOptions } from '@dotcom-tool-kit/options'
 import groupBy from 'lodash/groupBy'
 import type { Logger } from 'winston'
-import { loadConfig, loadHooks, updateHashes, ValidConfig } from './config'
+import { loadConfig, loadHookInstallations, updateHashes, ValidConfig } from './config'
 import { unwrapValidated } from '@dotcom-tool-kit/types'
 
 // implementation of the Array.some method that supports asynchronous predicates
@@ -27,7 +27,7 @@ export default async function installHooks(logger: Logger): Promise<ValidConfig>
   const errors: Error[] = []
   // group hooks without an installGroup separately so that their check()
   // method runs independently
-  const hooks = unwrapValidated(await loadHooks(logger, config), 'hooks are invalid')
+  const hooks = unwrapValidated(await loadHookInstallations(logger, config), 'hooks are invalid')
 
   const groups = groupBy(hooks, (hook) => hook.installGroup ?? '__' + hook.id)
 

--- a/core/cli/src/messages.ts
+++ b/core/cli/src/messages.ts
@@ -2,7 +2,7 @@ import { styles as s, styles } from '@dotcom-tool-kit/logger'
 import type { Hook, Plugin } from '@dotcom-tool-kit/types'
 import type { z } from 'zod'
 import { fromZodError } from 'zod-validation-error'
-import type { EntryPoint, PluginOptions } from './config'
+import type { HookOptions, EntryPoint, PluginOptions } from './config'
 import type { Conflict } from '@dotcom-tool-kit/types/lib/conflict'
 import type { CommandTask } from './command'
 
@@ -64,6 +64,23 @@ ${conflicts.map(formatOptionConflict).join('\n')}
 
 You must resolve this conflict by providing options in your app's Tool Kit configuration for these plugins, or installing a use-case plugin that provides these options. See ${s.URL(
   'https://github.com/financial-times/dotcom-tool-kit/tree/main/readme.md#options'
+)} for more details.
+
+`
+
+const formatHookOptionConflict = (conflict: Conflict<HookOptions>): string => `${s.plugin(
+  conflict.conflicting[0].forHook
+)}, configured by:
+${conflict.conflicting.map((option) => `- ${s.plugin(option.plugin.id)}`)}`
+
+export const formatHookOptionConflicts = (conflicts: Conflict<HookOptions>[]): string => `${s.heading(
+  'These plugins have conflicting options for hooks'
+)}:
+
+${conflicts.map(formatHookOptionConflict).join('\n')}
+
+You must resolve this conflict by providing options in your app's Tool Kit configuration for these hooks, or installing a use-case plugin that provides these options. See ${s.URL(
+  'https://github.com/financial-times/dotcom-tool-kit/tree/main/readme.md#hook-options'
 )} for more details.
 
 `

--- a/core/cli/src/messages.ts
+++ b/core/cli/src/messages.ts
@@ -2,7 +2,7 @@ import { styles as s, styles } from '@dotcom-tool-kit/logger'
 import type { Hook, Plugin } from '@dotcom-tool-kit/types'
 import type { z } from 'zod'
 import { fromZodError } from 'zod-validation-error'
-import type { HookOptions, EntryPoint, PluginOptions } from './config'
+import type {  EntryPoint, PluginOptions } from './config'
 import type { Conflict } from '@dotcom-tool-kit/types/lib/conflict'
 import type { CommandTask } from './command'
 
@@ -64,23 +64,6 @@ ${conflicts.map(formatOptionConflict).join('\n')}
 
 You must resolve this conflict by providing options in your app's Tool Kit configuration for these plugins, or installing a use-case plugin that provides these options. See ${s.URL(
   'https://github.com/financial-times/dotcom-tool-kit/tree/main/readme.md#options'
-)} for more details.
-
-`
-
-const formatHookOptionConflict = (conflict: Conflict<HookOptions>): string => `${s.plugin(
-  conflict.conflicting[0].forHook
-)}, configured by:
-${conflict.conflicting.map((option) => `- ${s.plugin(option.plugin.id)}`)}`
-
-export const formatHookOptionConflicts = (conflicts: Conflict<HookOptions>[]): string => `${s.heading(
-  'These plugins have conflicting options for hooks'
-)}:
-
-${conflicts.map(formatHookOptionConflict).join('\n')}
-
-You must resolve this conflict by providing options in your app's Tool Kit configuration for these hooks, or installing a use-case plugin that provides these options. See ${s.URL(
-  'https://github.com/financial-times/dotcom-tool-kit/tree/main/readme.md#hook-options'
 )} for more details.
 
 `

--- a/core/cli/src/messages.ts
+++ b/core/cli/src/messages.ts
@@ -135,7 +135,7 @@ ${
 `
 
 export const formatUninstalledHooks = (
-  uninstalledHooks: Hook<unknown>[]
+  uninstalledHooks: Hook<z.ZodTypeAny, unknown>[]
 ): string => `These hooks aren't installed into your app:
 
 ${uninstalledHooks.map((hook) => `- ${s.hook(hook.id || 'unknown event')}`).join('\n')}

--- a/core/cli/src/plugin.ts
+++ b/core/cli/src/plugin.ts
@@ -281,6 +281,31 @@ export function resolvePlugin(plugin: Plugin, config: ValidPluginsConfig, logger
   config.resolvedPlugins.add(plugin)
 }
 
+// this function recursively collects all the hook installation requests from all plugins,
+// and merges them into a single, flat array of HookInstallation objects and/or Conflicts.
+//
+// it works depth-first (i.e. recurses into child plugins first), and considers how to
+// merge options or create conflicts in two stages: 1) when considering all installations
+// from child plugins, and 2) when considering how a parent plugin would override its
+// children. these steps are separate as a particular parent might not provide an override
+// for all its children, and different hooks could expect different ways of resolving
+// conflicts.
+//
+// the actual logic for this is delegated to static methods on Hook classes,
+// `Hook.mergeChildInstallations` and `Hook.overrideChildInstallations`, so separate hooks
+// can provide different logic for these steps.
+//
+// the default logic in the base Hook class is to always consider multiple installations
+// from child plugins as a conflict, and always consider a installation in a parent as
+// completely replacing any installations from children.
+//
+// for example, for a plugin `p` that depends on children `a`, `b`, and `c` that all provide
+// configuration for the `PackageJson` hook, this function will:
+//   - do all this logic for `a`, `b`, and `c`
+//   - call `Hook.mergeChildInstallations` with the appropriate concrete Hook class, and
+//     the resulting installations and/or conflicts from `a`, `b`, and `c`
+//   - call `Hook.overrideChildInstallations` with the appropriate concrete Hook class, and
+//     the resulting installations and/or conflicts from `Hook.mergeChildInstallations` and `p`
 export async function reducePluginHookInstallations(
   logger: Logger,
   config: ValidConfig,

--- a/core/cli/src/plugin.ts
+++ b/core/cli/src/plugin.ts
@@ -9,7 +9,7 @@ import {
 } from '@dotcom-tool-kit/types'
 import resolvePkg from 'resolve-pkg'
 import type { Logger } from 'winston'
-import { EntryPoint, PluginOptions, RawConfig, ValidPluginsConfig } from './config'
+import { HookOptions, EntryPoint, PluginOptions, RawConfig, ValidPluginsConfig } from './config'
 import { Conflict, isConflict } from '@dotcom-tool-kit/types/lib/conflict'
 import type { CommandTask } from './command'
 import { loadToolKitRC } from './rc-file'
@@ -271,6 +271,45 @@ export function resolvePlugin(plugin: Plugin, config: ValidPluginsConfig, logger
       } else {
         // this options key might not have been set yet, in which case use the new one
         config.options[pluginId] = pluginOptions
+      }
+    }
+
+    // load plugin hook options. do this after loading child plugins, so
+    // parent options get assigned after child options and can override them
+    for (const [id, configHookOptions] of Object.entries(plugin.rcFile.hooks)) {
+      // users can specify root options with the dotcom-tool-kit key to mirror
+      // the name of the root npm package
+      const existingOptions = config.hookOptions[id]
+
+      const hookOptions: HookOptions = {
+        options: configHookOptions,
+        plugin,
+        forHook: id
+      }
+
+      if (existingOptions) {
+        const existingFromDescendent = isDescendent(plugin, existingOptions.plugin)
+
+        // plugins can only override options from their descendents, otherwise it's a conflict
+        // return a conflict either listing these options and the sibling's,
+        // or merging in previously-generated options
+        if (!existingFromDescendent) {
+          const conflicting = isConflict(existingOptions) ? existingOptions.conflicting : [existingOptions]
+
+          const conflict: Conflict<HookOptions> = {
+            plugin,
+            conflicting: conflicting.concat(hookOptions)
+          }
+
+          config.hookOptions[id] = conflict
+        } else {
+          // if we're here, any existing options are from a child plugin,
+          // so merge in overrides from the parent
+          config.hookOptions[id] = { ...existingOptions, ...hookOptions }
+        }
+      } else {
+        // this options key might not have been set yet, in which case use the new one
+        config.hookOptions[id] = hookOptions
       }
     }
   }

--- a/core/cli/src/rc-file.ts
+++ b/core/cli/src/rc-file.ts
@@ -5,7 +5,7 @@ import * as path from 'path'
 import type { Logger } from 'winston'
 
 export const explorer = cosmiconfig('toolkit', { ignoreEmptySearchPlaces: false })
-const emptyConfig = { plugins: [], installs: {}, tasks: {}, commands: {}, options: {}, hooks: {} }
+const emptyConfig = { plugins: [], installs: {}, tasks: {}, commands: {}, options: {}, hooks: [] }
 let rootConfig: string | undefined
 
 type RawRCFile = {
@@ -39,6 +39,6 @@ export async function loadToolKitRC(logger: Logger, root: string, isAppRoot: boo
     tasks: config.tasks ?? {},
     commands: config.commands ?? {},
     options: config.options ?? {},
-    hooks: config.hooks ?? {}
+    hooks: config.hooks ?? []
   }
 }

--- a/core/cli/src/rc-file.ts
+++ b/core/cli/src/rc-file.ts
@@ -5,7 +5,7 @@ import * as path from 'path'
 import type { Logger } from 'winston'
 
 export const explorer = cosmiconfig('toolkit', { ignoreEmptySearchPlaces: false })
-const emptyConfig = { plugins: [], installs: {}, tasks: {}, commands: {}, options: {} }
+const emptyConfig = { plugins: [], installs: {}, tasks: {}, commands: {}, options: {}, hooks: {} }
 let rootConfig: string | undefined
 
 type RawRCFile = {
@@ -38,6 +38,7 @@ export async function loadToolKitRC(logger: Logger, root: string, isAppRoot: boo
     installs: config.installs ?? {},
     tasks: config.tasks ?? {},
     commands: config.commands ?? {},
-    options: config.options ?? {}
+    options: config.options ?? {},
+    hooks: config.hooks ?? {}
   }
 }

--- a/core/create/src/index.ts
+++ b/core/create/src/index.ts
@@ -100,7 +100,7 @@ async function main() {
     tasks: {},
     commands: {},
     options: {},
-    hooks: {}
+    hooks: []
   }
 
   const originalCircleConfig = await fs.readFile(circleConfigPath, 'utf8').catch(() => undefined)

--- a/core/create/src/index.ts
+++ b/core/create/src/index.ts
@@ -99,7 +99,8 @@ async function main() {
     installs: {},
     tasks: {},
     commands: {},
-    options: {}
+    options: {},
+    hooks: {}
   }
 
   const originalCircleConfig = await fs.readFile(circleConfigPath, 'utf8').catch(() => undefined)

--- a/lib/types/src/hook.ts
+++ b/lib/types/src/hook.ts
@@ -2,12 +2,19 @@ import type { Logger } from 'winston'
 import { Base } from './base'
 import { hookSymbol, typeSymbol } from './symbols'
 import { z } from 'zod'
+import { Plugin } from './index'
+import { Conflict, isConflict } from './conflict'
+
+export interface HookInstallation {
+  options: Record<string, unknown>
+  plugin: Plugin
+  forHook: string
+  hookConstructor: HookConstructor
+}
 
 export abstract class Hook<Options extends z.ZodTypeAny = z.ZodTypeAny, State = void> extends Base {
   logger: Logger
   static description?: string
-  id: string
-  options: z.output<Options>
   // This field is used to collect hooks that share state when running their
   // install methods. All hooks in the same group will run their install method
   // one after the other, and then their commitInstall method will be run with
@@ -22,12 +29,31 @@ export abstract class Hook<Options extends z.ZodTypeAny = z.ZodTypeAny, State = 
     return hookSymbol
   }
 
-  constructor(logger: Logger, id: string, options: z.output<Options>) {
-    super()
+  static mergeChildInstallations(
+    plugin: Plugin,
+    childInstallations: (HookInstallation | Conflict<HookInstallation>)[]
+  ): (HookInstallation | Conflict<HookInstallation>)[] {
+    return [
+      {
+        plugin,
+        conflicting: childInstallations.flatMap((installation) =>
+          isConflict(installation) ? installation.conflicting : installation
+        )
+      }
+    ]
+  }
 
-    this.id = id
+  static overrideChildInstallations(
+    plugin: Plugin,
+    parentInstallation: HookInstallation,
+    _childInstallations: (HookInstallation | Conflict<HookInstallation>)[]
+  ): (HookInstallation | Conflict<HookInstallation>)[] {
+    return [parentInstallation]
+  }
+
+  constructor(logger: Logger, public id: string, public options: z.output<Options>) {
+    super()
     this.logger = logger.child({ hook: this.constructor.name })
-    this.options = options
   }
 
   abstract check(): Promise<boolean>

--- a/lib/types/src/hook.ts
+++ b/lib/types/src/hook.ts
@@ -1,11 +1,13 @@
 import type { Logger } from 'winston'
 import { Base } from './base'
 import { hookSymbol, typeSymbol } from './symbols'
+import { z } from 'zod'
 
-export abstract class Hook<State = void> extends Base {
+export abstract class Hook<Options extends z.ZodTypeAny = z.ZodTypeAny, State = void> extends Base {
   logger: Logger
   static description?: string
   id: string
+  options: z.output<Options>
   // This field is used to collect hooks that share state when running their
   // install methods. All hooks in the same group will run their install method
   // one after the other, and then their commitInstall method will be run with
@@ -20,11 +22,12 @@ export abstract class Hook<State = void> extends Base {
     return hookSymbol
   }
 
-  constructor(logger: Logger, id: string) {
+  constructor(logger: Logger, id: string, options: z.output<Options>) {
     super()
 
     this.id = id
     this.logger = logger.child({ hook: this.constructor.name })
+    this.options = options
   }
 
   abstract check(): Promise<boolean>
@@ -34,6 +37,6 @@ export abstract class Hook<State = void> extends Base {
   }
 }
 
-export type HookConstructor = { new (logger: Logger, id: string): Hook<void> }
+export type HookConstructor = { new (logger: Logger, id: string, options: z.output<z.ZodTypeAny>): Hook }
 
 export type HookClass = HookConstructor & typeof Hook

--- a/lib/types/src/hooks.ts
+++ b/lib/types/src/hooks.ts
@@ -1,7 +1,9 @@
 import { z } from 'zod'
 
+import { PackageJsonSchema } from './schema/hooks/package-json'
+
 export const HookSchemas = {
-  'dummy schema to get types working for now': z.never()
+  PackageJson: PackageJsonSchema
 }
 
 // Gives the TypeScript type represented by each Schema

--- a/lib/types/src/hooks.ts
+++ b/lib/types/src/hooks.ts
@@ -1,0 +1,12 @@
+import { z } from 'zod'
+
+export const HookSchemas = {
+  'dummy schema to get types working for now': z.never()
+}
+
+// Gives the TypeScript type represented by each Schema
+export type Options = {
+  [plugin in keyof typeof HookSchemas]: typeof HookSchemas[plugin] extends z.ZodTypeAny
+    ? z.infer<typeof HookSchemas[plugin]>
+    : never
+}

--- a/lib/types/src/index.ts
+++ b/lib/types/src/index.ts
@@ -9,6 +9,7 @@ export type RCFile = {
   tasks: { [id: string]: string }
   commands: { [id: string]: string | string[] }
   options: { [id: string]: Record<string, unknown> }
+  hooks: { [id: string]: Record<string, unknown> }
 }
 
 export interface Plugin {

--- a/lib/types/src/index.ts
+++ b/lib/types/src/index.ts
@@ -9,7 +9,7 @@ export type RCFile = {
   tasks: { [id: string]: string }
   commands: { [id: string]: string | string[] }
   options: { [id: string]: Record<string, unknown> }
-  hooks: { [id: string]: Record<string, unknown> }
+  hooks: { [id: string]: Record<string, unknown> }[]
 }
 
 export interface Plugin {

--- a/lib/types/src/schema/hooks/package-json.ts
+++ b/lib/types/src/schema/hooks/package-json.ts
@@ -1,0 +1,7 @@
+import { z } from 'zod'
+
+export const PackageJsonSchema = z.record(z.record(z.union([z.array(z.string()), z.string()])))
+
+export type PackageJsonOptions = z.infer<typeof PackageJsonSchema>
+
+export const Schema = PackageJsonSchema

--- a/lib/types/src/schema/hooks/package-json.ts
+++ b/lib/types/src/schema/hooks/package-json.ts
@@ -1,6 +1,17 @@
 import { z } from 'zod'
 
-export const PackageJsonSchema = z.record(z.record(z.union([z.array(z.string()), z.string()])))
+const CommandListSchema = z.union([z.array(z.string()), z.string()])
+export const PackageJsonSchema = z.record(
+  z.record(
+    z.union([
+      CommandListSchema,
+      z.object({
+        commands: CommandListSchema,
+        trailingString: z.string()
+      })
+    ])
+  )
+)
 
 export type PackageJsonOptions = z.infer<typeof PackageJsonSchema>
 

--- a/lib/types/src/validated.ts
+++ b/lib/types/src/validated.ts
@@ -78,3 +78,11 @@ export function unwrapValidated<T>(validated: Validated<T>, message = ''): T {
     throw error
   }
 }
+
+export async function sequenceValidated<T>(validated: Validated<Promise<T>>): Promise<Validated<T>> {
+  if (validated.valid) {
+    return { value: await validated.value, valid: true }
+  } else {
+    return validated
+  }
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1059,12 +1059,32 @@
       }
     },
     "core/sandbox": {
-      "version": "1.0.0",
+      "name": "@dotcom-tool-kit/sandbox",
+      "version": "2.0.0",
       "extraneous": true,
       "license": "ISC",
-      "dependencies": {
-        "@dotcom-tool-kit/node": "^3.3.6",
-        "dotcom-tool-kit": "^3.3.7"
+      "devDependencies": {
+        "@dotcom-tool-kit/circleci-heroku": "^2.0.0",
+        "@dotcom-tool-kit/circleci-npm": "^4.0.0",
+        "@dotcom-tool-kit/eslint": "^2.0.0",
+        "@dotcom-tool-kit/frontend-app": "^2.0.0",
+        "@dotcom-tool-kit/jest": "^2.0.0",
+        "@dotcom-tool-kit/lint-staged": "^3.0.0",
+        "@dotcom-tool-kit/lint-staged-npm": "^2.0.0",
+        "@dotcom-tool-kit/mocha": "^2.0.0",
+        "@dotcom-tool-kit/n-test": "^2.0.0",
+        "@dotcom-tool-kit/next-router": "^2.0.0",
+        "@dotcom-tool-kit/nodemon": "^2.0.0",
+        "@dotcom-tool-kit/npm": "^2.0.0",
+        "@dotcom-tool-kit/pa11y": "^0.3.0",
+        "@dotcom-tool-kit/prettier": "^2.0.0",
+        "@dotcom-tool-kit/upload-assets-to-s3": "^2.0.0",
+        "dotcom-tool-kit": "^2.0.0",
+        "nodemon": "^2.0.15"
+      },
+      "engines": {
+        "node": "16.x || 18.x",
+        "npm": "7.x || 8.x || 9.x"
       }
     },
     "lib/doppler": {
@@ -30071,6 +30091,7 @@
       "version": "4.1.0",
       "license": "ISC",
       "dependencies": {
+        "@dotcom-tool-kit/types": "^3.4.0",
         "@financial-times/package-json": "^3.0.0",
         "lodash": "^4.17.21",
         "tslib": "^2.3.1"
@@ -36064,6 +36085,7 @@
     "@dotcom-tool-kit/package-json-hook": {
       "version": "file:plugins/package-json-hook",
       "requires": {
+        "@dotcom-tool-kit/types": "^3.4.0",
         "@financial-times/package-json": "^3.0.0",
         "@jest/globals": "^27.4.6",
         "@types/lodash": "^4.14.185",

--- a/plugins/circleci/.toolkitrc.yml
+++ b/plugins/circleci/.toolkitrc.yml
@@ -1,0 +1,2 @@
+installs:
+  CircleCiConfig: './lib/circleci-config'

--- a/plugins/circleci/src/circleci-config.ts
+++ b/plugins/circleci/src/circleci-config.ts
@@ -241,7 +241,7 @@ const hasJob = (expectedJob: string, jobs: NonNullable<Workflow['jobs']>): boole
       (typeof job === 'object' && job.hasOwnProperty(expectedJob))
   )
 
-export default abstract class CircleCiConfigHook extends Hook<z.ZodTypeAny, CircleCIState> {
+export default abstract class CircleCiConfig extends Hook<z.ZodTypeAny, CircleCIState> {
   installGroup = 'circleci'
 
   circleConfigPath = path.resolve(process.cwd(), '.circleci/config.yml')

--- a/plugins/circleci/src/circleci-config.ts
+++ b/plugins/circleci/src/circleci-config.ts
@@ -13,6 +13,7 @@ import mergeWith from 'lodash/mergeWith'
 import path from 'path'
 import type { PartialDeep } from 'type-fest'
 import YAML from 'yaml'
+import { z } from 'zod'
 
 const MAJOR_ORB_VERSION = '4'
 
@@ -240,7 +241,7 @@ const hasJob = (expectedJob: string, jobs: NonNullable<Workflow['jobs']>): boole
       (typeof job === 'object' && job.hasOwnProperty(expectedJob))
   )
 
-export default abstract class CircleCiConfigHook extends Hook<CircleCIState> {
+export default abstract class CircleCiConfigHook extends Hook<z.ZodTypeAny, CircleCIState> {
   installGroup = 'circleci'
 
   circleConfigPath = path.resolve(process.cwd(), '.circleci/config.yml')

--- a/plugins/package-json-hook/package.json
+++ b/plugins/package-json-hook/package.json
@@ -10,6 +10,7 @@
   "author": "FT.com Platforms Team <platforms-team.customer-products@ft.com>",
   "license": "ISC",
   "dependencies": {
+    "@dotcom-tool-kit/types": "^3.4.0",
     "@financial-times/package-json": "^3.0.0",
     "lodash": "^4.17.21",
     "tslib": "^2.3.1"

--- a/plugins/package-json-hook/src/package-json-helper.ts
+++ b/plugins/package-json-hook/src/package-json-helper.ts
@@ -2,32 +2,33 @@ import { z } from 'zod'
 import { Hook } from '@dotcom-tool-kit/types'
 import fs from 'fs'
 import get from 'lodash/get'
-import mapValues from 'lodash/mapValues'
-import merge from 'lodash/merge'
+import set from 'lodash/set'
 import update from 'lodash/update'
 import path from 'path'
+
+import { PackageJsonSchema } from '@dotcom-tool-kit/types/lib/schema/hooks/package-json'
 
 interface PackageJsonContents {
   [field: string]: PackageJsonContents | string
 }
 
 interface PackageJsonStateValue {
-  hooks: string[]
-  trailingString: string
+  commands: string[]
+  trailingString?: string
+  installedBy: PackageJson
 }
 
 interface PackageJsonState {
-  [field: string]: PackageJsonState | PackageJsonStateValue
+  [path: string]: PackageJsonStateValue
 }
 
-export default abstract class PackageJson extends Hook<z.ZodTypeAny, PackageJsonState> {
+export default abstract class PackageJson extends Hook<typeof PackageJsonSchema, PackageJsonState> {
   private _packageJson?: PackageJsonContents
-  abstract field: string | string[]
-  abstract key: string
-  abstract hook: string
+
   // Allow some extra characters to be appended to the end of a hooked field.
   // This is useful if you, for example, need to append the '--' argument
   // delimiter to commands to allow files to be passed as additional arguments.
+  // TODO how to handle this with hook options
   trailingString?: string
 
   installGroup = 'package-json'
@@ -45,36 +46,45 @@ export default abstract class PackageJson extends Hook<z.ZodTypeAny, PackageJson
     return this._packageJson
   }
 
-  private get hookPath(): string[] {
-    return Array.isArray(this.field) ? [...this.field, this.key] : [this.field, this.key]
-  }
-
   async check(): Promise<boolean> {
     const packageJson = await this.getPackageJson()
-    return get(packageJson, this.hookPath)?.includes(this.hook)
+    return Object.entries(this.options).every(([field, object]) =>
+      Object.entries(object).every(([key, command]) => get(packageJson, [field, key])?.includes(command))
+    )
   }
 
-  async install(state?: PackageJsonState): Promise<PackageJsonState> {
-    state ??= {}
-    // prepend each hook to maintain the same order as previous implementations
-    update(state, this.hookPath, (hookState?: PackageJsonStateValue) => ({
-      hooks: [this.hook, ...(hookState?.hooks ?? [])],
-      trailingString: this.trailingString
-    }))
+  async install(state: PackageJsonState = {}): Promise<PackageJsonState> {
+    for (const [field, object] of Object.entries(this.options)) {
+      for (const [key, command] of Object.entries(object)) {
+        // prepend each hook to maintain the same order as previous implementations
+        update(
+          state,
+          [field + '.' + key],
+          (hookState?: PackageJsonStateValue): PackageJsonStateValue => ({
+            commands: [...(Array.isArray(command) ? command : [command]), ...(hookState?.commands ?? [])],
+            installedBy: this,
+            trailingString: this.trailingString
+          })
+        )
+      }
+    }
+
     return state
   }
 
   async commitInstall(state: PackageJsonState): Promise<void> {
-    const reduceHooks = (state: PackageJsonState): PackageJsonContents =>
-      mapValues(state, (field) =>
-        Array.isArray(field?.hooks)
-          ? `dotcom-tool-kit ${field.hooks.join(' ')}${
-              field.trailingString ? ' ' + field.trailingString : ''
-            }`
-          : reduceHooks(field as PackageJsonState)
-      )
+    const packageJson = await this.getPackageJson()
 
-    const newPackageJson = merge(await this.getPackageJson(), reduceHooks(state))
-    await fs.promises.writeFile(this.filepath, JSON.stringify(newPackageJson, null, 2) + '\n')
+    for (const [path, installation] of Object.entries(state)) {
+      set(
+        packageJson,
+        path,
+        `dotcom-tool-kit ${installation.commands.join(' ')}${
+          installation.trailingString ? ' ' + installation.trailingString : ''
+        }`
+      )
+    }
+
+    await fs.promises.writeFile(this.filepath, JSON.stringify(packageJson, null, 2) + '\n')
   }
 }

--- a/plugins/package-json-hook/src/package-json-helper.ts
+++ b/plugins/package-json-hook/src/package-json-helper.ts
@@ -1,3 +1,4 @@
+import { z } from 'zod'
 import { Hook } from '@dotcom-tool-kit/types'
 import fs from 'fs'
 import get from 'lodash/get'
@@ -19,7 +20,7 @@ interface PackageJsonState {
   [field: string]: PackageJsonState | PackageJsonStateValue
 }
 
-export default abstract class PackageJson extends Hook<PackageJsonState> {
+export default abstract class PackageJson extends Hook<z.ZodTypeAny, PackageJsonState> {
   private _packageJson?: PackageJsonContents
   abstract field: string | string[]
   abstract key: string


### PR DESCRIPTION
- plugins specify which hooks they want to instatiate with particular options
- these installations are merged into a list of (potentially-conflicting) installations, based on conflict resolution handlers the hook classes provide (with some basic fallback logic)
- the installations are lazily reduced and loaded when checking hook installations and installing them
- implement a sensible options structure for the `PackageJson` hook

### still to do in this PR:
- [x] at least get the current tests passing

### still to come in future PRs:

- [ ] write tests for the new behaviour 😬 
- [ ] specific conflict resolution logic for `PackageJson` and `CircleCIConfig`
- [ ] implement options for `CircleCIConfig` 😬 
- [ ] recreate existing hooks using new options in the relevant plugins
- [ ] tracking which commands are referenced by hook installations, and checking that tasks are assigned to commands that exist
- [ ] tracking which files hook classes manage and using those to extend the list of files to hash
- [x] refactoring `Validated` and `Conflict` to make code using them more readable/less nested
- [ ] documentation
- [ ] oh jeez oh fuck that's so much work