### PR TITLE
fix: add default assignment for build:ci and build:remote for TypescriptBuild

### DIFF
--- a/plugins/typescript/.toolkitrc.yml
+++ b/plugins/typescript/.toolkitrc.yml
@@ -1,4 +1,5 @@
 hooks:
   'build:local': TypeScriptBuild
+  'build:ci': TypeScriptBuild
   'run:local': TypeScriptWatch
   'test:local': TypeScriptTest

--- a/plugins/typescript/.toolkitrc.yml
+++ b/plugins/typescript/.toolkitrc.yml
@@ -1,5 +1,6 @@
 hooks:
   'build:local': TypeScriptBuild
   'build:ci': TypeScriptBuild
+  'build:remote': TypeScriptBuild
   'run:local': TypeScriptWatch
   'test:local': TypeScriptTest

--- a/plugins/typescript/readme.md
+++ b/plugins/typescript/readme.md
@@ -28,6 +28,6 @@ plugins:
 
 | Task | Description | Preconfigured hook |
 |-|-|-|
-| `TypeScriptBuild` | runs `tsc` to compile TypeScript to JavaScript | `build:local`, `build:ci` |
+| `TypeScriptBuild` | runs `tsc` to compile TypeScript to JavaScript | `build:local`, `build:ci`, `build:remote` |
 | `TypeScriptWatch` | rebuild project on every project file change | `run:local` |
 | `TypeScriptTest` | type check TypeScript code without emitting code | `test:local` |

--- a/plugins/typescript/readme.md
+++ b/plugins/typescript/readme.md
@@ -28,6 +28,6 @@ plugins:
 
 | Task | Description | Preconfigured hook |
 |-|-|-|
-| `TypeScriptBuild` | runs `tsc` to compile TypeScript to JavaScript | `build:local` |
+| `TypeScriptBuild` | runs `tsc` to compile TypeScript to JavaScript | `build:local`, `build:ci` |
 | `TypeScriptWatch` | rebuild project on every project file change | `run:local` |
 | `TypeScriptTest` | type check TypeScript code without emitting code | `test:local` |


### PR DESCRIPTION
this aligns it with eg the `babel` plugin, as well as where cp-content-pipeline was originally running it

HT @andygout for noticing this omission!