### PR TITLE
Add permission to read Parameter Store values to default OIDC role created by migration script

### DIFF
--- a/core/create/files/oidc-cloudformation.yml
+++ b/core/create/files/oidc-cloudformation.yml
@@ -118,3 +118,9 @@ Resources:
               - s3:*
             Resource:
               - arn:aws:s3:::*serverlessdeploymentbuck*
+          - Sid: AllowReadDopplerSecrets
+            Effect: Allow
+            Action:
+              - ssm:GetParameter
+            Resource:
+              - !Sub arn:aws:ssm:eu-west-1:${AWS::AccountId}:parameter:/${SystemCode}/*


### PR DESCRIPTION
# Description

Needed for Serverless deployments to be able to read Doppler secrets synced to AWS Parameter Store.

# Checklist:

- [x] My branch has been rebased onto the latest commit on main (don't merge main into your branch)
- [x] My commit messages are [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/), for example: `feat(circleci): add support for nightly workflows`, `fix: set Heroku app name for staging apps too`
