### PR TITLE
Add Doppler support to cypress plugin

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -29111,7 +29111,10 @@
       "version": "3.2.3",
       "license": "ISC",
       "dependencies": {
-        "@dotcom-tool-kit/doppler": "^1.0.7"
+        "@dotcom-tool-kit/doppler": "^1.0.7",
+        "@dotcom-tool-kit/logger": "^3.3.0",
+        "@dotcom-tool-kit/state": "^3.1.1",
+        "@dotcom-tool-kit/types": "^3.4.1"
       },
       "engines": {
         "node": "16.x || 18.x",
@@ -35296,7 +35299,10 @@
     "@dotcom-tool-kit/cypress": {
       "version": "file:plugins/cypress",
       "requires": {
-        "@dotcom-tool-kit/doppler": "^1.0.7"
+        "@dotcom-tool-kit/doppler": "^1.0.7",
+        "@dotcom-tool-kit/logger": "^3.3.0",
+        "@dotcom-tool-kit/state": "^3.1.1",
+        "@dotcom-tool-kit/types": "^3.4.1"
       }
     },
     "@dotcom-tool-kit/doppler": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -47,7 +47,7 @@
     },
     "core/cli": {
       "name": "dotcom-tool-kit",
-      "version": "3.3.6",
+      "version": "3.3.8",
       "license": "MIT",
       "dependencies": {
         "@dotcom-tool-kit/error": "^3.1.0",
@@ -68,15 +68,15 @@
       },
       "devDependencies": {
         "@dotcom-tool-kit/babel": "^3.1.5",
-        "@dotcom-tool-kit/backend-heroku-app": "^3.0.7",
+        "@dotcom-tool-kit/backend-heroku-app": "^3.0.9",
         "@dotcom-tool-kit/circleci": "^5.3.8",
         "@dotcom-tool-kit/circleci-deploy": "^3.2.8",
         "@dotcom-tool-kit/eslint": "^3.1.5",
-        "@dotcom-tool-kit/frontend-app": "^3.1.20",
-        "@dotcom-tool-kit/heroku": "^3.3.10",
+        "@dotcom-tool-kit/frontend-app": "^3.1.22",
+        "@dotcom-tool-kit/heroku": "^3.3.12",
         "@dotcom-tool-kit/mocha": "^3.1.5",
         "@dotcom-tool-kit/n-test": "^3.2.7",
-        "@dotcom-tool-kit/npm": "^3.2.1",
+        "@dotcom-tool-kit/npm": "^3.2.2",
         "@dotcom-tool-kit/webpack": "^3.1.6",
         "@jest/globals": "^27.4.6",
         "@types/lodash": "^4.14.185",
@@ -122,12 +122,12 @@
     },
     "core/create": {
       "name": "@dotcom-tool-kit/create",
-      "version": "3.2.11",
+      "version": "3.2.13",
       "license": "ISC",
       "dependencies": {
         "@aws-sdk/client-iam": "^3.282.0",
         "@aws-sdk/client-sts": "^3.282.0",
-        "@dotcom-tool-kit/doppler": "^1.0.6",
+        "@dotcom-tool-kit/doppler": "^1.0.7",
         "@dotcom-tool-kit/error": "^3.1.0",
         "@dotcom-tool-kit/logger": "^3.3.0",
         "@dotcom-tool-kit/types": "^3.4.1",
@@ -158,7 +158,7 @@
         "@types/pacote": "^11.1.3",
         "@types/prompts": "^2.0.14",
         "cosmiconfig": "^7.0.1",
-        "dotcom-tool-kit": "^3.3.6"
+        "dotcom-tool-kit": "^3.3.8"
       },
       "engines": {
         "node": "16.x || 18.x",
@@ -1089,7 +1089,7 @@
     },
     "lib/doppler": {
       "name": "@dotcom-tool-kit/doppler",
-      "version": "1.0.6",
+      "version": "1.0.7",
       "license": "ISC",
       "dependencies": {
         "@dotcom-tool-kit/error": "^3.1.0",
@@ -28843,10 +28843,10 @@
     },
     "plugins/backend-app": {
       "name": "@dotcom-tool-kit/backend-app",
-      "version": "3.1.19",
+      "version": "3.1.21",
       "license": "ISC",
       "dependencies": {
-        "@dotcom-tool-kit/backend-heroku-app": "^3.0.7"
+        "@dotcom-tool-kit/backend-heroku-app": "^3.0.9"
       },
       "engines": {
         "node": "16.x || 18.x",
@@ -28858,13 +28858,13 @@
     },
     "plugins/backend-heroku-app": {
       "name": "@dotcom-tool-kit/backend-heroku-app",
-      "version": "3.0.7",
+      "version": "3.0.9",
       "license": "ISC",
       "dependencies": {
         "@dotcom-tool-kit/circleci-deploy": "^3.2.8",
-        "@dotcom-tool-kit/heroku": "^3.3.10",
-        "@dotcom-tool-kit/node": "^3.3.6",
-        "@dotcom-tool-kit/npm": "^3.2.1"
+        "@dotcom-tool-kit/heroku": "^3.3.12",
+        "@dotcom-tool-kit/node": "^3.3.7",
+        "@dotcom-tool-kit/npm": "^3.2.2"
       },
       "engines": {
         "node": "16.x || 18.x",
@@ -28876,13 +28876,13 @@
     },
     "plugins/backend-serverless-app": {
       "name": "@dotcom-tool-kit/backend-serverless-app",
-      "version": "3.0.6",
+      "version": "3.0.9",
       "license": "ISC",
       "dependencies": {
         "@dotcom-tool-kit/circleci-deploy": "^3.2.8",
-        "@dotcom-tool-kit/node": "^3.3.6",
-        "@dotcom-tool-kit/npm": "^3.2.1",
-        "@dotcom-tool-kit/serverless": "^2.2.7"
+        "@dotcom-tool-kit/node": "^3.3.7",
+        "@dotcom-tool-kit/npm": "^3.2.2",
+        "@dotcom-tool-kit/serverless": "^2.2.9"
       },
       "engines": {
         "node": "16.x || 18.x",
@@ -28948,11 +28948,11 @@
     },
     "plugins/circleci-heroku": {
       "name": "@dotcom-tool-kit/circleci-heroku",
-      "version": "3.1.19",
+      "version": "3.1.21",
       "license": "ISC",
       "dependencies": {
         "@dotcom-tool-kit/circleci-deploy": "^3.2.8",
-        "@dotcom-tool-kit/heroku": "^3.3.10",
+        "@dotcom-tool-kit/heroku": "^3.3.12",
         "tslib": "^2.3.1"
       },
       "engines": {
@@ -28970,11 +28970,11 @@
     },
     "plugins/circleci-npm": {
       "name": "@dotcom-tool-kit/circleci-npm",
-      "version": "5.2.10",
+      "version": "5.2.11",
       "license": "ISC",
       "dependencies": {
         "@dotcom-tool-kit/circleci": "^5.3.8",
-        "@dotcom-tool-kit/npm": "^3.2.1",
+        "@dotcom-tool-kit/npm": "^3.2.2",
         "@dotcom-tool-kit/types": "^3.4.1",
         "tslib": "^2.3.1"
       },
@@ -29092,11 +29092,11 @@
     },
     "plugins/component": {
       "name": "@dotcom-tool-kit/component",
-      "version": "4.0.3",
+      "version": "4.0.4",
       "license": "ISC",
       "dependencies": {
-        "@dotcom-tool-kit/circleci-npm": "^5.2.10",
-        "@dotcom-tool-kit/npm": "^3.2.1"
+        "@dotcom-tool-kit/circleci-npm": "^5.2.11",
+        "@dotcom-tool-kit/npm": "^3.2.2"
       },
       "engines": {
         "node": "16.x || 18.x",
@@ -29111,7 +29111,7 @@
       "version": "3.2.3",
       "license": "ISC",
       "dependencies": {
-        "@dotcom-tool-kit/vault": "^3.1.6"
+        "@dotcom-tool-kit/doppler": "^1.0.7"
       },
       "engines": {
         "node": "16.x || 18.x",
@@ -29345,10 +29345,10 @@
     },
     "plugins/frontend-app": {
       "name": "@dotcom-tool-kit/frontend-app",
-      "version": "3.1.20",
+      "version": "3.1.22",
       "license": "ISC",
       "dependencies": {
-        "@dotcom-tool-kit/backend-heroku-app": "^3.0.7",
+        "@dotcom-tool-kit/backend-heroku-app": "^3.0.9",
         "@dotcom-tool-kit/upload-assets-to-s3": "^3.1.6",
         "@dotcom-tool-kit/webpack": "^3.1.6"
       },
@@ -29362,13 +29362,13 @@
     },
     "plugins/heroku": {
       "name": "@dotcom-tool-kit/heroku",
-      "version": "3.3.10",
+      "version": "3.3.12",
       "license": "ISC",
       "dependencies": {
-        "@dotcom-tool-kit/doppler": "^1.0.6",
+        "@dotcom-tool-kit/doppler": "^1.0.7",
         "@dotcom-tool-kit/error": "^3.1.0",
         "@dotcom-tool-kit/logger": "^3.3.0",
-        "@dotcom-tool-kit/npm": "^3.2.1",
+        "@dotcom-tool-kit/npm": "^3.2.2",
         "@dotcom-tool-kit/options": "^3.1.5",
         "@dotcom-tool-kit/package-json-hook": "^4.1.0",
         "@dotcom-tool-kit/state": "^3.1.1",
@@ -29699,10 +29699,10 @@
     },
     "plugins/next-router": {
       "name": "@dotcom-tool-kit/next-router",
-      "version": "3.3.6",
+      "version": "3.3.7",
       "license": "ISC",
       "dependencies": {
-        "@dotcom-tool-kit/doppler": "^1.0.6",
+        "@dotcom-tool-kit/doppler": "^1.0.7",
         "@dotcom-tool-kit/error": "^3.1.0",
         "@dotcom-tool-kit/logger": "^3.3.0",
         "@dotcom-tool-kit/state": "^3.1.1",
@@ -29830,10 +29830,10 @@
     },
     "plugins/node": {
       "name": "@dotcom-tool-kit/node",
-      "version": "3.3.6",
+      "version": "3.3.7",
       "license": "ISC",
       "dependencies": {
-        "@dotcom-tool-kit/doppler": "^1.0.6",
+        "@dotcom-tool-kit/doppler": "^1.0.7",
         "@dotcom-tool-kit/error": "^3.1.0",
         "@dotcom-tool-kit/state": "^3.1.1",
         "@dotcom-tool-kit/types": "^3.4.1",
@@ -29856,10 +29856,10 @@
     },
     "plugins/nodemon": {
       "name": "@dotcom-tool-kit/nodemon",
-      "version": "3.3.6",
+      "version": "3.3.7",
       "license": "ISC",
       "dependencies": {
-        "@dotcom-tool-kit/doppler": "^1.0.6",
+        "@dotcom-tool-kit/doppler": "^1.0.7",
         "@dotcom-tool-kit/error": "^3.1.0",
         "@dotcom-tool-kit/state": "^3.1.1",
         "@dotcom-tool-kit/types": "^3.4.1",
@@ -29885,7 +29885,7 @@
     },
     "plugins/npm": {
       "name": "@dotcom-tool-kit/npm",
-      "version": "3.2.1",
+      "version": "3.2.2",
       "license": "ISC",
       "dependencies": {
         "@actions/exec": "^1.1.0",
@@ -30071,7 +30071,7 @@
     },
     "plugins/pa11y": {
       "name": "@dotcom-tool-kit/pa11y",
-      "version": "0.4.6",
+      "version": "0.5.0",
       "license": "ISC",
       "dependencies": {
         "@dotcom-tool-kit/types": "^3.4.1",
@@ -30148,10 +30148,10 @@
     },
     "plugins/serverless": {
       "name": "@dotcom-tool-kit/serverless",
-      "version": "2.2.7",
+      "version": "2.2.9",
       "license": "ISC",
       "dependencies": {
-        "@dotcom-tool-kit/doppler": "^1.0.6",
+        "@dotcom-tool-kit/doppler": "^1.0.7",
         "@dotcom-tool-kit/error": "^3.1.0",
         "@dotcom-tool-kit/state": "^3.1.1",
         "@dotcom-tool-kit/types": "^3.4.1",
@@ -34381,25 +34381,25 @@
     "@dotcom-tool-kit/backend-app": {
       "version": "file:plugins/backend-app",
       "requires": {
-        "@dotcom-tool-kit/backend-heroku-app": "^3.0.7"
+        "@dotcom-tool-kit/backend-heroku-app": "^3.0.9"
       }
     },
     "@dotcom-tool-kit/backend-heroku-app": {
       "version": "file:plugins/backend-heroku-app",
       "requires": {
         "@dotcom-tool-kit/circleci-deploy": "^3.2.8",
-        "@dotcom-tool-kit/heroku": "^3.3.10",
-        "@dotcom-tool-kit/node": "^3.3.6",
-        "@dotcom-tool-kit/npm": "^3.2.1"
+        "@dotcom-tool-kit/heroku": "^3.3.12",
+        "@dotcom-tool-kit/node": "^3.3.7",
+        "@dotcom-tool-kit/npm": "^3.2.2"
       }
     },
     "@dotcom-tool-kit/backend-serverless-app": {
       "version": "file:plugins/backend-serverless-app",
       "requires": {
         "@dotcom-tool-kit/circleci-deploy": "^3.2.8",
-        "@dotcom-tool-kit/node": "^3.3.6",
-        "@dotcom-tool-kit/npm": "^3.2.1",
-        "@dotcom-tool-kit/serverless": "^2.2.7"
+        "@dotcom-tool-kit/node": "^3.3.7",
+        "@dotcom-tool-kit/npm": "^3.2.2",
+        "@dotcom-tool-kit/serverless": "^2.2.9"
       }
     },
     "@dotcom-tool-kit/circleci": {
@@ -34511,7 +34511,7 @@
       "version": "file:plugins/circleci-heroku",
       "requires": {
         "@dotcom-tool-kit/circleci-deploy": "^3.2.8",
-        "@dotcom-tool-kit/heroku": "^3.3.10",
+        "@dotcom-tool-kit/heroku": "^3.3.12",
         "tslib": "^2.3.1"
       },
       "dependencies": {
@@ -34526,7 +34526,7 @@
       "version": "file:plugins/circleci-npm",
       "requires": {
         "@dotcom-tool-kit/circleci": "^5.3.8",
-        "@dotcom-tool-kit/npm": "^3.2.1",
+        "@dotcom-tool-kit/npm": "^3.2.2",
         "@dotcom-tool-kit/types": "^3.4.1",
         "tslib": "^2.3.1"
       },
@@ -34541,8 +34541,8 @@
     "@dotcom-tool-kit/component": {
       "version": "file:plugins/component",
       "requires": {
-        "@dotcom-tool-kit/circleci-npm": "^5.2.10",
-        "@dotcom-tool-kit/npm": "^3.2.1"
+        "@dotcom-tool-kit/circleci-npm": "^5.2.11",
+        "@dotcom-tool-kit/npm": "^3.2.2"
       }
     },
     "@dotcom-tool-kit/create": {
@@ -34550,7 +34550,7 @@
       "requires": {
         "@aws-sdk/client-iam": "^3.282.0",
         "@aws-sdk/client-sts": "^3.282.0",
-        "@dotcom-tool-kit/doppler": "^1.0.6",
+        "@dotcom-tool-kit/doppler": "^1.0.7",
         "@dotcom-tool-kit/error": "^3.1.0",
         "@dotcom-tool-kit/logger": "^3.3.0",
         "@dotcom-tool-kit/types": "^3.4.1",
@@ -34566,7 +34566,7 @@
         "cli-highlight": "^2.1.11",
         "code-suggester": "^4.3.0",
         "cosmiconfig": "^7.0.1",
-        "dotcom-tool-kit": "^3.3.6",
+        "dotcom-tool-kit": "^3.3.8",
         "import-cwd": "^3.0.0",
         "komatsu": "^1.3.0",
         "lodash": "^4.17.21",
@@ -35296,7 +35296,7 @@
     "@dotcom-tool-kit/cypress": {
       "version": "file:plugins/cypress",
       "requires": {
-        "@dotcom-tool-kit/vault": "^3.1.6"
+        "@dotcom-tool-kit/doppler": "^1.0.7"
       }
     },
     "@dotcom-tool-kit/doppler": {
@@ -35483,7 +35483,7 @@
     "@dotcom-tool-kit/frontend-app": {
       "version": "file:plugins/frontend-app",
       "requires": {
-        "@dotcom-tool-kit/backend-heroku-app": "^3.0.7",
+        "@dotcom-tool-kit/backend-heroku-app": "^3.0.9",
         "@dotcom-tool-kit/upload-assets-to-s3": "^3.1.6",
         "@dotcom-tool-kit/webpack": "^3.1.6"
       }
@@ -35491,10 +35491,10 @@
     "@dotcom-tool-kit/heroku": {
       "version": "file:plugins/heroku",
       "requires": {
-        "@dotcom-tool-kit/doppler": "^1.0.6",
+        "@dotcom-tool-kit/doppler": "^1.0.7",
         "@dotcom-tool-kit/error": "^3.1.0",
         "@dotcom-tool-kit/logger": "^3.3.0",
-        "@dotcom-tool-kit/npm": "^3.2.1",
+        "@dotcom-tool-kit/npm": "^3.2.2",
         "@dotcom-tool-kit/options": "^3.1.5",
         "@dotcom-tool-kit/package-json-hook": "^4.1.0",
         "@dotcom-tool-kit/state": "^3.1.1",
@@ -35746,7 +35746,7 @@
     "@dotcom-tool-kit/next-router": {
       "version": "file:plugins/next-router",
       "requires": {
-        "@dotcom-tool-kit/doppler": "^1.0.6",
+        "@dotcom-tool-kit/doppler": "^1.0.7",
         "@dotcom-tool-kit/error": "^3.1.0",
         "@dotcom-tool-kit/logger": "^3.3.0",
         "@dotcom-tool-kit/state": "^3.1.1",
@@ -35851,7 +35851,7 @@
     "@dotcom-tool-kit/node": {
       "version": "file:plugins/node",
       "requires": {
-        "@dotcom-tool-kit/doppler": "^1.0.6",
+        "@dotcom-tool-kit/doppler": "^1.0.7",
         "@dotcom-tool-kit/error": "^3.1.0",
         "@dotcom-tool-kit/state": "^3.1.1",
         "@dotcom-tool-kit/types": "^3.4.1",
@@ -35870,7 +35870,7 @@
     "@dotcom-tool-kit/nodemon": {
       "version": "file:plugins/nodemon",
       "requires": {
-        "@dotcom-tool-kit/doppler": "^1.0.6",
+        "@dotcom-tool-kit/doppler": "^1.0.7",
         "@dotcom-tool-kit/error": "^3.1.0",
         "@dotcom-tool-kit/state": "^3.1.1",
         "@dotcom-tool-kit/types": "^3.4.1",
@@ -36109,7 +36109,7 @@
     "@dotcom-tool-kit/serverless": {
       "version": "file:plugins/serverless",
       "requires": {
-        "@dotcom-tool-kit/doppler": "^1.0.6",
+        "@dotcom-tool-kit/doppler": "^1.0.7",
         "@dotcom-tool-kit/error": "^3.1.0",
         "@dotcom-tool-kit/state": "^3.1.1",
         "@dotcom-tool-kit/types": "^3.4.1",
@@ -41944,17 +41944,17 @@
       "version": "file:core/cli",
       "requires": {
         "@dotcom-tool-kit/babel": "^3.1.5",
-        "@dotcom-tool-kit/backend-heroku-app": "^3.0.7",
+        "@dotcom-tool-kit/backend-heroku-app": "^3.0.9",
         "@dotcom-tool-kit/circleci": "^5.3.8",
         "@dotcom-tool-kit/circleci-deploy": "^3.2.8",
         "@dotcom-tool-kit/error": "^3.1.0",
         "@dotcom-tool-kit/eslint": "^3.1.5",
-        "@dotcom-tool-kit/frontend-app": "^3.1.20",
-        "@dotcom-tool-kit/heroku": "^3.3.10",
+        "@dotcom-tool-kit/frontend-app": "^3.1.22",
+        "@dotcom-tool-kit/heroku": "^3.3.12",
         "@dotcom-tool-kit/logger": "^3.3.0",
         "@dotcom-tool-kit/mocha": "^3.1.5",
         "@dotcom-tool-kit/n-test": "^3.2.7",
-        "@dotcom-tool-kit/npm": "^3.2.1",
+        "@dotcom-tool-kit/npm": "^3.2.2",
         "@dotcom-tool-kit/options": "^3.1.5",
         "@dotcom-tool-kit/types": "^3.4.1",
         "@dotcom-tool-kit/wait-for-ok": "^3.1.0",

--- a/plugins/cypress/package.json
+++ b/plugins/cypress/package.json
@@ -28,6 +28,9 @@
     "npm": "7.x || 8.x || 9.x"
   },
   "dependencies": {
-    "@dotcom-tool-kit/doppler": "^1.0.7"
+    "@dotcom-tool-kit/doppler": "^1.0.7",
+    "@dotcom-tool-kit/logger": "^3.3.0",
+    "@dotcom-tool-kit/state": "^3.1.1",
+    "@dotcom-tool-kit/types": "^3.4.1"
   }
 }

--- a/plugins/cypress/package.json
+++ b/plugins/cypress/package.json
@@ -20,14 +20,14 @@
     "/lib",
     ".toolkitrc.yml"
   ],
-  "dependencies": {
-    "@dotcom-tool-kit/vault": "^3.1.6"
-  },
   "peerDependencies": {
     "dotcom-tool-kit": "3.x"
   },
   "engines": {
     "node": "16.x || 18.x",
     "npm": "7.x || 8.x || 9.x"
+  },
+  "dependencies": {
+    "@dotcom-tool-kit/doppler": "^1.0.7"
   }
 }

--- a/plugins/cypress/src/tasks/cypress.ts
+++ b/plugins/cypress/src/tasks/cypress.ts
@@ -1,9 +1,9 @@
 import { spawn } from 'child_process'
+import { DopplerEnvVars } from '@dotcom-tool-kit/doppler'
 import { hookFork, waitOnExit } from '@dotcom-tool-kit/logger'
 import { readState } from '@dotcom-tool-kit/state'
 import { Task } from '@dotcom-tool-kit/types'
 import { CypressSchema } from '@dotcom-tool-kit/types/src/schema/cypress'
-import { VaultEnvVars } from '@dotcom-tool-kit/vault'
 
 export class CypressLocal extends Task<typeof CypressSchema> {
   async run(): Promise<void> {
@@ -12,9 +12,7 @@ export class CypressLocal extends Task<typeof CypressSchema> {
       cypressEnv.CYPRESS_BASE_URL = this.options.localUrl
     }
 
-    const vault = new VaultEnvVars(this.logger, {
-      environment: 'development'
-    })
+    const vault = new DopplerEnvVars(this.logger, 'dev')
     const vaultEnv = await vault.get()
 
     const env = { ...process.env, ...cypressEnv, ...vaultEnv }

--- a/plugins/cypress/tsconfig.json
+++ b/plugins/cypress/tsconfig.json
@@ -13,6 +13,9 @@
     },
     {
       "path": "../../lib/state"
+    },
+    {
+      "path": "../../lib/doppler"
     }
   ],
   "include": ["src/**/*"]


### PR DESCRIPTION
# Description

I suspect this slipped through the [original migration](https://github.com/Financial-Times/dotcom-tool-kit/pull/458) as Vault support was [added](https://github.com/Financial-Times/dotcom-tool-kit/pull/460) to the plugin around the same time.

# Checklist:

- [x] My branch has been rebased onto the latest commit on main (don't merge main into your branch)
- [x] My commit messages are [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/), for example: `feat(circleci): add support for nightly workflows`, `fix: set Heroku app name for staging apps too`
