### PR TITLE
split task/plugin options

### DIFF
--- a/core/cli/src/config.ts
+++ b/core/cli/src/config.ts
@@ -32,6 +32,7 @@ export const createConfig = (): RawConfig => ({
   tasks: {},
   commandTasks: {},
   pluginOptions: {},
+  taskOptions: {},
   hooks: {},
   inits: []
 })

--- a/core/cli/src/config.ts
+++ b/core/cli/src/config.ts
@@ -68,7 +68,8 @@ export function validateConfig(config: ValidPluginsConfig, logger: Logger): Vali
     hookConflicts.length > 0 ||
     definedCommandTaskConflicts.length > 0 ||
     taskConflicts.length > 0 ||
-    pluginOptionConflicts.length > 0
+    pluginOptionConflicts.length > 0 ||
+    taskOptionConflicts.length > 0
   ) {
     shouldThrow = true
 

--- a/core/cli/src/config.ts
+++ b/core/cli/src/config.ts
@@ -13,12 +13,14 @@ import { RawConfig, ValidConfig, ValidPluginsConfig } from '@dotcom-tool-kit/con
 import {
   formatTaskConflicts,
   formatUndefinedCommandTasks,
-  formatUnusedOptions,
+  formatUnusedPluginOptions,
   formatCommandTaskConflicts,
   formatHookConflicts,
-  formatOptionConflicts,
+  formatPluginOptionConflicts,
   formatMissingTasks,
-  formatInvalidOptions
+  formatInvalidOptions,
+  formatTaskOptionConflicts,
+  formatUnusedTaskOptions
 } from './messages'
 import { validatePlugins } from './config/validate-plugins'
 import { validatePluginOptions } from './plugin/options'
@@ -43,7 +45,8 @@ export function validateConfig(config: ValidPluginsConfig, logger: Logger): Vali
   const commandTaskConflicts = findConflicts(Object.values(config.commandTasks))
   const hookConflicts = findConflictingEntries(config.hooks)
   const taskConflicts = findConflictingEntries(config.tasks)
-  const optionConflicts = findConflicts(Object.values(config.pluginOptions))
+  const pluginOptionConflicts = findConflicts(Object.values(config.pluginOptions))
+  const taskOptionConflicts = findConflicts(Object.values(config.taskOptions))
 
   const definedCommandTaskConflicts = commandTaskConflicts.filter((conflict) => {
     return conflict.conflicting[0].id in config.hooks
@@ -65,7 +68,7 @@ export function validateConfig(config: ValidPluginsConfig, logger: Logger): Vali
     hookConflicts.length > 0 ||
     definedCommandTaskConflicts.length > 0 ||
     taskConflicts.length > 0 ||
-    optionConflicts.length > 0
+    pluginOptionConflicts.length > 0
   ) {
     shouldThrow = true
 
@@ -81,8 +84,12 @@ export function validateConfig(config: ValidPluginsConfig, logger: Logger): Vali
       error.details += formatTaskConflicts(taskConflicts)
     }
 
-    if (optionConflicts.length) {
-      error.details += formatOptionConflicts(optionConflicts)
+    if (pluginOptionConflicts.length) {
+      error.details += formatPluginOptionConflicts(pluginOptionConflicts)
+    }
+
+    if (taskOptionConflicts.length) {
+      error.details += formatTaskOptionConflicts(taskOptionConflicts)
     }
   }
 
@@ -108,15 +115,27 @@ export function validateConfig(config: ValidPluginsConfig, logger: Logger): Vali
     error.details += formatInvalidOptions(invalidOptions)
   }
 
-  const unusedOptions = Object.entries(config.pluginOptions)
+  const unusedPluginOptions = Object.entries(config.pluginOptions)
     .filter(
       ([, option]) =>
         option && !isConflict(option) && !option.forPlugin && option.plugin.root === process.cwd()
     )
     .map(([id]) => id)
-  if (unusedOptions.length > 0) {
+
+  if (unusedPluginOptions.length > 0) {
     shouldThrow = true
-    error.details += formatUnusedOptions(unusedOptions, Object.keys(config.plugins))
+    error.details += formatUnusedPluginOptions(unusedPluginOptions, Object.keys(config.plugins))
+  }
+
+  const unusedTaskOptions = Object.entries(config.taskOptions)
+    .filter(
+      ([, option]) => option && !isConflict(option) && !option.task && option.plugin.root === process.cwd()
+    )
+    .map(([id]) => id)
+
+  if (unusedTaskOptions.length > 0) {
+    shouldThrow = true
+    error.details += formatUnusedTaskOptions(unusedTaskOptions, Object.keys(config.tasks))
   }
 
   const missingTasks = configuredCommandTasks

--- a/core/cli/src/config.ts
+++ b/core/cli/src/config.ts
@@ -31,7 +31,7 @@ export const createConfig = (): RawConfig => ({
   resolvedPlugins: new Set(),
   tasks: {},
   commandTasks: {},
-  options: {},
+  pluginOptions: {},
   hooks: {},
   inits: []
 })
@@ -42,7 +42,7 @@ export function validateConfig(config: ValidPluginsConfig, logger: Logger): Vali
   const commandTaskConflicts = findConflicts(Object.values(config.commandTasks))
   const hookConflicts = findConflictingEntries(config.hooks)
   const taskConflicts = findConflictingEntries(config.tasks)
-  const optionConflicts = findConflicts(Object.values(config.options))
+  const optionConflicts = findConflicts(Object.values(config.pluginOptions))
 
   const definedCommandTaskConflicts = commandTaskConflicts.filter((conflict) => {
     return conflict.conflicting[0].id in config.hooks
@@ -107,7 +107,7 @@ export function validateConfig(config: ValidPluginsConfig, logger: Logger): Vali
     error.details += formatInvalidOptions(invalidOptions)
   }
 
-  const unusedOptions = Object.entries(config.options)
+  const unusedOptions = Object.entries(config.pluginOptions)
     .filter(
       ([, option]) =>
         option && !isConflict(option) && !option.forPlugin && option.plugin.root === process.cwd()

--- a/core/cli/src/help.ts
+++ b/core/cli/src/help.ts
@@ -10,7 +10,7 @@ export default async function showHelp(logger: Logger, hooks: string[]): Promise
     hooks = Object.keys(config.hooks).sort()
   }
 
-  for (const pluginOptions of Object.values(config.options)) {
+  for (const pluginOptions of Object.values(config.pluginOptions)) {
     if (pluginOptions.forPlugin) {
       setOptions(pluginOptions.forPlugin.id as OptionKey, pluginOptions.options)
     }

--- a/core/cli/src/install.ts
+++ b/core/cli/src/install.ts
@@ -101,7 +101,7 @@ export async function checkInstall(logger: Logger, config: ValidConfig): Promise
 export default async function installHooks(logger: Logger): Promise<ValidConfig> {
   const config = await loadConfig(logger)
 
-  for (const pluginOptions of Object.values(config.options)) {
+  for (const pluginOptions of Object.values(config.pluginOptions)) {
     if (pluginOptions.forPlugin) {
       setOptions(pluginOptions.forPlugin.id as OptionKey, pluginOptions.options)
     }

--- a/core/cli/src/messages.ts
+++ b/core/cli/src/messages.ts
@@ -1,6 +1,12 @@
 import { styles as s, styles } from '@dotcom-tool-kit/logger'
 import type { Hook } from '@dotcom-tool-kit/base'
-import type { CommandTask, EntryPoint, Plugin, OptionsForPlugin } from '@dotcom-tool-kit/plugin'
+import type {
+  CommandTask,
+  EntryPoint,
+  Plugin,
+  OptionsForPlugin,
+  OptionsForTask
+} from '@dotcom-tool-kit/plugin'
 import type { z } from 'zod'
 import { fromZodError } from 'zod-validation-error'
 import type { Conflict } from '@dotcom-tool-kit/conflict'
@@ -50,18 +56,35 @@ You must resolve this conflict by explicitly configuring which task to run for t
 
 `
 
-const formatOptionConflict = (conflict: Conflict<OptionsForPlugin>): string => `${s.plugin(
+const formatPluginOptionConflict = (conflict: Conflict<OptionsForPlugin>): string => `${s.plugin(
   conflict.conflicting[0].forPlugin.id
 )}, configured by:
 ${conflict.conflicting.map((option) => `- ${s.plugin(option.plugin.id)}`)}`
 
-export const formatOptionConflicts = (conflicts: Conflict<OptionsForPlugin>[]): string => `${s.heading(
+export const formatPluginOptionConflicts = (conflicts: Conflict<OptionsForPlugin>[]): string => `${s.heading(
   'These plugins have conflicting options'
 )}:
 
-${conflicts.map(formatOptionConflict).join('\n')}
+${conflicts.map(formatPluginOptionConflict).join('\n')}
 
 You must resolve this conflict by providing options in your app's Tool Kit configuration for these plugins, or installing a use-case plugin that provides these options. See ${s.URL(
+  'https://github.com/financial-times/dotcom-tool-kit/tree/main/readme.md#options'
+)} for more details.
+
+`
+
+const formatTaskOptionConflict = (conflict: Conflict<OptionsForTask>): string => `${s.task(
+  conflict.conflicting[0].task
+)}, configured by:
+${conflict.conflicting.map((option) => `- ${s.plugin(option.plugin.id)}`)}`
+
+export const formatTaskOptionConflicts = (conflicts: Conflict<OptionsForTask>[]): string => `${s.heading(
+  'These tasks have conflicting options'
+)}:
+
+${conflicts.map(formatTaskOptionConflict).join('\n')}
+
+You must resolve this conflict by providing options in your app's Tool Kit configuration for these tasks, or installing a use-case plugin that provides these options. See ${s.URL(
   'https://github.com/financial-times/dotcom-tool-kit/tree/main/readme.md#options'
 )} for more details.
 
@@ -100,7 +123,7 @@ ${invalidOptions
 Please update the options so that they are the expected types. You can refer to the README for the plugin for examples and descriptions of the options used.
 `
 
-export const formatUnusedOptions = (
+export const formatUnusedPluginOptions = (
   unusedOptions: string[],
   definedPlugins: string[]
 ): string => `Options are defined in your Tool Kit configuration for plugins that don't exist:
@@ -113,6 +136,22 @@ ${
   definedPlugins.length > 0
     ? `Plugins that are defined and can have options set are: ${definedPlugins.map(s.plugin).join(', ')}`
     : `There are no plugins installed currently. You'll need to install some plugins before options can be set.`
+}.
+`
+
+export const formatUnusedTaskOptions = (
+  unusedOptions: string[],
+  definedTasks: string[]
+): string => `Options are defined in your Tool Kit configuration for tasks that don't exist:
+
+${unusedOptions.map((optionName) => `- ${s.task(optionName)}`).join('\n')}
+
+They could be misspelt, or defined by a Tool Kit plugin that isn't installed in this app.
+
+${
+  definedTasks.length > 0
+    ? `Task that are defined and can have options set are: ${definedTasks.map(s.task).join(', ')}`
+    : `You don't have currently any plugins installed that provide tasks. You'll need to install some plugins before options can be set.`
 }.
 `
 

--- a/core/cli/src/messages.ts
+++ b/core/cli/src/messages.ts
@@ -1,6 +1,6 @@
 import { styles as s, styles } from '@dotcom-tool-kit/logger'
 import type { Hook } from '@dotcom-tool-kit/base'
-import type { CommandTask, EntryPoint, Plugin, PluginOptions } from '@dotcom-tool-kit/plugin'
+import type { CommandTask, EntryPoint, Plugin, OptionsForPlugin } from '@dotcom-tool-kit/plugin'
 import type { z } from 'zod'
 import { fromZodError } from 'zod-validation-error'
 import type { Conflict } from '@dotcom-tool-kit/conflict'
@@ -50,12 +50,12 @@ You must resolve this conflict by explicitly configuring which task to run for t
 
 `
 
-const formatOptionConflict = (conflict: Conflict<PluginOptions>): string => `${s.plugin(
+const formatOptionConflict = (conflict: Conflict<OptionsForPlugin>): string => `${s.plugin(
   conflict.conflicting[0].forPlugin.id
 )}, configured by:
 ${conflict.conflicting.map((option) => `- ${s.plugin(option.plugin.id)}`)}`
 
-export const formatOptionConflicts = (conflicts: Conflict<PluginOptions>[]): string => `${s.heading(
+export const formatOptionConflicts = (conflicts: Conflict<OptionsForPlugin>[]): string => `${s.heading(
   'These plugins have conflicting options'
 )}:
 

--- a/core/cli/src/plugin.ts
+++ b/core/cli/src/plugin.ts
@@ -6,11 +6,11 @@ import resolvePkg from 'resolve-pkg'
 import type { Logger } from 'winston'
 import { loadToolKitRC } from './rc-file'
 import { indentReasons } from './messages'
-import { mergePluginTasks } from './plugin/merge-tasks'
-import { mergePluginHooks } from './plugin/merge-hooks'
-import { mergePluginCommands } from './plugin/merge-commands'
+import { mergeTasks } from './plugin/merge-tasks'
+import { mergeHooks } from './plugin/merge-hooks'
+import { mergeCommands } from './plugin/merge-commands'
 import { mergePluginOptions } from './plugin/merge-plugin-options'
-import { mergePluginInits } from './plugin/merge-inits'
+import { mergeInits } from './plugin/merge-inits'
 import { mergeTaskOptions } from './plugin/merge-task-options'
 
 export async function loadPlugin(
@@ -75,12 +75,12 @@ export function resolvePlugin(plugin: Plugin, config: ValidPluginsConfig, logger
     }
   }
 
-  mergePluginTasks(config, plugin)
-  mergePluginHooks(config, plugin)
-  mergePluginCommands(config, plugin)
+  mergeTasks(config, plugin)
+  mergeHooks(config, plugin)
+  mergeCommands(config, plugin)
   mergePluginOptions(config, plugin)
   mergeTaskOptions(config, plugin)
-  mergePluginInits(config, plugin)
+  mergeInits(config, plugin)
 
   config.resolvedPlugins.add(plugin.id)
 }

--- a/core/cli/src/plugin.ts
+++ b/core/cli/src/plugin.ts
@@ -9,8 +9,9 @@ import { indentReasons } from './messages'
 import { mergePluginTasks } from './plugin/merge-tasks'
 import { mergePluginHooks } from './plugin/merge-hooks'
 import { mergePluginCommands } from './plugin/merge-commands'
-import { mergePluginOptions } from './plugin/merge-options'
+import { mergePluginOptions } from './plugin/merge-plugin-options'
 import { mergePluginInits } from './plugin/merge-inits'
+import { mergeTaskOptions } from './plugin/merge-task-options'
 
 export async function loadPlugin(
   id: string,
@@ -78,6 +79,7 @@ export function resolvePlugin(plugin: Plugin, config: ValidPluginsConfig, logger
   mergePluginHooks(config, plugin)
   mergePluginCommands(config, plugin)
   mergePluginOptions(config, plugin)
+  mergeTaskOptions(config, plugin)
   mergePluginInits(config, plugin)
 
   config.resolvedPlugins.add(plugin.id)

--- a/core/cli/src/plugin/merge-commands.ts
+++ b/core/cli/src/plugin/merge-commands.ts
@@ -3,7 +3,7 @@ import type { ValidPluginsConfig } from '@dotcom-tool-kit/config'
 import { Conflict, isConflict } from '@dotcom-tool-kit/conflict'
 import { isDescendent } from './is-descendent'
 
-export const mergePluginCommands = (config: ValidPluginsConfig, plugin: Plugin) => {
+export const mergeCommands = (config: ValidPluginsConfig, plugin: Plugin) => {
   if (plugin.rcFile) {
     for (const [id, configCommandTask] of Object.entries(plugin.rcFile.commands)) {
       // handle conflicts between commands from different plugins

--- a/core/cli/src/plugin/merge-hooks.ts
+++ b/core/cli/src/plugin/merge-hooks.ts
@@ -2,7 +2,7 @@ import type { EntryPoint, Plugin } from '@dotcom-tool-kit/plugin'
 import type { ValidPluginsConfig } from '@dotcom-tool-kit/config'
 import { isConflict } from '@dotcom-tool-kit/conflict'
 
-export const mergePluginHooks = (config: ValidPluginsConfig, plugin: Plugin) => {
+export const mergeHooks = (config: ValidPluginsConfig, plugin: Plugin) => {
   if (plugin.rcFile) {
     // add hooks to the registry, handling any conflicts
     // TODO refactor with command conflict handler

--- a/core/cli/src/plugin/merge-inits.ts
+++ b/core/cli/src/plugin/merge-inits.ts
@@ -1,7 +1,7 @@
 import type { Plugin } from '@dotcom-tool-kit/plugin'
 import type { ValidPluginsConfig } from '@dotcom-tool-kit/config'
 
-export const mergePluginInits = (config: ValidPluginsConfig, plugin: Plugin) => {
+export const mergeInits = (config: ValidPluginsConfig, plugin: Plugin) => {
   if (plugin.rcFile) {
     // no conflict resolution needed; we'll just run them all ig
     config.inits.push(

--- a/core/cli/src/plugin/merge-options.ts
+++ b/core/cli/src/plugin/merge-options.ts
@@ -7,7 +7,7 @@ import { Conflict, isConflict } from '@dotcom-tool-kit/conflict'
 // TODO this is almost the exact same code as for command tasks, refactor
 export const mergePluginOptions = (config: ValidPluginsConfig, plugin: Plugin) => {
   if (plugin.rcFile) {
-    for (const [id, configOptions] of Object.entries(plugin.rcFile.options)) {
+    for (const [id, configOptions] of Object.entries(plugin.rcFile.options.plugins ?? {})) {
       // users can specify root options with the dotcom-tool-kit key to mirror
       // the name of the root npm package
       const pluginId = id === 'dotcom-tool-kit' ? 'app root' : id

--- a/core/cli/src/plugin/merge-options.ts
+++ b/core/cli/src/plugin/merge-options.ts
@@ -1,4 +1,4 @@
-import type { Plugin, PluginOptions } from '@dotcom-tool-kit/plugin'
+import type { Plugin, OptionsForPlugin } from '@dotcom-tool-kit/plugin'
 import type { ValidPluginsConfig } from '@dotcom-tool-kit/config'
 import { isDescendent } from './is-descendent'
 import { Conflict, isConflict } from '@dotcom-tool-kit/conflict'
@@ -13,7 +13,7 @@ export const mergePluginOptions = (config: ValidPluginsConfig, plugin: Plugin) =
       const pluginId = id === 'dotcom-tool-kit' ? 'app root' : id
       const existingOptions = config.pluginOptions[pluginId]
 
-      const pluginOptions: PluginOptions = {
+      const pluginOptions: OptionsForPlugin = {
         options: configOptions,
         plugin,
         forPlugin: config.plugins[pluginId]
@@ -28,7 +28,7 @@ export const mergePluginOptions = (config: ValidPluginsConfig, plugin: Plugin) =
         if (!existingFromDescendent) {
           const conflicting = isConflict(existingOptions) ? existingOptions.conflicting : [existingOptions]
 
-          const conflict: Conflict<PluginOptions> = {
+          const conflict: Conflict<OptionsForPlugin> = {
             plugin,
             conflicting: conflicting.concat(pluginOptions)
           }

--- a/core/cli/src/plugin/merge-options.ts
+++ b/core/cli/src/plugin/merge-options.ts
@@ -11,7 +11,7 @@ export const mergePluginOptions = (config: ValidPluginsConfig, plugin: Plugin) =
       // users can specify root options with the dotcom-tool-kit key to mirror
       // the name of the root npm package
       const pluginId = id === 'dotcom-tool-kit' ? 'app root' : id
-      const existingOptions = config.options[pluginId]
+      const existingOptions = config.pluginOptions[pluginId]
 
       const pluginOptions: PluginOptions = {
         options: configOptions,
@@ -33,15 +33,15 @@ export const mergePluginOptions = (config: ValidPluginsConfig, plugin: Plugin) =
             conflicting: conflicting.concat(pluginOptions)
           }
 
-          config.options[pluginId] = conflict
+          config.pluginOptions[pluginId] = conflict
         } else {
           // if we're here, any existing options are from a child plugin,
           // so merge in overrides from the parent
-          config.options[pluginId] = { ...existingOptions, ...pluginOptions }
+          config.pluginOptions[pluginId] = { ...existingOptions, ...pluginOptions }
         }
       } else {
         // this options key might not have been set yet, in which case use the new one
-        config.options[pluginId] = pluginOptions
+        config.pluginOptions[pluginId] = pluginOptions
       }
     }
   }

--- a/core/cli/src/plugin/merge-plugin-options.ts
+++ b/core/cli/src/plugin/merge-plugin-options.ts
@@ -7,7 +7,7 @@ import { Conflict, isConflict } from '@dotcom-tool-kit/conflict'
 // TODO this is almost the exact same code as for command tasks, refactor
 export const mergePluginOptions = (config: ValidPluginsConfig, plugin: Plugin) => {
   if (plugin.rcFile) {
-    for (const [id, configOptions] of Object.entries(plugin.rcFile.options.plugins ?? {})) {
+    for (const [id, configOptions] of Object.entries(plugin.rcFile.options.plugins)) {
       // users can specify root options with the dotcom-tool-kit key to mirror
       // the name of the root npm package
       const pluginId = id === 'dotcom-tool-kit' ? 'app root' : id

--- a/core/cli/src/plugin/merge-task-options.ts
+++ b/core/cli/src/plugin/merge-task-options.ts
@@ -1,0 +1,46 @@
+import type { Plugin, OptionsForTask } from '@dotcom-tool-kit/plugin'
+import type { ValidPluginsConfig } from '@dotcom-tool-kit/config'
+import { type Conflict, isConflict } from '@dotcom-tool-kit/conflict'
+
+import { isDescendent } from './is-descendent'
+
+// merge options from this plugin's config with any options we've collected already
+// TODO this is almost the exact same code as for command tasks, refactor
+export const mergeTaskOptions = (config: ValidPluginsConfig, plugin: Plugin) => {
+  if (plugin.rcFile) {
+    for (const [taskId, configOptions] of Object.entries(plugin.rcFile.options.tasks)) {
+      const existingOptions = config.taskOptions[taskId]
+
+      const taskOptions: OptionsForTask = {
+        options: configOptions,
+        plugin,
+        task: taskId
+      }
+
+      if (existingOptions) {
+        const existingFromDescendent = isDescendent(plugin, existingOptions.plugin)
+
+        // plugins can only override options from their descendents, otherwise it's a conflict
+        // return a conflict either listing these options and the sibling's,
+        // or merging in previously-generated options
+        if (!existingFromDescendent) {
+          const conflicting = isConflict(existingOptions) ? existingOptions.conflicting : [existingOptions]
+
+          const conflict: Conflict<OptionsForTask> = {
+            plugin,
+            conflicting: conflicting.concat(taskOptions)
+          }
+
+          config.taskOptions[taskId] = conflict
+        } else {
+          // if we're here, any existing options are from a child plugin,
+          // so merge in overrides from the parent
+          config.taskOptions[taskId] = { ...existingOptions, ...taskOptions }
+        }
+      } else {
+        // this options key might not have been set yet, in which case use the new one
+        config.taskOptions[taskId] = taskOptions
+      }
+    }
+  }
+}

--- a/core/cli/src/plugin/merge-tasks.ts
+++ b/core/cli/src/plugin/merge-tasks.ts
@@ -1,9 +1,9 @@
-import type{ EntryPoint, Plugin } from '@dotcom-tool-kit/plugin'
+import type { EntryPoint, Plugin } from '@dotcom-tool-kit/plugin'
 import type { ValidPluginsConfig } from '@dotcom-tool-kit/config'
 import { isConflict } from '@dotcom-tool-kit/conflict'
 
 // add plugin tasks to our task registry, handling any conflicts
-export const mergePluginTasks = (config: ValidPluginsConfig, plugin: Plugin) => {
+export const mergeTasks = (config: ValidPluginsConfig, plugin: Plugin) => {
   if (plugin.rcFile) {
     for (const [taskName, modulePath] of Object.entries(plugin.rcFile.tasks || {})) {
       const existingTaskId = config.tasks[taskName]

--- a/core/cli/src/plugin/options.ts
+++ b/core/cli/src/plugin/options.ts
@@ -1,6 +1,6 @@
 import { ValidPluginsConfig } from '@dotcom-tool-kit/config'
 import { InvalidOption } from '../messages'
-import { SchemaOptions, PluginSchemas } from '@dotcom-tool-kit/schemas'
+import { type PluginOptions, PluginSchemas } from '@dotcom-tool-kit/schemas'
 import { isConflict } from '@dotcom-tool-kit/conflict'
 import type { Logger } from 'winston'
 
@@ -8,7 +8,7 @@ export const validatePluginOptions = (logger: Logger, config: ValidPluginsConfig
   const invalidOptions: InvalidOption[] = []
 
   for (const [id, plugin] of Object.entries(config.plugins)) {
-    const pluginId = id as keyof SchemaOptions
+    const pluginId = id as keyof PluginOptions
     const pluginOptions = config.pluginOptions[pluginId]
     if (pluginOptions && isConflict(pluginOptions)) {
       continue

--- a/core/cli/src/plugin/options.ts
+++ b/core/cli/src/plugin/options.ts
@@ -9,7 +9,7 @@ export const validatePluginOptions = (logger: Logger, config: ValidPluginsConfig
 
   for (const [id, plugin] of Object.entries(config.plugins)) {
     const pluginId = id as keyof SchemaOptions
-    const pluginOptions = config.options[pluginId]
+    const pluginOptions = config.pluginOptions[pluginId]
     if (pluginOptions && isConflict(pluginOptions)) {
       continue
     }
@@ -28,7 +28,7 @@ export const validatePluginOptions = (logger: Logger, config: ValidPluginsConfig
         // `Foo<a | b | c>` and the other as `Foo<a> | Foo<b> | Foo<c>` for
         // some reason (something to do with the record indexing) and it can't
         // unify them. But they are equivalent so let's force it with a cast.
-        config.options[pluginId] = {
+        config.pluginOptions[pluginId] = {
           options: result.data,
           plugin: config.plugins['app root'],
           forPlugin: plugin

--- a/core/cli/src/plugin/options.ts
+++ b/core/cli/src/plugin/options.ts
@@ -24,15 +24,11 @@ export const validatePluginOptions = (logger: Logger, config: ValidPluginsConfig
       // Set up options entry for plugins that don't have options specified
       // explicitly. They could still have default options that are set by zod.
       if (!pluginOptions) {
-        // TypeScript struggles with this type as it sees one side as
-        // `Foo<a | b | c>` and the other as `Foo<a> | Foo<b> | Foo<c>` for
-        // some reason (something to do with the record indexing) and it can't
-        // unify them. But they are equivalent so let's force it with a cast.
         config.pluginOptions[pluginId] = {
           options: result.data,
           plugin: config.plugins['app root'],
           forPlugin: plugin
-        } as any // eslint-disable-line @typescript-eslint/no-explicit-any
+        }
       } else {
         pluginOptions.options = result.data
       }

--- a/core/cli/src/rc-file.ts
+++ b/core/cli/src/rc-file.ts
@@ -10,7 +10,7 @@ const emptyConfig = {
   installs: {},
   tasks: {},
   commands: {},
-  options: { plugins: {} },
+  options: { plugins: {}, tasks: {} },
   hooks: [],
   init: []
 } satisfies RCFile
@@ -50,7 +50,9 @@ export async function loadToolKitRC(logger: Logger, root: string, isAppRoot: boo
     installs: config.installs ?? {},
     tasks: config.tasks ?? {},
     commands: config.commands ?? {},
-    options: config.options ? { plugins: config.options.plugins ?? {} } : { plugins: {} },
+    options: config.options
+      ? { plugins: config.options.plugins ?? {}, tasks: config.options.tasks ?? {} }
+      : { plugins: {}, tasks: {} },
     hooks: config.hooks ?? [],
     init: config.init ?? []
   }

--- a/core/cli/src/rc-file.ts
+++ b/core/cli/src/rc-file.ts
@@ -5,11 +5,23 @@ import * as path from 'path'
 import type { Logger } from 'winston'
 
 export const explorer = cosmiconfig('toolkit', { ignoreEmptySearchPlaces: false })
-const emptyConfig = { plugins: [], installs: {}, tasks: {}, commands: {}, options: {}, hooks: [], init: [] }
+const emptyConfig = {
+  plugins: [],
+  installs: {},
+  tasks: {},
+  commands: {},
+  options: { plugins: {} },
+  hooks: [],
+  init: []
+} satisfies RCFile
 let rootConfig: string | undefined
 
 type RawRCFile = {
-  [key in keyof RCFile]?: RCFile[key] | null
+  [key in Exclude<keyof RCFile, 'options'>]?: RCFile[key] | null
+} & {
+  options: {
+    [key in keyof RCFile['options']]?: RCFile['options'][key] | null
+  }
 }
 
 export async function loadToolKitRC(logger: Logger, root: string, isAppRoot: boolean): Promise<RCFile> {
@@ -38,7 +50,7 @@ export async function loadToolKitRC(logger: Logger, root: string, isAppRoot: boo
     installs: config.installs ?? {},
     tasks: config.tasks ?? {},
     commands: config.commands ?? {},
-    options: config.options ?? {},
+    options: config.options ? { plugins: config.options.plugins ?? {} } : { plugins: {} },
     hooks: config.hooks ?? [],
     init: config.init ?? []
   }

--- a/core/cli/src/tasks.ts
+++ b/core/cli/src/tasks.ts
@@ -59,7 +59,7 @@ ${availableCommands}`
     throw error
   }
 
-  for (const pluginOptions of Object.values(config.options)) {
+  for (const pluginOptions of Object.values(config.pluginOptions)) {
     if (pluginOptions.forPlugin) {
       setOptions(pluginOptions.forPlugin.id as OptionKey, pluginOptions.options)
     }

--- a/core/cli/test/files/conflict-resolution/.toolkitrc.yml
+++ b/core/cli/test/files/conflict-resolution/.toolkitrc.yml
@@ -5,17 +5,18 @@ plugins:
   - '@dotcom-tool-kit/heroku' # for build:remote hook and build:local via npm plugin
 
 options:
-  '@dotcom-tool-kit/heroku':
-    pipeline: tool-kit-test
-    systemCode: tool-kit-test
-    scaling:
-      tool-kit-test:
-        web:
-          size: standard-1x
-          quantity: 1
-  '@dotcom-tool-kit/vault':
-    team: platforms
-    app: tool-kit-test
+  plugins:
+    '@dotcom-tool-kit/heroku':
+      pipeline: tool-kit-test
+      systemCode: tool-kit-test
+      scaling:
+        tool-kit-test:
+          web:
+            size: standard-1x
+            quantity: 1
+    '@dotcom-tool-kit/vault':
+      team: platforms
+      app: tool-kit-test
 
 commands:
   build:local:

--- a/core/cli/test/files/duplicate/.toolkitrc.yml
+++ b/core/cli/test/files/duplicate/.toolkitrc.yml
@@ -3,16 +3,17 @@ plugins:
   - '@dotcom-tool-kit/heroku'
 
 options:
-  '@dotcom-tool-kit/heroku':
-    pipeline: tool-kit-test
-    systemCode: tool-kit-test
-    scaling:
-      tool-kit-test:
-        web:
-          size: standard-1x
-          quantity: 1
-  '@dotcom-tool-kit/vault':
-    team: platforms
-    app: tool-kit-test
+  plugins:
+    '@dotcom-tool-kit/heroku':
+      pipeline: tool-kit-test
+      systemCode: tool-kit-test
+      scaling:
+        tool-kit-test:
+          web:
+            size: standard-1x
+            quantity: 1
+    '@dotcom-tool-kit/vault':
+      team: platforms
+      app: tool-kit-test
 
 commands:

--- a/core/cli/test/files/successful/.toolkitrc.yml
+++ b/core/cli/test/files/successful/.toolkitrc.yml
@@ -5,13 +5,14 @@ plugins:
   - '@dotcom-tool-kit/circleci-deploy' # test:local hook via npm plugin and test:ci hook
 
 options:
-  '@dotcom-tool-kit/eslint':
-    files:
-      - webpack.config.js
-  '@dotcom-tool-kit/mocha':
-    testDir: './mocha_tests'
-  '@dotcom-tool-kit/n-test':
-    host: 'https://example.com'
+  plugins:
+    '@dotcom-tool-kit/eslint':
+      files:
+        - webpack.config.js
+    '@dotcom-tool-kit/mocha':
+      testDir: './mocha_tests'
+    '@dotcom-tool-kit/n-test':
+      host: 'https://example.com'
 
 commands:
   'test:local':

--- a/core/create/src/index.ts
+++ b/core/create/src/index.ts
@@ -116,7 +116,7 @@ async function main() {
     installs: {},
     tasks: {},
     commands: {},
-    options: {},
+    options: { plugins: {} },
     hooks: [],
     init: []
   }

--- a/core/create/src/index.ts
+++ b/core/create/src/index.ts
@@ -116,7 +116,7 @@ async function main() {
     installs: {},
     tasks: {},
     commands: {},
-    options: { plugins: {} },
+    options: { plugins: {}, tasks: {} },
     hooks: [],
     init: []
   }

--- a/core/create/src/prompts/oidc.ts
+++ b/core/create/src/prompts/oidc.ts
@@ -256,8 +256,8 @@ export default async function oidcPrompt({ toolKitConfig }: OidcParams): Promise
         // Kit vault plugin options. The class tries to read the options from
         // the global options object so let's set these options based on what's
         // been selected during the options prompt.
-        setOptions('@dotcom-tool-kit/vault', toolKitConfig.options['@dotcom-tool-kit/vault'])
-        setOptions('@dotcom-tool-kit/doppler', toolKitConfig.options['@dotcom-tool-kit/doppler'])
+        setOptions('@dotcom-tool-kit/vault', toolKitConfig.options.plugins['@dotcom-tool-kit/vault'])
+        setOptions('@dotcom-tool-kit/doppler', toolKitConfig.options.plugins['@dotcom-tool-kit/doppler'])
         const dopplerProjectName = new DopplerEnvVars(winstonLogger, 'prod').options.project
         const ssmAction = 'ssm:GetParameter'
         const ssmResource = `arn:aws:ssm:eu-west-1:\${AWS::AccountId}:parameter/${dopplerProjectName}/*`

--- a/core/create/src/prompts/options.ts
+++ b/core/create/src/prompts/options.ts
@@ -51,7 +51,7 @@ async function optionsPromptForPlugin(
             { onCancel }
           )
           if (stringOption !== '') {
-            toolKitConfig.options[plugin][optionName] = stringOption
+            toolKitConfig.options.plugins[plugin][optionName] = stringOption
           }
           break
         case 'ZodBoolean':
@@ -67,7 +67,7 @@ async function optionsPromptForPlugin(
             },
             { onCancel }
           )
-          toolKitConfig.options[plugin][optionName] = boolOption
+          toolKitConfig.options.plugins[plugin][optionName] = boolOption
           break
         case 'ZodNumber':
           const { numberOption } = await prompt(
@@ -80,7 +80,7 @@ async function optionsPromptForPlugin(
             { onCancel }
           )
           if (numberOption !== '') {
-            toolKitConfig.options[plugin][optionName] = Number.parseFloat(numberOption)
+            toolKitConfig.options.plugins[plugin][optionName] = Number.parseFloat(numberOption)
           }
           break
         case 'ZodArray':
@@ -98,7 +98,9 @@ async function optionsPromptForPlugin(
                 { onCancel }
               )
               if (stringArrayOption !== '' && stringArrayOption !== undefined) {
-                toolKitConfig.options[plugin][optionName] = stringArrayOption.split(',').map((s) => s.trim())
+                toolKitConfig.options.plugins[plugin][optionName] = stringArrayOption
+                  .split(',')
+                  .map((s) => s.trim())
               }
               break
             case 'ZodNumber':
@@ -113,7 +115,7 @@ async function optionsPromptForPlugin(
                 { onCancel }
               )
               if (numberArrayOption !== '' && numberArrayOption !== undefined) {
-                toolKitConfig.options[plugin][optionName] = numberArrayOption
+                toolKitConfig.options.plugins[plugin][optionName] = numberArrayOption
                   .split(',')
                   .map((s) => Number.parseFloat(s.trim()))
               }
@@ -135,7 +137,7 @@ async function optionsPromptForPlugin(
                 { onCancel }
               )
               if (option !== '') {
-                toolKitConfig.options[plugin][optionName] = option
+                toolKitConfig.options.plugins[plugin][optionName] = option
               }
               break
           }
@@ -154,7 +156,7 @@ async function optionsPromptForPlugin(
             { onCancel }
           )
           if (option !== '') {
-            toolKitConfig.options[plugin][optionName] = option
+            toolKitConfig.options.plugins[plugin][optionName] = option
           }
           break
         case 'ZodUnion':
@@ -199,6 +201,8 @@ export default async ({
   configPath,
   bizOpsSystem
 }: OptionsParams): Promise<boolean> => {
+  toolKitConfig.options.plugins = {}
+
   for (const plugin of Object.keys(config.plugins)) {
     let options: z.AnyZodObject
     let generators: PromptGenerators<z.AnyZodObject> | undefined
@@ -224,7 +228,6 @@ export default async ({
     const anyRequired = required.length > 0
 
     const styledPlugin = styles.plugin(pluginName)
-    toolKitConfig.options[plugin] = {}
 
     if (anyRequired) {
       winstonLogger.info(`Please now configure the options for the ${styledPlugin} plugin.`)
@@ -238,7 +241,7 @@ export default async ({
            * the object is partial because not all options for a plugin will
            * have generators, but all values in the record will be defined
            **/
-          toolKitConfig.options[plugin][optionName] = await generator!(
+          toolKitConfig.options.plugins![plugin][optionName] = await generator!(
             winstonLogger.child({ plugin }),
             prompt,
             onCancel,
@@ -256,12 +259,12 @@ export default async ({
           plugin,
           required
             .map(([name, type]) => ({ name, type }))
-            .filter(({ name }) => !toolKitConfig.options[plugin][name])
+            .filter(({ name }) => !toolKitConfig.options.plugins[plugin][name])
         )
       }
 
       if (cancelled) {
-        delete toolKitConfig.options[plugin]
+        delete toolKitConfig.options.plugins[plugin]
         return true
       }
     }
@@ -286,7 +289,7 @@ export default async ({
           })
         )
       } else if (!anyRequired) {
-        delete toolKitConfig.options[plugin]
+        delete toolKitConfig.options.plugins[plugin]
       }
     }
   }

--- a/docs/developing-tool-kit.md
+++ b/docs/developing-tool-kit.md
@@ -138,7 +138,7 @@ To avoid boilerplate for tasks (the most common use case for options), when defi
 import { Task } from '@dotcom-tool-kit/types'
 import { ESLintOptions, ESLintSchema } from '@dotcom-tool-kit/schemas/lib/plugins/eslint'
 
-export default class Eslint extends Task<typeof ESLintSchema> {
+export default class Eslint extends Task<{ plugin: typeof ESLintSchema }> {
   static description = ''
 
   async run(): Promise<void> {

--- a/lib/base/src/task.ts
+++ b/lib/base/src/task.ts
@@ -3,9 +3,8 @@ import { Base } from './base'
 import { taskSymbol, typeSymbol } from './symbols'
 import type { Logger } from 'winston'
 
-export abstract class Task<O extends z.ZodTypeAny = z.ZodTypeAny> extends Base {
+export abstract class Task<PluginOptions extends z.ZodTypeAny = z.ZodTypeAny> extends Base {
   static description: string
-  id: string
 
   static get [typeSymbol](): symbol {
     return taskSymbol
@@ -15,14 +14,14 @@ export abstract class Task<O extends z.ZodTypeAny = z.ZodTypeAny> extends Base {
     return taskSymbol
   }
 
-  options: z.output<O>
   logger: Logger
 
-  constructor(logger: Logger, id: string, options: z.output<O>) {
+  constructor(
+    logger: Logger,
+    public id: string,
+    public pluginOptions: z.output<PluginOptions>
+  ) {
     super()
-
-    this.id = id
-    this.options = options
     this.logger = logger.child({ task: id })
   }
 

--- a/lib/base/src/task.ts
+++ b/lib/base/src/task.ts
@@ -26,8 +26,8 @@ export abstract class Task<
   constructor(
     logger: Logger,
     public id: string,
-    public pluginOptions: z.output<Default<Options['plugin'], z.ZodTypeAny>>,
-    public options: z.output<Default<Options['task'], z.ZodTypeAny>>
+    public pluginOptions: z.output<Default<Options['plugin'], z.ZodObject<Record<string, never>>>>,
+    public options: z.output<Default<Options['task'], z.ZodObject<Record<string, never>>>>
   ) {
     super()
     this.logger = logger.child({ task: id })

--- a/lib/config/src/index.ts
+++ b/lib/config/src/index.ts
@@ -1,5 +1,5 @@
 import type { Validated } from '@dotcom-tool-kit/validated'
-import type { EntryPoint, CommandTask, PluginOptions, Plugin } from '@dotcom-tool-kit/plugin'
+import type { EntryPoint, CommandTask, OptionsForPlugin, Plugin } from '@dotcom-tool-kit/plugin'
 import type { SchemaOptions } from '@dotcom-tool-kit/schemas'
 import type { Conflict } from '@dotcom-tool-kit/conflict'
 
@@ -9,7 +9,7 @@ export interface RawConfig {
   resolvedPlugins: Set<string>
   tasks: { [id: string]: EntryPoint | Conflict<EntryPoint> }
   commandTasks: { [id: string]: CommandTask | Conflict<CommandTask> }
-  pluginOptions: { [id: string]: PluginOptions | Conflict<PluginOptions> | undefined }
+  pluginOptions: { [id: string]: OptionsForPlugin | Conflict<OptionsForPlugin> | undefined }
   hooks: { [id: string]: EntryPoint | Conflict<EntryPoint> }
   inits: EntryPoint[]
 }
@@ -18,7 +18,7 @@ export type ValidPluginsConfig = Omit<RawConfig, 'plugins'> & {
   plugins: { [id: string]: Plugin }
 }
 
-export type ValidPluginOptions<Id extends keyof SchemaOptions> = Omit<PluginOptions, 'options'> & {
+export type ValidPluginOptions<Id extends keyof SchemaOptions> = Omit<OptionsForPlugin, 'options'> & {
   options: SchemaOptions[Id]
 }
 

--- a/lib/config/src/index.ts
+++ b/lib/config/src/index.ts
@@ -9,7 +9,7 @@ export interface RawConfig {
   resolvedPlugins: Set<string>
   tasks: { [id: string]: EntryPoint | Conflict<EntryPoint> }
   commandTasks: { [id: string]: CommandTask | Conflict<CommandTask> }
-  options: { [id: string]: PluginOptions | Conflict<PluginOptions> | undefined }
+  pluginOptions: { [id: string]: PluginOptions | Conflict<PluginOptions> | undefined }
   hooks: { [id: string]: EntryPoint | Conflict<EntryPoint> }
   inits: EntryPoint[]
 }
@@ -26,9 +26,9 @@ export type ValidOptions = {
   [Id in keyof SchemaOptions]: ValidPluginOptions<Id>
 }
 
-export type ValidConfig = Omit<ValidPluginsConfig, 'tasks' | 'commandTasks' | 'options' | 'hooks'> & {
+export type ValidConfig = Omit<ValidPluginsConfig, 'tasks' | 'commandTasks' | 'pluginOptions' | 'hooks'> & {
   tasks: { [id: string]: EntryPoint }
   commandTasks: { [id: string]: CommandTask }
-  options: ValidOptions
+  pluginOptions: ValidOptions
   hooks: { [id: string]: EntryPoint }
 }

--- a/lib/config/src/index.ts
+++ b/lib/config/src/index.ts
@@ -1,6 +1,6 @@
 import type { Validated } from '@dotcom-tool-kit/validated'
 import type { EntryPoint, CommandTask, OptionsForPlugin, Plugin } from '@dotcom-tool-kit/plugin'
-import type { SchemaOptions } from '@dotcom-tool-kit/schemas'
+import type { PluginOptions } from '@dotcom-tool-kit/schemas'
 import type { Conflict } from '@dotcom-tool-kit/conflict'
 
 export interface RawConfig {
@@ -18,12 +18,12 @@ export type ValidPluginsConfig = Omit<RawConfig, 'plugins'> & {
   plugins: { [id: string]: Plugin }
 }
 
-export type ValidPluginOptions<Id extends keyof SchemaOptions> = Omit<OptionsForPlugin, 'options'> & {
-  options: SchemaOptions[Id]
+export type ValidPluginOptions<Id extends keyof PluginOptions> = Omit<OptionsForPlugin, 'options'> & {
+  options: PluginOptions[Id]
 }
 
 export type ValidOptions = {
-  [Id in keyof SchemaOptions]: ValidPluginOptions<Id>
+  [Id in keyof PluginOptions]: ValidPluginOptions<Id>
 }
 
 export type ValidConfig = Omit<ValidPluginsConfig, 'tasks' | 'commandTasks' | 'pluginOptions' | 'hooks'> & {

--- a/lib/config/src/index.ts
+++ b/lib/config/src/index.ts
@@ -1,5 +1,11 @@
 import type { Validated } from '@dotcom-tool-kit/validated'
-import type { EntryPoint, CommandTask, OptionsForPlugin, Plugin } from '@dotcom-tool-kit/plugin'
+import type {
+  CommandTask,
+  EntryPoint,
+  Plugin,
+  OptionsForPlugin,
+  OptionsForTask
+} from '@dotcom-tool-kit/plugin'
 import type { PluginOptions } from '@dotcom-tool-kit/schemas'
 import type { Conflict } from '@dotcom-tool-kit/conflict'
 
@@ -10,6 +16,7 @@ export interface RawConfig {
   tasks: { [id: string]: EntryPoint | Conflict<EntryPoint> }
   commandTasks: { [id: string]: CommandTask | Conflict<CommandTask> }
   pluginOptions: { [id: string]: OptionsForPlugin | Conflict<OptionsForPlugin> | undefined }
+  taskOptions: { [id: string]: OptionsForTask | Conflict<OptionsForTask> | undefined }
   hooks: { [id: string]: EntryPoint | Conflict<EntryPoint> }
   inits: EntryPoint[]
 }

--- a/lib/config/src/index.ts
+++ b/lib/config/src/index.ts
@@ -25,17 +25,21 @@ export type ValidPluginsConfig = Omit<RawConfig, 'plugins'> & {
   plugins: { [id: string]: Plugin }
 }
 
-export type ValidPluginOptions<Id extends keyof PluginOptions> = Omit<OptionsForPlugin, 'options'> & {
+export type ValidOptionsForPlugin<Id extends keyof PluginOptions> = Omit<OptionsForPlugin, 'options'> & {
   options: PluginOptions[Id]
 }
 
-export type ValidOptions = {
-  [Id in keyof PluginOptions]: ValidPluginOptions<Id>
+export type ValidPluginOptions = {
+  [Id in keyof PluginOptions]: ValidOptionsForPlugin<Id>
 }
 
-export type ValidConfig = Omit<ValidPluginsConfig, 'tasks' | 'commandTasks' | 'pluginOptions' | 'hooks'> & {
+export type ValidConfig = Omit<
+  ValidPluginsConfig,
+  'tasks' | 'commandTasks' | 'pluginOptions' | 'taskOptions' | 'hooks'
+> & {
   tasks: { [id: string]: EntryPoint }
   commandTasks: { [id: string]: CommandTask }
-  pluginOptions: ValidOptions
+  pluginOptions: ValidPluginOptions
+  taskOptions: { [id: string]: OptionsForTask }
   hooks: { [id: string]: EntryPoint }
 }

--- a/lib/options/src/index.ts
+++ b/lib/options/src/index.ts
@@ -1,11 +1,11 @@
-import type { SchemaOptions } from '@dotcom-tool-kit/schemas'
+import type { PluginOptions } from '@dotcom-tool-kit/schemas'
 
-const options: Partial<SchemaOptions> = {}
+const options: Partial<PluginOptions> = {}
 
-export type OptionKey = keyof SchemaOptions
+export type OptionKey = keyof PluginOptions
 
-export const getOptions = <T extends OptionKey>(plugin: T): SchemaOptions[T] | undefined => options[plugin]
+export const getOptions = <T extends OptionKey>(plugin: T): PluginOptions[T] | undefined => options[plugin]
 
-export const setOptions = <T extends OptionKey>(plugin: T, opts: SchemaOptions[T]): void => {
+export const setOptions = <T extends OptionKey>(plugin: T, opts: PluginOptions[T]): void => {
   options[plugin] = opts
 }

--- a/lib/plugin/src/index.ts
+++ b/lib/plugin/src/index.ts
@@ -22,7 +22,7 @@ export interface CommandTask {
   tasks: string[]
 }
 
-export interface PluginOptions {
+export interface OptionsForPlugin {
   options: Record<string, unknown>
   plugin: Plugin
   forPlugin: Plugin

--- a/lib/plugin/src/index.ts
+++ b/lib/plugin/src/index.ts
@@ -1,34 +1,34 @@
 export type RCFile = {
-	plugins: string[]
-	installs: { [id: string]: string }
-	tasks: { [id: string]: string }
-	commands: { [id: string]: string | string[] }
-	options: { [id: string]: Record<string, unknown> }
-	hooks: { [id: string]: Record<string, unknown> }[]
-	init: string[]
- }
+  plugins: string[]
+  installs: { [id: string]: string }
+  tasks: { [id: string]: string }
+  commands: { [id: string]: string | string[] }
+  options: { plugins: { [id: string]: Record<string, unknown> } }
+  hooks: { [id: string]: Record<string, unknown> }[]
+  init: string[]
+}
 
- export interface Plugin {
-	id: string
-	root: string
-	rcFile?: RCFile
-	parent?: Plugin
-	children?: Plugin[]
- }
+export interface Plugin {
+  id: string
+  root: string
+  rcFile?: RCFile
+  parent?: Plugin
+  children?: Plugin[]
+}
 
- export interface CommandTask {
-	id: string
-	plugin: Plugin
-	tasks: string[]
- }
+export interface CommandTask {
+  id: string
+  plugin: Plugin
+  tasks: string[]
+}
 
- export interface PluginOptions {
-	options: Record<string, unknown>
-	plugin: Plugin
-	forPlugin: Plugin
- }
+export interface PluginOptions {
+  options: Record<string, unknown>
+  plugin: Plugin
+  forPlugin: Plugin
+}
 
- export interface EntryPoint {
-	plugin: Plugin
-	modulePath: string
- }
+export interface EntryPoint {
+  plugin: Plugin
+  modulePath: string
+}

--- a/lib/plugin/src/index.ts
+++ b/lib/plugin/src/index.ts
@@ -3,7 +3,10 @@ export type RCFile = {
   installs: { [id: string]: string }
   tasks: { [id: string]: string }
   commands: { [id: string]: string | string[] }
-  options: { plugins: { [id: string]: Record<string, unknown> } }
+  options: {
+    plugins: { [id: string]: Record<string, unknown> }
+    tasks: { [id: string]: Record<string, unknown> }
+  }
   hooks: { [id: string]: Record<string, unknown> }[]
   init: string[]
 }
@@ -26,6 +29,12 @@ export interface OptionsForPlugin {
   options: Record<string, unknown>
   plugin: Plugin
   forPlugin: Plugin
+}
+
+export interface OptionsForTask {
+  options: Record<string, unknown>
+  plugin: Plugin
+  task: string
 }
 
 export interface EntryPoint {

--- a/lib/schemas/src/hooks.ts
+++ b/lib/schemas/src/hooks.ts
@@ -1,14 +1,8 @@
-import { z } from 'zod'
-
 import { PackageJsonSchema } from './hooks/package-json'
+import { type InferSchemaOptions } from './infer'
 
 export const HookSchemas = {
   PackageJson: PackageJsonSchema
 }
 
-// Gives the TypeScript type represented by each Schema
-export type HookOptions = {
-  [plugin in keyof typeof HookSchemas]: typeof HookSchemas[plugin] extends z.ZodTypeAny
-    ? z.infer<typeof HookSchemas[plugin]>
-    : never
-}
+export type HookOptions = InferSchemaOptions<typeof HookSchemas>

--- a/lib/schemas/src/hooks.ts
+++ b/lib/schemas/src/hooks.ts
@@ -7,7 +7,7 @@ export const HookSchemas = {
 }
 
 // Gives the TypeScript type represented by each Schema
-export type Options = {
+export type HookOptions = {
   [plugin in keyof typeof HookSchemas]: typeof HookSchemas[plugin] extends z.ZodTypeAny
     ? z.infer<typeof HookSchemas[plugin]>
     : never

--- a/lib/schemas/src/index.ts
+++ b/lib/schemas/src/index.ts
@@ -1,3 +1,4 @@
-export * from './plugins'
 export * from './hooks'
+export * from './plugins'
 export * from './prompts'
+export * from './tasks'

--- a/lib/schemas/src/index.ts
+++ b/lib/schemas/src/index.ts
@@ -1,3 +1,3 @@
-export { Options as SchemaOptions, Schemas as PluginSchemas } from './plugins'
-export { Options as HookOptions, HookSchemas } from './hooks'
+export * from './plugins'
+export * from './hooks'
 export * from './prompts'

--- a/lib/schemas/src/infer.ts
+++ b/lib/schemas/src/infer.ts
@@ -1,0 +1,6 @@
+import { type z } from 'zod'
+
+// Gives the TypeScript type represented by each Schema
+export type InferSchemaOptions<Schemas> = {
+  [key in keyof Schemas]: Schemas[key] extends z.ZodTypeAny ? z.infer<Schemas[key]> : never
+}

--- a/lib/schemas/src/plugins.ts
+++ b/lib/schemas/src/plugins.ts
@@ -22,7 +22,7 @@ import { UploadAssetsToS3Schema } from './plugins/upload-assets-to-s3'
 import { VaultSchema } from './plugins/vault'
 import { WebpackSchema } from './plugins/webpack'
 
-export const Schemas = {
+export const PluginSchemas = {
   'app root': RootSchema,
   '@dotcom-tool-kit/babel': BabelSchema,
   '@dotcom-tool-kit/circleci': CircleCISchema,
@@ -47,8 +47,8 @@ export const Schemas = {
 }
 
 // Gives the TypeScript type represented by each Schema
-export type Options = {
-  [plugin in keyof typeof Schemas]: typeof Schemas[plugin] extends z.ZodTypeAny
-    ? z.infer<typeof Schemas[plugin]>
+export type PluginOptions = {
+  [plugin in keyof typeof PluginSchemas]: (typeof PluginSchemas)[plugin] extends z.ZodTypeAny
+    ? z.infer<(typeof PluginSchemas)[plugin]>
     : never
 }

--- a/lib/schemas/src/plugins.ts
+++ b/lib/schemas/src/plugins.ts
@@ -1,5 +1,3 @@
-import type { z } from 'zod'
-
 import { BabelSchema } from './plugins/babel'
 import { CircleCISchema } from './plugins/circleci'
 import { CypressSchema } from './plugins/cypress'
@@ -21,6 +19,7 @@ import { TypeScriptSchema } from './plugins/typescript'
 import { UploadAssetsToS3Schema } from './plugins/upload-assets-to-s3'
 import { VaultSchema } from './plugins/vault'
 import { WebpackSchema } from './plugins/webpack'
+import { type InferSchemaOptions } from './infer'
 
 export const PluginSchemas = {
   'app root': RootSchema,
@@ -46,9 +45,4 @@ export const PluginSchemas = {
   '@dotcom-tool-kit/webpack': WebpackSchema
 }
 
-// Gives the TypeScript type represented by each Schema
-export type PluginOptions = {
-  [plugin in keyof typeof PluginSchemas]: (typeof PluginSchemas)[plugin] extends z.ZodTypeAny
-    ? z.infer<(typeof PluginSchemas)[plugin]>
-    : never
-}
+export type PluginOptions = InferSchemaOptions<typeof PluginSchemas>

--- a/lib/schemas/src/tasks.ts
+++ b/lib/schemas/src/tasks.ts
@@ -1,5 +1,9 @@
+import { z } from 'zod'
+
 import { type InferSchemaOptions } from './infer'
 
-export const TaskSchemas = {}
+export const TaskSchemas = {
+  'fake schema': z.never()
+}
 
 export type TaskOptions = InferSchemaOptions<typeof TaskSchemas>

--- a/lib/schemas/src/tasks.ts
+++ b/lib/schemas/src/tasks.ts
@@ -1,0 +1,5 @@
+import { type InferSchemaOptions } from './infer'
+
+export const TaskSchemas = {}
+
+export type TaskOptions = InferSchemaOptions<typeof TaskSchemas>

--- a/plugins/babel/src/tasks/development.ts
+++ b/plugins/babel/src/tasks/development.ts
@@ -2,7 +2,7 @@ import { runBabel } from '../run-babel'
 import { Task } from '@dotcom-tool-kit/base'
 import { BabelSchema } from '@dotcom-tool-kit/schemas/lib/plugins/babel'
 
-export default class BabelDevelopment extends Task<typeof BabelSchema> {
+export default class BabelDevelopment extends Task<{ plugin: typeof BabelSchema }> {
   static description = 'build babel'
 
   async run(): Promise<void> {

--- a/plugins/babel/src/tasks/development.ts
+++ b/plugins/babel/src/tasks/development.ts
@@ -6,6 +6,6 @@ export default class BabelDevelopment extends Task<typeof BabelSchema> {
   static description = 'build babel'
 
   async run(): Promise<void> {
-    await runBabel(this.logger, this.options)
+    await runBabel(this.logger, this.pluginOptions)
   }
 }

--- a/plugins/babel/src/tasks/production.ts
+++ b/plugins/babel/src/tasks/production.ts
@@ -2,7 +2,7 @@ import { runBabel } from '../run-babel'
 import { Task } from '@dotcom-tool-kit/base'
 import { BabelSchema } from '@dotcom-tool-kit/schemas/lib/plugins/babel'
 
-export default class BabelProduction extends Task<typeof BabelSchema> {
+export default class BabelProduction extends Task<{ plugin: typeof BabelSchema }> {
   static description = 'build babel'
 
   async run(): Promise<void> {

--- a/plugins/babel/src/tasks/production.ts
+++ b/plugins/babel/src/tasks/production.ts
@@ -6,6 +6,6 @@ export default class BabelProduction extends Task<typeof BabelSchema> {
   static description = 'build babel'
 
   async run(): Promise<void> {
-    await runBabel(this.logger, this.options, { envName: 'production' })
+    await runBabel(this.logger, this.pluginOptions, { envName: 'production' })
   }
 }

--- a/plugins/cypress/src/tasks/ci.ts
+++ b/plugins/cypress/src/tasks/ci.ts
@@ -4,7 +4,7 @@ import { readState } from '@dotcom-tool-kit/state'
 import { Task } from '@dotcom-tool-kit/base'
 import { CypressSchema } from '@dotcom-tool-kit/schemas/lib/plugins/cypress'
 
-export default class CypressCi extends Task<typeof CypressSchema> {
+export default class CypressCi extends Task<{ plugin: typeof CypressSchema }> {
   async run(): Promise<void> {
     const reviewState = readState('review')
     const cypressEnv: Record<string, string> = {}

--- a/plugins/cypress/src/tasks/local.ts
+++ b/plugins/cypress/src/tasks/local.ts
@@ -8,8 +8,8 @@ import { CypressSchema } from '@dotcom-tool-kit/schemas/lib/plugins/cypress'
 export default class CypressLocal extends Task<typeof CypressSchema> {
   async run(): Promise<void> {
     const cypressEnv: Record<string, string> = {}
-    if (this.options.localUrl) {
-      cypressEnv.CYPRESS_BASE_URL = this.options.localUrl
+    if (this.pluginOptions.localUrl) {
+      cypressEnv.CYPRESS_BASE_URL = this.pluginOptions.localUrl
     }
 
     const doppler = new DopplerEnvVars(this.logger, 'dev')

--- a/plugins/cypress/src/tasks/local.ts
+++ b/plugins/cypress/src/tasks/local.ts
@@ -5,7 +5,7 @@ import { readState } from '@dotcom-tool-kit/state'
 import { Task } from '@dotcom-tool-kit/base'
 import { CypressSchema } from '@dotcom-tool-kit/schemas/lib/plugins/cypress'
 
-export default class CypressLocal extends Task<typeof CypressSchema> {
+export default class CypressLocal extends Task<{ plugin: typeof CypressSchema }> {
   async run(): Promise<void> {
     const cypressEnv: Record<string, string> = {}
     if (this.pluginOptions.localUrl) {

--- a/plugins/eslint/src/tasks/eslint.ts
+++ b/plugins/eslint/src/tasks/eslint.ts
@@ -8,8 +8,8 @@ export default class Eslint extends Task<typeof ESLintSchema> {
   static description = ''
 
   async run(files?: string[]): Promise<void> {
-    const eslint = new ESLint(this.options.options)
-    const results = await eslint.lintFiles(files ?? this.options.files)
+    const eslint = new ESLint(this.pluginOptions.options)
+    const results = await eslint.lintFiles(files ?? this.pluginOptions.files)
     const formatter = await eslint.loadFormatter('stylish')
     const resultText = formatter.format(results)
 

--- a/plugins/eslint/src/tasks/eslint.ts
+++ b/plugins/eslint/src/tasks/eslint.ts
@@ -4,7 +4,7 @@ import { Task } from '@dotcom-tool-kit/base'
 import { ESLintSchema } from '@dotcom-tool-kit/schemas/lib/plugins/eslint'
 import { ESLint } from 'eslint'
 
-export default class Eslint extends Task<typeof ESLintSchema> {
+export default class Eslint extends Task<{ plugin: typeof ESLintSchema }> {
   static description = ''
 
   async run(files?: string[]): Promise<void> {

--- a/plugins/heroku/src/tasks/production.ts
+++ b/plugins/heroku/src/tasks/production.ts
@@ -20,7 +20,7 @@ export default class HerokuProduction extends Task<typeof HerokuSchema> {
       }
       const { slugId } = state
 
-      const { scaling } = this.options
+      const { scaling } = this.pluginOptions
 
       const scale = async () => {
         for (const [appName, typeConfig] of Object.entries(scaling)) {
@@ -33,7 +33,7 @@ export default class HerokuProduction extends Task<typeof HerokuSchema> {
       }
       const promote = async () => {
         this.logger.verbose('promoting staging to production....')
-        await promoteStagingToProduction(this.logger, slugId, this.options.systemCode)
+        await promoteStagingToProduction(this.logger, slugId, this.pluginOptions.systemCode)
         this.logger.info('staging has been successfully promoted to production')
       }
 

--- a/plugins/heroku/src/tasks/production.ts
+++ b/plugins/heroku/src/tasks/production.ts
@@ -8,7 +8,7 @@ import heroku, { extractHerokuError } from '../herokuClient'
 import { scaleDyno } from '../scaleDyno'
 import { promoteStagingToProduction } from '../promoteStagingToProduction'
 
-export default class HerokuProduction extends Task<typeof HerokuSchema> {
+export default class HerokuProduction extends Task<{ plugin: typeof HerokuSchema }> {
   static description = ''
 
   async run(): Promise<void> {

--- a/plugins/heroku/src/tasks/review.ts
+++ b/plugins/heroku/src/tasks/review.ts
@@ -9,7 +9,7 @@ import { ToolKitError } from '@dotcom-tool-kit/error'
 import herokuClient, { extractHerokuError } from '../herokuClient'
 import type { HerokuApiResPipeline } from 'heroku-client'
 
-export default class HerokuReview extends Task<typeof HerokuSchema> {
+export default class HerokuReview extends Task<{ plugin: typeof HerokuSchema }> {
   static description = ''
 
   async run(): Promise<void> {

--- a/plugins/heroku/src/tasks/review.ts
+++ b/plugins/heroku/src/tasks/review.ts
@@ -15,8 +15,8 @@ export default class HerokuReview extends Task<typeof HerokuSchema> {
   async run(): Promise<void> {
     try {
       const pipeline = await herokuClient
-        .get<HerokuApiResPipeline>(`/pipelines/${this.options.pipeline}`)
-        .catch(extractHerokuError(`getting pipeline ${this.options.pipeline}`))
+        .get<HerokuApiResPipeline>(`/pipelines/${this.pluginOptions.pipeline}`)
+        .catch(extractHerokuError(`getting pipeline ${this.pluginOptions.pipeline}`))
       await setStageConfigVars(this.logger, 'review', 'prod', pipeline.id)
 
       let reviewAppId = await getHerokuReviewApp(this.logger, pipeline.id)

--- a/plugins/heroku/src/tasks/staging.ts
+++ b/plugins/heroku/src/tasks/staging.ts
@@ -16,13 +16,13 @@ export default class HerokuStaging extends Task<typeof HerokuSchema> {
   async run(): Promise<void> {
     try {
       this.logger.verbose(`retrieving pipeline details...`)
-      await getPipelineCouplings(this.logger, this.options.pipeline)
+      await getPipelineCouplings(this.logger, this.pluginOptions.pipeline)
 
       this.logger.verbose(`retrieving staging app details...`)
       const appName = await getHerokuStagingApp()
 
       // setting config vars on staging from the doppler production directory
-      await setAppConfigVars(this.logger, appName, 'prod', this.options.systemCode)
+      await setAppConfigVars(this.logger, appName, 'prod', this.pluginOptions.systemCode)
 
       // create build from latest commit, even on no change
       const buildDetails = await createBuild(this.logger, appName)

--- a/plugins/heroku/src/tasks/staging.ts
+++ b/plugins/heroku/src/tasks/staging.ts
@@ -10,7 +10,7 @@ import { getPipelineCouplings } from '../getPipelineCouplings'
 import { HerokuSchema } from '@dotcom-tool-kit/schemas/lib/plugins/heroku'
 import { setStagingSlug } from '../setStagingSlug'
 
-export default class HerokuStaging extends Task<typeof HerokuSchema> {
+export default class HerokuStaging extends Task<{ plugin: typeof HerokuSchema }> {
   static description = ''
 
   async run(): Promise<void> {

--- a/plugins/jest/src/tasks/ci.ts
+++ b/plugins/jest/src/tasks/ci.ts
@@ -6,6 +6,6 @@ export default class JestCI extends Task<typeof JestSchema> {
   static description = ''
 
   async run(): Promise<void> {
-    await runJest(this.logger, 'ci', this.options)
+    await runJest(this.logger, 'ci', this.pluginOptions)
   }
 }

--- a/plugins/jest/src/tasks/ci.ts
+++ b/plugins/jest/src/tasks/ci.ts
@@ -2,7 +2,7 @@ import { Task } from '@dotcom-tool-kit/base'
 import { JestSchema } from '@dotcom-tool-kit/schemas/lib/plugins/jest'
 import runJest from '../run-jest'
 
-export default class JestCI extends Task<typeof JestSchema> {
+export default class JestCI extends Task<{ plugin: typeof JestSchema }> {
   static description = ''
 
   async run(): Promise<void> {

--- a/plugins/jest/src/tasks/local.ts
+++ b/plugins/jest/src/tasks/local.ts
@@ -6,6 +6,6 @@ export default class JestLocal extends Task<typeof JestSchema> {
   static description = ''
 
   async run(): Promise<void> {
-    await runJest(this.logger, 'local', this.options)
+    await runJest(this.logger, 'local', this.pluginOptions)
   }
 }

--- a/plugins/jest/src/tasks/local.ts
+++ b/plugins/jest/src/tasks/local.ts
@@ -2,7 +2,7 @@ import { Task } from '@dotcom-tool-kit/base'
 import { JestSchema } from '@dotcom-tool-kit/schemas/lib/plugins/jest'
 import runJest from '../run-jest'
 
-export default class JestLocal extends Task<typeof JestSchema> {
+export default class JestLocal extends Task<{ plugin: typeof JestSchema }> {
   static description = ''
 
   async run(): Promise<void> {

--- a/plugins/mocha/src/tasks/mocha.ts
+++ b/plugins/mocha/src/tasks/mocha.ts
@@ -6,7 +6,7 @@ import { fork } from 'child_process'
 import { promisify } from 'util'
 const mochaCLIPath = require.resolve('mocha/bin/mocha')
 
-export default class Mocha extends Task<typeof MochaSchema> {
+export default class Mocha extends Task<{ plugin: typeof MochaSchema }> {
   static description = ''
 
   async run(): Promise<void> {

--- a/plugins/mocha/src/tasks/mocha.ts
+++ b/plugins/mocha/src/tasks/mocha.ts
@@ -10,11 +10,11 @@ export default class Mocha extends Task<typeof MochaSchema> {
   static description = ''
 
   async run(): Promise<void> {
-    const files = await promisify(glob)(this.options.files)
+    const files = await promisify(glob)(this.pluginOptions.files)
 
     const args = ['--color', ...files]
-    if (this.options.configPath) {
-      args.unshift(`--config=${this.options.configPath}`)
+    if (this.pluginOptions.configPath) {
+      args.unshift(`--config=${this.pluginOptions.configPath}`)
     }
     this.logger.info(`running mocha ${args.join(' ')}`)
     const child = fork(mochaCLIPath, args, { silent: true })

--- a/plugins/n-test/src/tasks/n-test.ts
+++ b/plugins/n-test/src/tasks/n-test.ts
@@ -4,7 +4,7 @@ import { SmokeTestSchema } from '@dotcom-tool-kit/schemas/lib/plugins/n-test'
 import { SmokeTest } from '@financial-times/n-test'
 import { readState } from '@dotcom-tool-kit/state'
 
-export default class NTest extends Task<typeof SmokeTestSchema> {
+export default class NTest extends Task<{ plugin: typeof SmokeTestSchema }> {
   static description = ''
 
   async run(): Promise<void> {

--- a/plugins/n-test/src/tasks/n-test.ts
+++ b/plugins/n-test/src/tasks/n-test.ts
@@ -14,18 +14,18 @@ export default class NTest extends Task<typeof SmokeTestSchema> {
     if (appState) {
       // HACK:20231003:IM keep the old logic of using the app name as the
       // subdomain to maintain backwards compatibility
-      this.options.host =
+      this.pluginOptions.host =
         'url' in appState && appState.url ? appState.url : `https://${appState.appName}.herokuapp.com`
       // HACK:20231003:IM n-test naively appends paths to the host URL so
       // expects there to be no trailing slash
-      if (this.options.host.endsWith('/')) {
-        this.options.host = this.options.host.slice(0, -1)
+      if (this.pluginOptions.host.endsWith('/')) {
+        this.pluginOptions.host = this.pluginOptions.host.slice(0, -1)
       }
     }
 
-    const smokeTest = new SmokeTest(this.options)
+    const smokeTest = new SmokeTest(this.pluginOptions)
     this.logger.info(
-      `Running smoke test${this.options.host ? ` for URL ${styles.URL(this.options.host)}` : ''}`
+      `Running smoke test${this.pluginOptions.host ? ` for URL ${styles.URL(this.pluginOptions.host)}` : ''}`
     )
     await smokeTest.run()
   }

--- a/plugins/n-test/test/tasks/n-test.test.ts
+++ b/plugins/n-test/test/tasks/n-test.test.ts
@@ -46,6 +46,6 @@ describe('n-test', () => {
       await task.run()
     } catch {}
 
-    expect(task.options.host).toEqual(appUrl)
+    expect(task.pluginOptions.host).toEqual(appUrl)
   })
 })

--- a/plugins/next-router/src/tasks/next-router.ts
+++ b/plugins/next-router/src/tasks/next-router.ts
@@ -38,7 +38,7 @@ export default class NextRouter extends Task<typeof NextRouterSchema> {
 
     const unhook = hookConsole(this.logger, 'ft-next-router')
     try {
-      await register({ service: this.options.appName, port: local.port })
+      await register({ service: this.pluginOptions.appName, port: local.port })
     } finally {
       unhook()
     }

--- a/plugins/next-router/src/tasks/next-router.ts
+++ b/plugins/next-router/src/tasks/next-router.ts
@@ -7,7 +7,7 @@ import { ToolKitError } from '@dotcom-tool-kit/error'
 import { fork } from 'child_process'
 import { NextRouterSchema } from '@dotcom-tool-kit/schemas/lib/plugins/next-router'
 
-export default class NextRouter extends Task<typeof NextRouterSchema> {
+export default class NextRouter extends Task<{ plugin: typeof NextRouterSchema }> {
   static description = ''
 
   async run(): Promise<void> {

--- a/plugins/node/src/tasks/node.ts
+++ b/plugins/node/src/tasks/node.ts
@@ -12,7 +12,7 @@ export default class Node extends Task<typeof NodeSchema> {
   static description = ''
 
   async run(): Promise<void> {
-    const { entry, args, useVault, ports } = this.options
+    const { entry, args, useVault, ports } = this.pluginOptions
 
     let vaultEnv = {}
 

--- a/plugins/node/src/tasks/node.ts
+++ b/plugins/node/src/tasks/node.ts
@@ -8,7 +8,7 @@ import { fork } from 'child_process'
 import getPort from 'get-port'
 import waitPort from 'wait-port'
 
-export default class Node extends Task<typeof NodeSchema> {
+export default class Node extends Task<{ plugin: typeof NodeSchema }> {
   static description = ''
 
   async run(): Promise<void> {

--- a/plugins/nodemon/src/tasks/nodemon.ts
+++ b/plugins/nodemon/src/tasks/nodemon.ts
@@ -8,7 +8,7 @@ import nodemon from 'nodemon'
 import { Readable } from 'stream'
 import { shouldDisableNativeFetch } from 'dotcom-tool-kit'
 
-export default class Nodemon extends Task<typeof NodemonSchema> {
+export default class Nodemon extends Task<{ plugin: typeof NodemonSchema }> {
   static description = ''
 
   async run(): Promise<void> {

--- a/plugins/nodemon/src/tasks/nodemon.ts
+++ b/plugins/nodemon/src/tasks/nodemon.ts
@@ -12,7 +12,7 @@ export default class Nodemon extends Task<typeof NodemonSchema> {
   static description = ''
 
   async run(): Promise<void> {
-    const { entry, configPath, useVault, ports } = this.options
+    const { entry, configPath, useVault, ports } = this.pluginOptions
 
     let dopplerEnv = {}
 

--- a/plugins/pa11y/src/tasks/pa11y.ts
+++ b/plugins/pa11y/src/tasks/pa11y.ts
@@ -6,7 +6,7 @@ import { readState } from '@dotcom-tool-kit/state'
 
 const pa11yCIPath = require.resolve('pa11y-ci/bin/pa11y-ci')
 
-export default class Pa11y extends Task<typeof Pa11ySchema> {
+export default class Pa11y extends Task<{ plugin: typeof Pa11ySchema }> {
   static description = ''
 
   async run(): Promise<void> {

--- a/plugins/pa11y/src/tasks/pa11y.ts
+++ b/plugins/pa11y/src/tasks/pa11y.ts
@@ -19,7 +19,7 @@ export default class Pa11y extends Task<typeof Pa11ySchema> {
       process.env.TEST_URL = `https://${reviewState.appName}.herokuapp.com`
     }
 
-    const args = this.options.configFile ? ['--config', this.options.configFile] : []
+    const args = this.pluginOptions.configFile ? ['--config', this.pluginOptions.configFile] : []
 
     this.logger.info(`running pa11y-ci ${args.join(' ')}`)
     const child = fork(pa11yCIPath, args, { silent: true })

--- a/plugins/prettier/src/tasks/prettier.ts
+++ b/plugins/prettier/src/tasks/prettier.ts
@@ -11,11 +11,11 @@ export default class Prettier extends Task<typeof PrettierSchema> {
 
   async run(files?: string[]): Promise<void> {
     try {
-      const filepaths = await fg(files ?? this.options.files)
+      const filepaths = await fg(files ?? this.pluginOptions.files)
       for (const filepath of filepaths) {
         const { ignored } = await prettier.getFileInfo(filepath)
         if (!ignored) {
-          await this.formatFile(filepath, this.options)
+          await this.formatFile(filepath, this.pluginOptions)
         }
       }
     } catch (err) {
@@ -50,7 +50,7 @@ export default class Prettier extends Task<typeof PrettierSchema> {
       prettierConfig = options.configOptions
     }
 
-    const { ignored } = await prettier.getFileInfo(filepath, { ignorePath: this.options.ignoreFile })
+    const { ignored } = await prettier.getFileInfo(filepath, { ignorePath: this.pluginOptions.ignoreFile })
 
     if (ignored) {
       return

--- a/plugins/prettier/src/tasks/prettier.ts
+++ b/plugins/prettier/src/tasks/prettier.ts
@@ -6,7 +6,7 @@ import { hookConsole, styles } from '@dotcom-tool-kit/logger'
 import { Task } from '@dotcom-tool-kit/base'
 import { ToolKitError } from '@dotcom-tool-kit/error'
 
-export default class Prettier extends Task<typeof PrettierSchema> {
+export default class Prettier extends Task<{ plugin: typeof PrettierSchema }> {
   static description = ''
 
   async run(files?: string[]): Promise<void> {

--- a/plugins/serverless/src/tasks/deploy.ts
+++ b/plugins/serverless/src/tasks/deploy.ts
@@ -10,7 +10,7 @@ export default class ServerlessDeploy extends Task<typeof ServerlessSchema> {
   static description = 'Deploys on AWS'
 
   async run(): Promise<void> {
-    const { useVault, configPath, buildNumVariable, regions, systemCode } = this.options
+    const { useVault, configPath, buildNumVariable, regions, systemCode } = this.pluginOptions
     const buildNum = process.env[buildNumVariable]
 
     if (buildNum === undefined) {

--- a/plugins/serverless/src/tasks/deploy.ts
+++ b/plugins/serverless/src/tasks/deploy.ts
@@ -6,7 +6,7 @@ import { DopplerEnvVars } from '@dotcom-tool-kit/doppler'
 import { getOptions } from '@dotcom-tool-kit/options'
 import { spawn } from 'child_process'
 
-export default class ServerlessDeploy extends Task<typeof ServerlessSchema> {
+export default class ServerlessDeploy extends Task<{ plugin: typeof ServerlessSchema }> {
   static description = 'Deploys on AWS'
 
   async run(): Promise<void> {

--- a/plugins/serverless/src/tasks/provision.ts
+++ b/plugins/serverless/src/tasks/provision.ts
@@ -11,7 +11,7 @@ export default class ServerlessProvision extends Task<typeof ServerlessSchema> {
   static description = 'Provisions a job on AWS'
 
   async run(): Promise<void> {
-    const { useVault, configPath, buildNumVariable, systemCode, regions } = this.options
+    const { useVault, configPath, buildNumVariable, systemCode, regions } = this.pluginOptions
     const buildNum = process.env[buildNumVariable]
 
     if (buildNum === undefined) {

--- a/plugins/serverless/src/tasks/provision.ts
+++ b/plugins/serverless/src/tasks/provision.ts
@@ -7,7 +7,7 @@ import { spawn } from 'child_process'
 import { getOptions } from '@dotcom-tool-kit/options'
 import { writeState } from '@dotcom-tool-kit/state'
 
-export default class ServerlessProvision extends Task<typeof ServerlessSchema> {
+export default class ServerlessProvision extends Task<{ plugin: typeof ServerlessSchema }> {
   static description = 'Provisions a job on AWS'
 
   async run(): Promise<void> {

--- a/plugins/serverless/src/tasks/run.ts
+++ b/plugins/serverless/src/tasks/run.ts
@@ -10,7 +10,7 @@ export default class ServerlessRun extends Task<typeof ServerlessSchema> {
   static description = 'Run serverless functions locally'
 
   async run(): Promise<void> {
-    const { useVault, ports, configPath } = this.options
+    const { useVault, ports, configPath } = this.pluginOptions
 
     let dopplerEnv = {}
 

--- a/plugins/serverless/src/tasks/run.ts
+++ b/plugins/serverless/src/tasks/run.ts
@@ -6,7 +6,7 @@ import { hookConsole, hookFork } from '@dotcom-tool-kit/logger'
 import getPort from 'get-port'
 import waitPort from 'wait-port'
 
-export default class ServerlessRun extends Task<typeof ServerlessSchema> {
+export default class ServerlessRun extends Task<{ plugin: typeof ServerlessSchema }> {
   static description = 'Run serverless functions locally'
 
   async run(): Promise<void> {

--- a/plugins/serverless/src/tasks/teardown.ts
+++ b/plugins/serverless/src/tasks/teardown.ts
@@ -7,11 +7,11 @@ import { DopplerEnvVars } from '@dotcom-tool-kit/doppler'
 import { spawn } from 'child_process'
 import { getOptions } from '@dotcom-tool-kit/options'
 
-export default class ServerlessTeardown extends Task<typeof ServerlessSchema> {
+export default class ServerlessTeardown extends Task<{ plugin: typeof ServerlessSchema }> {
   static description = 'Teardown existing serverless functions'
 
   async run(): Promise<void> {
-    const { useVault, configPath, regions, systemCode } = this.options
+    const { useVault, configPath, regions, systemCode } = this.pluginOptions
 
     const reviewState = readState('review')
 

--- a/plugins/typescript/src/tasks/typescript.ts
+++ b/plugins/typescript/src/tasks/typescript.ts
@@ -5,7 +5,7 @@ import { fork } from 'child_process'
 
 const tscPath = require.resolve('typescript/bin/tsc')
 
-export default abstract class TypeScriptTask extends Task<typeof TypeScriptSchema> {
+export default abstract class TypeScriptTask extends Task<{ plugin: typeof TypeScriptSchema }> {
   abstract taskArgs: string[]
 
   async run(): Promise<void> {

--- a/plugins/typescript/src/tasks/typescript.ts
+++ b/plugins/typescript/src/tasks/typescript.ts
@@ -11,11 +11,11 @@ export default abstract class TypeScriptTask extends Task<typeof TypeScriptSchem
   async run(): Promise<void> {
     // TODO: add monorepo support with --build option
     const args = [...this.taskArgs]
-    if (this.options.configPath) {
-      args.unshift('--project', this.options.configPath)
+    if (this.pluginOptions.configPath) {
+      args.unshift('--project', this.pluginOptions.configPath)
     }
-    if (this.options.extraArgs) {
-      args.push(...this.options.extraArgs)
+    if (this.pluginOptions.extraArgs) {
+      args.push(...this.pluginOptions.extraArgs)
     }
 
     const child = fork(tscPath, args, { silent: true })

--- a/plugins/upload-assets-to-s3/src/tasks/upload-assets-to-s3.ts
+++ b/plugins/upload-assets-to-s3/src/tasks/upload-assets-to-s3.ts
@@ -15,7 +15,7 @@ export default class UploadAssetsToS3 extends Task<typeof UploadAssetsToS3Schema
   static description = ''
 
   async run(): Promise<void> {
-    await this.uploadAssetsToS3(this.options)
+    await this.uploadAssetsToS3(this.pluginOptions)
   }
   async uploadFile(file: string, options: UploadAssetsToS3Options, s3: S3Client): Promise<void> {
     const type = getFileType(file)

--- a/plugins/upload-assets-to-s3/src/tasks/upload-assets-to-s3.ts
+++ b/plugins/upload-assets-to-s3/src/tasks/upload-assets-to-s3.ts
@@ -11,7 +11,7 @@ import {
   UploadAssetsToS3Schema
 } from '@dotcom-tool-kit/schemas/lib/plugins/upload-assets-to-s3'
 
-export default class UploadAssetsToS3 extends Task<typeof UploadAssetsToS3Schema> {
+export default class UploadAssetsToS3 extends Task<{ plugin: typeof UploadAssetsToS3Schema }> {
   static description = ''
 
   async run(): Promise<void> {

--- a/plugins/webpack/src/tasks/development.ts
+++ b/plugins/webpack/src/tasks/development.ts
@@ -2,7 +2,7 @@ import { Task } from '@dotcom-tool-kit/base'
 import { WebpackSchema } from '@dotcom-tool-kit/schemas/lib/plugins/webpack'
 import runWebpack from '../run-webpack'
 
-export default class WebpackDevelopment extends Task<typeof WebpackSchema> {
+export default class WebpackDevelopment extends Task<{ plugin: typeof WebpackSchema }> {
   static description = 'Run Webpack in development mode'
 
   async run(): Promise<void> {

--- a/plugins/webpack/src/tasks/development.ts
+++ b/plugins/webpack/src/tasks/development.ts
@@ -7,7 +7,7 @@ export default class WebpackDevelopment extends Task<typeof WebpackSchema> {
 
   async run(): Promise<void> {
     await runWebpack(this.logger, {
-      ...this.options,
+      ...this.pluginOptions,
       mode: 'development'
     })
   }

--- a/plugins/webpack/src/tasks/production.ts
+++ b/plugins/webpack/src/tasks/production.ts
@@ -2,7 +2,7 @@ import { Task } from '@dotcom-tool-kit/base'
 import { WebpackSchema } from '@dotcom-tool-kit/schemas/lib/plugins/webpack'
 import runWebpack from '../run-webpack'
 
-export default class WebpackProduction extends Task<typeof WebpackSchema> {
+export default class WebpackProduction extends Task<{ plugin: typeof WebpackSchema }> {
   static description = 'Run Webpack in production mode'
 
   async run(): Promise<void> {

--- a/plugins/webpack/src/tasks/production.ts
+++ b/plugins/webpack/src/tasks/production.ts
@@ -7,7 +7,7 @@ export default class WebpackProduction extends Task<typeof WebpackSchema> {
 
   async run(): Promise<void> {
     await runWebpack(this.logger, {
-      ...this.options,
+      ...this.pluginOptions,
       mode: 'production'
     })
   }

--- a/plugins/webpack/src/tasks/watch.ts
+++ b/plugins/webpack/src/tasks/watch.ts
@@ -8,7 +8,7 @@ export default class WebpackWatch extends Task<typeof WebpackSchema> {
   async run(): Promise<void> {
     // don't wait for Webpack to exit, to leave it running in the background
     runWebpack(this.logger, {
-      ...this.options,
+      ...this.pluginOptions,
       mode: 'development',
       watch: true
     })

--- a/plugins/webpack/src/tasks/watch.ts
+++ b/plugins/webpack/src/tasks/watch.ts
@@ -2,7 +2,7 @@ import { Task } from '@dotcom-tool-kit/base'
 import { WebpackSchema } from '@dotcom-tool-kit/schemas/lib/plugins/webpack'
 import runWebpack from '../run-webpack'
 
-export default class WebpackWatch extends Task<typeof WebpackSchema> {
+export default class WebpackWatch extends Task<{ plugin: typeof WebpackSchema }> {
   static description = 'Run Webpack in watch mode in the background'
 
   async run(): Promise<void> {


### PR DESCRIPTION
this PR adds support for loading task options from `.toolkitrc.yml`s, validating them against (task-option-specific) schemas, and passing those into the task constructors as an argument (separate from plugin options, which has been renamed to `this.pluginOptions`, and avoiding merging them with plugin options to make it clearer for task authors)

this PR does not yet implement any actual task options. that's a much bigger task; i've made a start in #570.