### PR TITLE
refactor!: rename Hook#check to Hook#isInstalled

### DIFF
--- a/core/cli/src/config.ts
+++ b/core/cli/src/config.ts
@@ -164,7 +164,7 @@ export async function checkInstall(logger: Logger, config: ValidConfig): Promise
   const hooks = (await loadHookInstallations(logger, config)).unwrap('hooks are invalid')
 
   const uninstalledHooks = await asyncFilter(hooks, async (hook) => {
-    return !(await hook.check())
+    return !(await hook.isInstalled())
   })
 
   if (uninstalledHooks.length > 0) {

--- a/core/cli/src/install.ts
+++ b/core/cli/src/install.ts
@@ -32,7 +32,7 @@ export default async function installHooks(logger: Logger): Promise<ValidConfig>
 
   for (const group of Object.values(groups)) {
     try {
-      if (await asyncSome(group, async (hook) => !(await hook.check()))) {
+      if (await asyncSome(group, async (hook) => !(await hook.isInstalled()))) {
         let state = undefined
         for (const hook of group) {
           state = await hook.install(state)

--- a/docs/custom-plugins.md
+++ b/docs/custom-plugins.md
@@ -79,13 +79,13 @@ A Hook defines an abstract label to run tasks with, as well as managing where in
 
 This abstraction lets us write different plugins for defining tasks to be run, separate from the plugins defining where they should be run from, whilst maintaining the link between them. We've already seen that `build:ci` could be running Rollup, or Webpack, or any other task; in addition, `build:ci` itself could be defined by a different plugin, such as a Github Actions plugin, that would automatically manage configuration in `.github/workflows`.
 
-The automatic configuration management is implemented by `Hook` subclasses. These define a `check` method that should return `true` if the hook is correctly installed in the repository or `false` if it needs installing, and an `install` method to actually perform the installation. Every time Tool Kit runs, it checks that every hook is installed in your repo, and if any aren't, it exits with an error (to ensure the repo is always consistent with what it expects). You can then run `dotcom-tool-kit --install` to run the installation of every hook that isn't installed.
+The automatic configuration management is implemented by `Hook` subclasses. These define an `isInstalled` method that should return `true` if the hook is correctly installed in the repository or `false` if it needs installing, and an `install` method to actually perform the installation. Every time Tool Kit runs, it checks that every hook is installed in your repo, and if any aren't, it exits with an error (to ensure the repo is always consistent with what it expects). You can then run `dotcom-tool-kit --install` to run the installation of every hook that isn't installed.
 
 If you find yourself asking a question like "how do I run a Tool Kit task from a different npm script", **you should implement a hook** to allow Tool Kit to automatically manage that configuration for any new repos using your plugin, rather than expecting new users to add that configuration themselves when installing the plugin.
 
 Hooks have a loose naming convention of `category:environment`. This is only meant for humans to be able to intuitively understand which hooks are related; it's not required by the Tool Kit core itself.
 
-Let's say you want to run some task on the npm `prepare` script (which automatically runs after `npm install` and before `npm publish`). We'll call that hook `prepare:local`, and the plugin will live in `toolkit/npm-prepare` ([structured as above](#common-plugin-structure)). Create a subclass of the `Hook` class from `@dotcom-tool-kit/types`, implement the `check` and `install` methods, and export a `hooks` object to map it to the name we're giving it. Your `toolkit/npm-prepare/index.js` might include:
+Let's say you want to run some task on the npm `prepare` script (which automatically runs after `npm install` and before `npm publish`). We'll call that hook `prepare:local`, and the plugin will live in `toolkit/npm-prepare` ([structured as above](#common-plugin-structure)). Create a subclass of the `Hook` class from `@dotcom-tool-kit/types`, implement the `isInstalled` and `install` methods, and export a `hooks` object to map it to the name we're giving it. Your `toolkit/npm-prepare/index.js` might include:
 
 ```js
 const { Hook } = require('@dotcom-tool-kit/types')
@@ -101,7 +101,7 @@ class PrepareHook extends Hook {
     return this._packageJson
   }
 
-  async check() {
+  async isInstalled() {
     return this.packageJson.getField('scripts')?.prepare === 'dotcom-tool-kit prepare:local'
   }
 

--- a/docs/developing-tool-kit.md
+++ b/docs/developing-tool-kit.md
@@ -58,7 +58,7 @@ Tasks won't be usable by your plugin's users unless you export them from the ent
 
 A hook ensures a repo using Tool Kit has the relevant configuration to run things from Tool Kit.
 
-A hook extends the `Hook` class from `@dotcom-tool-kit/types`, implementing its abstract asynchronous `check` and `install` functions. You also need to write a helpful `description` field, which will be displayed in the `--help` text.
+A hook extends the `Hook` class from `@dotcom-tool-kit/types`, implementing its abstract asynchronous `isInstalled` and `install` functions. You also need to write a helpful `description` field, which will be displayed in the `--help` text.
 
 ```typescript
 import { Hook } from '@dotcom-tool-kit/types'
@@ -66,7 +66,7 @@ import { Hook } from '@dotcom-tool-kit/types'
 export default NpmRunTest extends Hook {
   static description = 'hook to run tasks with `npm run test`'
 
-  async check(): Promise<boolean> {
+  async isInstalled(): Promise<boolean> {
     // return true if the `test` script is correctly defined in `package.json`
   }
 

--- a/lib/types/src/hook.ts
+++ b/lib/types/src/hook.ts
@@ -56,7 +56,7 @@ export abstract class Hook<Options extends z.ZodTypeAny = z.ZodTypeAny, State = 
     this.logger = logger.child({ hook: this.constructor.name })
   }
 
-  abstract check(): Promise<boolean>
+  abstract isInstalled(): Promise<boolean>
   abstract install(state?: State): Promise<State>
   async commitInstall(_state: State): Promise<void> {
     return

--- a/plugins/circleci/src/circleci-config.ts
+++ b/plugins/circleci/src/circleci-config.ts
@@ -266,7 +266,7 @@ export default abstract class CircleCiConfig extends Hook<z.ZodTypeAny, CircleCI
     return this._circleConfig
   }
 
-  async check(): Promise<boolean> {
+  async isInstalled(): Promise<boolean> {
     const rawConfig = await this.getCircleConfig()
     if (!rawConfig) {
       return false

--- a/plugins/circleci/test/circleci-config.test.ts
+++ b/plugins/circleci/test/circleci-config.test.ts
@@ -56,13 +56,13 @@ describe('CircleCI config hook', () => {
     it('should return true if the hook job is in the circleci workflow', async () => {
       process.chdir(path.join(__dirname, 'files', 'with-hook'))
       const hook = new TestHook(logger, 'TestHook')
-      expect(await hook.check()).toBeTruthy()
+      expect(await hook.isInstalled()).toBeTruthy()
     })
 
     it('should return false if the hook job is not in the circleci workflow', async () => {
       process.chdir(path.join(__dirname, 'files', 'without-hook'))
       const hook = new TestHook(logger, 'TestHook')
-      expect(await hook.check()).toBeFalsy()
+      expect(await hook.isInstalled()).toBeFalsy()
     })
 
     it('should return false if the base configuration is missing', async () => {
@@ -71,7 +71,7 @@ describe('CircleCI config hook', () => {
       // reset field overridden by FakeCircleCiConfigHook so that we do check
       // for the base config
       hook.haveCheckedBaseConfig = false
-      expect(await hook.check()).toBeFalsy()
+      expect(await hook.isInstalled()).toBeFalsy()
     })
   })
 

--- a/plugins/package-json-hook/src/package-json-helper.ts
+++ b/plugins/package-json-hook/src/package-json-helper.ts
@@ -40,7 +40,7 @@ export default class PackageJson extends Hook<typeof PackageJsonSchema, PackageJ
     return this._packageJson
   }
 
-  async check(): Promise<boolean> {
+  async isInstalled(): Promise<boolean> {
     const packageJson = await this.getPackageJson()
 
     // this instance's `options` is a nested object of expected package.json field/command mappings, e.g.

--- a/plugins/package-json-hook/test/index.test.ts
+++ b/plugins/package-json-hook/test/index.test.ts
@@ -22,7 +22,7 @@ describe('package.json hook', () => {
         }
       })
 
-      expect(await hook.check()).toBeTruthy()
+      expect(await hook.isInstalled()).toBeTruthy()
     })
 
     it('should return true when script includes other hooks', async () => {
@@ -33,7 +33,7 @@ describe('package.json hook', () => {
         }
       })
 
-      expect(await hook.check()).toBeTruthy()
+      expect(await hook.isInstalled()).toBeTruthy()
     })
 
     it(`should return false when package.json doesn't have hook call in script`, async () => {
@@ -44,7 +44,7 @@ describe('package.json hook', () => {
         }
       })
 
-      expect(await hook.check()).toBeFalsy()
+      expect(await hook.isInstalled()).toBeFalsy()
     })
   })
 


### PR DESCRIPTION
thanks for the suggestion @cerdfied!

i've gone for `isInstalled` rather than your suggestion of `checkInstalled` as this method is kind of a predicate? happy to bikeshed though. if this were Ruby i'd have called it `installed?`