### PR TITLE
CPP-1776 Add option to remove ESLint config from gitignore

### DIFF
--- a/core/create/src/index.ts
+++ b/core/create/src/index.ts
@@ -83,6 +83,8 @@ async function executeMigration(
     : Promise.resolve()
 
   const gitignorePath = '.gitignore'
+  // wrap this step in an async closure so that we can execute multiple
+  // statements and pass it to komatsu to log as one pending task
   const fixGitignoreAsync = async () => {
     const stateIgnore = '/.toolkitstate\n'
     let fixed

--- a/core/create/src/prompts/confirmation.ts
+++ b/core/create/src/prompts/confirmation.ts
@@ -4,7 +4,7 @@ import prompt from 'prompts'
 export interface ConfirmationParams {
   deleteConfig: boolean
   addEslintConfig: boolean
-  ignoreToolKitState: boolean
+  fixGitignore: boolean
   packagesToInstall: string[]
   packagesToRemove: string[]
   configFile: string
@@ -13,7 +13,7 @@ export interface ConfirmationParams {
 export default ({
   deleteConfig,
   addEslintConfig,
-  ignoreToolKitState,
+  fixGitignore,
   packagesToInstall,
   packagesToRemove,
   configFile
@@ -40,7 +40,7 @@ ${
 create a ${styles.filepath('.toolkitrc.yml')} containing:
 ${configFile}\
 ${deleteConfig ? `\nregenerate ${styles.filepath('.circleci/config.yml')}` : ''}
-${ignoreToolKitState ? `\nadd ${styles.filepath('.toolkitstate')} to ${styles.filepath('.gitignore')}` : ''}
+${fixGitignore ? `\nupdate ${styles.filepath('.gitignore')}` : ''}
 
 sound good?`
     }

--- a/core/create/src/prompts/main.ts
+++ b/core/create/src/prompts/main.ts
@@ -106,7 +106,7 @@ export default async ({
         initial: true,
         message: `Would you like your ${styles.filepath(
           '.gitignore'
-        )} to be updated? Tool Kit stores some state files that shouldn't be committed to your repository, whereas ESLint configuration can now be committed.`
+        )} to be updated? Tool Kit stores some state files that shouldn't be committed to your repository, whereas ESLint configuration should now be committed.`
       },
       {
         name: 'uninstall',

--- a/core/create/src/prompts/main.ts
+++ b/core/create/src/prompts/main.ts
@@ -99,10 +99,11 @@ export default async ({
       },
       {
         name: 'addEslintConfig',
-        // Only show prompt if eslint was selected and there isn't a eslint config file already
-        type: (prev) => (prev.includes('eslint') && !existsSync(eslintConfigPath) ? 'confirm' : null),
-        initial: true,
-        message: `Would you like to add a default eslint config file at ${styles.filepath('./eslintrc.js')}?`
+        // Only show prompt if eslint plugin was selected
+        type: (prev) => (prev.includes('eslint') ? 'confirm' : null),
+        // Default to creating a config if config doesn't currently exist
+        initial: !existsSync(eslintConfigPath),
+        message: `Would you like to set a default eslint config file at ${styles.filepath('./eslintrc.js')}?`
       },
       {
         name: 'deleteConfig',

--- a/core/create/src/prompts/main.ts
+++ b/core/create/src/prompts/main.ts
@@ -1,16 +1,10 @@
 import { styles } from '@dotcom-tool-kit/logger'
 import type { PackageJson } from 'type-fest'
-import { existsSync, promises as fs } from 'fs'
+import { existsSync } from 'fs'
 import prompt from 'prompts'
 import { BizOpsSystem } from '../bizOps'
 
-type PromptNames =
-  | 'preset'
-  | 'additional'
-  | 'addEslintConfig'
-  | 'deleteConfig'
-  | 'ignoreToolKitState'
-  | 'uninstall'
+type PromptNames = 'preset' | 'additional' | 'addEslintConfig' | 'deleteConfig' | 'fixGitignore' | 'uninstall'
 
 export interface MainParams {
   bizOpsSystem?: BizOpsSystem
@@ -44,14 +38,6 @@ export default async ({
     guessedPreset = 'backend-serverless-app'
   } else {
     guessedPreset = 'component'
-  }
-
-  let missingStateInGitignore
-  try {
-    const gitIgnore = await fs.readFile('.gitignore', 'utf8')
-    missingStateInGitignore = !gitIgnore.includes('toolkitstate')
-  } catch {
-    missingStateInGitignore = true
   }
 
   return prompt(
@@ -115,14 +101,12 @@ export default async ({
         )}.`
       },
       {
-        name: 'ignoreToolKitState',
-        type: missingStateInGitignore ? 'confirm' : null,
+        name: 'fixGitignore',
+        type: 'confirm',
         initial: true,
-        message: `Would you like the ${styles.filepath(
-          '.toolkitstate/'
-        )} directory to be added to your ${styles.filepath(
+        message: `Would you like your ${styles.filepath(
           '.gitignore'
-        )}? Tool Kit stores some state files that shouldn't be committed to your repository.`
+        )} to be updated? Tool Kit stores some state files that shouldn't be committed to your repository, whereas ESLint configuration can now be committed.`
       },
       {
         name: 'uninstall',


### PR DESCRIPTION
# Description

n-gage would copy a default ESLint config into your project but [only if `.eslintrc.js` was in your `.gitignore`](https://github.com/Financial-Times/n-gage/blob/1edbe16b1f49058b534c0bd117ce5bd0f17d13c2/src/tasks/install.mk#L55). This means that many n-gage projects don't have committed ESLint configuration. The Tool Kit migration script will set up our own recommended ESLint config (pulling in the settings from [eslint-config-next](https://github.com/Financial-Times/eslint-config-next)) but we should also make sure the config isn't also ignored by git.

# Checklist:

- [x] My branch has been rebased onto the latest commit on main (don't merge main into your branch)
- [x] My commit messages are [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/), for example: `feat(circleci): add support for nightly workflows`, `fix: set Heroku app name for staging apps too`
