### PR TITLE
CPP-1505 Add option in migration script to add .toolkitstate directory to gitignore

### DIFF
--- a/core/create/src/prompts/confirmation.ts
+++ b/core/create/src/prompts/confirmation.ts
@@ -4,6 +4,7 @@ import prompt from 'prompts'
 export interface ConfirmationParams {
   deleteConfig: boolean
   addEslintConfig: boolean
+  ignoreToolKitState: boolean
   packagesToInstall: string[]
   packagesToRemove: string[]
   configFile: string
@@ -12,6 +13,7 @@ export interface ConfirmationParams {
 export default ({
   deleteConfig,
   addEslintConfig,
+  ignoreToolKitState,
   packagesToInstall,
   packagesToRemove,
   configFile
@@ -37,7 +39,9 @@ ${
 }
 create a ${styles.filepath('.toolkitrc.yml')} containing:
 ${configFile}\
-${deleteConfig ? `\nregenerate ${styles.filepath('.circleci/config.yml')}\n` : ''}
+${deleteConfig ? `\nregenerate ${styles.filepath('.circleci/config.yml')}` : ''}
+${ignoreToolKitState ? `\nadd ${styles.filepath('.toolkitstate')} to ${styles.filepath('.gitignore')}` : ''}
+
 sound good?`
     }
   })


### PR DESCRIPTION
# Description

We don't want people committing the `.toolkitstate` directory, so let's add make sure it's ignored by git in the migration script. 

# Checklist:

- [x] My branch has been rebased onto the latest commit on main (don't merge main into your branch)
- [x] My commit messages are [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/), for example: `feat(circleci): add support for nightly workflows`, `fix: set Heroku app name for staging apps too`
