### PR TITLE
Fix Doppler never falling back to Vault

### DIFF
--- a/lib/doppler/src/index.ts
+++ b/lib/doppler/src/index.ts
@@ -90,14 +90,12 @@ export class DopplerEnvVars {
       }
     } catch (err) {
       if (!errorMsg) {
-        this.logger.warn(`caught error '${err}' when calling Doppler, falling back to Vault`)
+        this.logger.warn(`caught error '${err}' when calling Doppler`)
       }
     }
     if (errorMsg) {
       this.logger.warn(
-        `doppler CLI failed with the following error logs, falling back to Vault:\n${styles.warningHighlight(
-          errorMsg
-        )}`
+        `doppler CLI failed with the following error logs:\n${styles.warningHighlight(errorMsg)}`
       )
     }
     return undefined
@@ -130,6 +128,7 @@ export class DopplerEnvVars {
       //     'DEPRECATED'
       //   )} Vault secrets manager. please consider migrating to/fixing issues with Doppler.`
       // )
+      this.logger.warn('falling back to Vault')
       hasLoggedMigrationWarning = true
     }
 

--- a/lib/doppler/src/index.ts
+++ b/lib/doppler/src/index.ts
@@ -117,7 +117,7 @@ export class DopplerEnvVars {
     }
     // don't fallback to Vault if the project has doppler options set up
     // explicitly already
-    const migratedToolKitToDoppler = Boolean(getOptions('@dotcom-tool-kit/doppler'))
+    const migratedToolKitToDoppler = Boolean(getOptions('@dotcom-tool-kit/doppler')?.project)
     if (migratedToolKitToDoppler) {
       throw new ToolKitError('failed to get secrets from Doppler')
     }


### PR DESCRIPTION
# Description

We [avoid](https://github.com/Financial-Times/dotcom-tool-kit/pull/497) falling back to Vault if Doppler options have been explicitly configured. However, Zod will always create an empty Doppler options object even if no options are specified (as the options are all optional in this case), meaning that we were never falling back to Vault. 

# Checklist:

- [x] My branch has been rebased onto the latest commit on main (don't merge main into your branch)
- [x] My commit messages are [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/), for example: `feat(circleci): add support for nightly workflows`, `fix: set Heroku app name for staging apps too`
