### PR TITLE
Skip Serverless check for Doppler flag in Vault if options already configured

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -28876,13 +28876,13 @@
     },
     "plugins/backend-serverless-app": {
       "name": "@dotcom-tool-kit/backend-serverless-app",
-      "version": "3.0.9",
+      "version": "3.0.10",
       "license": "ISC",
       "dependencies": {
         "@dotcom-tool-kit/circleci-deploy": "^3.2.8",
         "@dotcom-tool-kit/node": "^3.3.7",
         "@dotcom-tool-kit/npm": "^3.2.2",
-        "@dotcom-tool-kit/serverless": "^2.2.9"
+        "@dotcom-tool-kit/serverless": "^2.2.10"
       },
       "engines": {
         "node": "16.x || 18.x",
@@ -29108,7 +29108,7 @@
     },
     "plugins/cypress": {
       "name": "@dotcom-tool-kit/cypress",
-      "version": "3.2.3",
+      "version": "3.3.0",
       "license": "ISC",
       "dependencies": {
         "@dotcom-tool-kit/doppler": "^1.0.7",
@@ -30151,11 +30151,12 @@
     },
     "plugins/serverless": {
       "name": "@dotcom-tool-kit/serverless",
-      "version": "2.2.9",
+      "version": "2.2.10",
       "license": "ISC",
       "dependencies": {
         "@dotcom-tool-kit/doppler": "^1.0.7",
         "@dotcom-tool-kit/error": "^3.1.0",
+        "@dotcom-tool-kit/options": "^3.1.5",
         "@dotcom-tool-kit/state": "^3.1.1",
         "@dotcom-tool-kit/types": "^3.4.1",
         "get-port": "^5.1.1",
@@ -34402,7 +34403,7 @@
         "@dotcom-tool-kit/circleci-deploy": "^3.2.8",
         "@dotcom-tool-kit/node": "^3.3.7",
         "@dotcom-tool-kit/npm": "^3.2.2",
-        "@dotcom-tool-kit/serverless": "^2.2.9"
+        "@dotcom-tool-kit/serverless": "^2.2.10"
       }
     },
     "@dotcom-tool-kit/circleci": {
@@ -36117,6 +36118,7 @@
       "requires": {
         "@dotcom-tool-kit/doppler": "^1.0.7",
         "@dotcom-tool-kit/error": "^3.1.0",
+        "@dotcom-tool-kit/options": "^3.1.5",
         "@dotcom-tool-kit/state": "^3.1.1",
         "@dotcom-tool-kit/types": "^3.4.1",
         "get-port": "^5.1.1",

--- a/plugins/heroku/src/setConfigVars.ts
+++ b/plugins/heroku/src/setConfigVars.ts
@@ -19,7 +19,7 @@ async function setAppConfigVars(
   // that and then get the passed argument later if the secret isn't present.
   // We can skip this call if we find the project has already added options for
   // doppler in the Tool Kit configuration.
-  const migratedToolKitToDoppler = Boolean(getOptions('@dotcom-tool-kit/doppler'))
+  const migratedToolKitToDoppler = Boolean(getOptions('@dotcom-tool-kit/doppler')?.project)
   if (migratedToolKitToDoppler) {
     return
   }
@@ -71,7 +71,7 @@ async function setStageConfigVars(
   // that and then get the passed argument later if the secret isn't present.
   // We can skip this call if we find the project has already added options for
   // doppler in the Tool Kit configuration.
-  const migratedToolKitToDoppler = Boolean(getOptions('@dotcom-tool-kit/doppler'))
+  const migratedToolKitToDoppler = Boolean(getOptions('@dotcom-tool-kit/doppler')?.project)
   if (migratedToolKitToDoppler) {
     return
   }

--- a/plugins/serverless/package.json
+++ b/plugins/serverless/package.json
@@ -25,10 +25,11 @@
     "serverless-offline": "^12.0.4"
   },
   "dependencies": {
+    "@dotcom-tool-kit/doppler": "^1.0.7",
     "@dotcom-tool-kit/error": "^3.1.0",
+    "@dotcom-tool-kit/options": "^3.1.5",
     "@dotcom-tool-kit/state": "^3.1.1",
     "@dotcom-tool-kit/types": "^3.4.1",
-    "@dotcom-tool-kit/doppler": "^1.0.7",
     "get-port": "^5.1.1",
     "tslib": "^2.3.1",
     "wait-port": "^0.2.9"

--- a/plugins/serverless/src/tasks/deploy.ts
+++ b/plugins/serverless/src/tasks/deploy.ts
@@ -3,6 +3,7 @@ import { hookFork, styles, waitOnExit } from '@dotcom-tool-kit/logger'
 import { Task } from '@dotcom-tool-kit/types'
 import { ServerlessSchema } from '@dotcom-tool-kit/types/lib/schema/serverless'
 import { DopplerEnvVars } from '@dotcom-tool-kit/doppler'
+import { getOptions } from '@dotcom-tool-kit/options'
 import { spawn } from 'child_process'
 
 export default class ServerlessDeploy extends Task<typeof ServerlessSchema> {
@@ -21,7 +22,13 @@ export default class ServerlessDeploy extends Task<typeof ServerlessSchema> {
     }
 
     let vaultEnv = {}
-    if (useVault) {
+    // HACK:20231124:IM We need to call Vault to check whether a project has
+    // migrated to Doppler yet, and sync Vault secrets if it hasn't, but this
+    // logic should be removed entirely once we drop support for Vault. We can
+    // skip this call if we find the project has already added options for
+    // doppler in the Tool Kit configuration.
+    const migratedToolKitToDoppler = Boolean(getOptions('@dotcom-tool-kit/doppler')?.project)
+    if (useVault && !migratedToolKitToDoppler) {
       const dopplerCi = new DopplerEnvVars(this.logger, 'ci')
       const vaultCi = await dopplerCi.fallbackToVault()
       // HACK:20231023:IM don't read secrets when the project has already

--- a/plugins/serverless/tsconfig.json
+++ b/plugins/serverless/tsconfig.json
@@ -13,6 +13,9 @@
     },
     {
       "path": "../../lib/logger"
+    },
+    {
+      "path": "../../lib/options"
     }
   ],
   "include": ["src/**/*"]


### PR DESCRIPTION
# Description

Skip checking Vault for the `MIGRATED_TO_DOPPLER` flag if the Tool Kit config has already moved to using `@dotcom-tool-kit/doppler` options in the `serverless` plugin, to reflect the same change in the [`doppler`](https://github.com/Financial-Times/dotcom-tool-kit/blob/631cca2488dd2fe2689f0ad5189985492ef9263b/lib/doppler/src/index.ts#L118) and [`heroku`](https://github.com/Financial-Times/dotcom-tool-kit/blob/631cca2488dd2fe2689f0ad5189985492ef9263b/plugins/heroku/src/setConfigVars.ts#L22) plugins.

Also copy over the fix from #530 to the `heroku` plugin.

# Checklist:

- [x] My branch has been rebased onto the latest commit on main (don't merge main into your branch)
- [x] My commit messages are [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/), for example: `feat(circleci): add support for nightly workflows`, `fix: set Heroku app name for staging apps too`
