### PR TITLE
Bump default CircleCI node image used to be Node 18

### DIFF
--- a/lib/types/src/schema/plugins/circleci.ts
+++ b/lib/types/src/schema/plugins/circleci.ts
@@ -1,7 +1,7 @@
 import { z } from 'zod'
 
 export const CircleCISchema = z.object({
-  nodeVersion: z.string().or(z.string().array()).default('16.14-browsers'),
+  nodeVersion: z.string().or(z.string().array()).default('18.18-browsers'),
   cypressImage: z.string().optional()
 })
 export type CircleCIOptions = z.infer<typeof CircleCISchema>


### PR DESCRIPTION
# Description

Don't love that this is a breaking change for the types package rather than for circleci but types is going to be getting a major version bump from other changes in the next branch anyway.

# Checklist:

- [x] My branch has been rebased onto the latest commit on main (don't merge main into your branch)
- [x] My commit messages are [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/), for example: `feat(circleci): add support for nightly workflows`, `fix: set Heroku app name for staging apps too`
