### PR TITLE
Don't call Doppler CLI in Serverless deployments

### DIFF
--- a/plugins/serverless/src/tasks/deploy.ts
+++ b/plugins/serverless/src/tasks/deploy.ts
@@ -20,11 +20,17 @@ export default class ServerlessDeploy extends Task<typeof ServerlessSchema> {
       )
     }
 
-    let dopplerEnv = {}
+    let vaultEnv = {}
     if (useVault) {
-      const doppler = new DopplerEnvVars(this.logger, 'prod')
-
-      dopplerEnv = await doppler.get()
+      const dopplerCi = new DopplerEnvVars(this.logger, 'ci')
+      const vaultCi = await dopplerCi.fallbackToVault()
+      // HACK:20231023:IM don't read secrets when the project has already
+      // migrated from Vault to Doppler – Doppler will instead sync secrets to
+      // Parameter Store for the Serverless config to reference
+      if (!vaultCi.MIGRATED_TO_DOPPLER) {
+        const dopplerEnvVars = new DopplerEnvVars(this.logger, 'prod')
+        vaultEnv = await dopplerEnvVars.fallbackToVault()
+      }
     }
 
     for (const region of regions) {
@@ -37,7 +43,7 @@ export default class ServerlessDeploy extends Task<typeof ServerlessSchema> {
       const child = spawn('serverless', args, {
         env: {
           ...process.env,
-          ...dopplerEnv
+          ...vaultEnv
         }
       })
 


### PR DESCRIPTION
# Description

The Doppler CLI isn't installed on CircleCI jobs so we instead sync Doppler secrets to AWS Parameter Store, as set up in the [migration script](https://github.com/Financial-Times/platform-scripts/pull/51).

# Checklist:

- [x] My branch has been rebased onto the latest commit on main (don't merge main into your branch)
- [x] My commit messages are [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/), for example: `feat(circleci): add support for nightly workflows`, `fix: set Heroku app name for staging apps too`
