### PR TITLE
Migration script fixes from n-test migration

### DIFF
--- a/core/create/src/bizOps.ts
+++ b/core/create/src/bizOps.ts
@@ -20,7 +20,7 @@ const getBizOpsApiKey = async () => {
   return bizOpsApiKey
 }
 
-export const getBizOpsSystem = async (systemCode: string): Promise<BizOpsSystem> => {
+export const getBizOpsSystem = async (systemCode: string): Promise<BizOpsSystem | undefined> => {
   const query = `#graphql
     query ToolKitMigrationMetadata($systemCode: String!) {
       systems(where: { code: $systemCode }) {
@@ -52,8 +52,10 @@ export const getBizOpsSystem = async (systemCode: string): Promise<BizOpsSystem>
       }
     }
   )
-  const { data } = BizOpsData.parse(await resp.json())
-  return data.systems[0]
+  const result = BizOpsData.safeParse(await resp.json())
+  if (result.success) {
+    return result.data.data.systems[0]
+  }
 }
 
 export { BizOpsData, BizOpsSystem }

--- a/core/create/src/makefile.ts
+++ b/core/create/src/makefile.ts
@@ -26,10 +26,10 @@ export default async (): Promise<void> => {
     const targets = Object.keys(rules)
     winstonLogger.info(`${styles.ruler()}\n`)
     winstonLogger.info(
-      'We recommend deleting your old Makefile as it will no longer be used. In the' +
-        "future you can run tasks with 'npm run' instead. Make sure that you won't be" +
-        "deleting any task logic that hasn't already been migrated to Tool Kit. If you" +
-        "find anything that can't be handled by Tool Kit then please let the Platforms" +
+      'We recommend deleting your old Makefile as it will no longer be used. In the ' +
+        "future you can run tasks with 'npm run' instead. Make sure that you won't be " +
+        "deleting any task logic that hasn't already been migrated to Tool Kit. If you " +
+        "find anything that can't be handled by Tool Kit then please let the Platforms " +
         'team know.'
     )
 

--- a/core/create/src/prompts/systemCode.ts
+++ b/core/create/src/prompts/systemCode.ts
@@ -10,19 +10,16 @@ export interface ConfirmationParams {
 export default async ({ packageJson }: ConfirmationParams): Promise<BizOpsSystem | undefined> => {
   const guessedSystemCode = packageJson.name
   let bizOpsSystem
-  try {
-    if (!guessedSystemCode) {
-      // fall back to the prompt if we don't have a system code to guess
-      throw new Error()
-    }
+  if (guessedSystemCode) {
+    bizOpsSystem = await getBizOpsSystem(guessedSystemCode)
+  }
+  if (!bizOpsSystem) {
     // try to guess the system code then assume an error means the guess was
     // wrong
-    bizOpsSystem = await getBizOpsSystem(guessedSystemCode)
-  } catch {
     const { systemCode } = await prompt({
       name: 'systemCode',
       type: 'text',
-      message: `what's your system code? ${styles.dim(
+      message: `what's your system code? leave this field blank if this is not a system ${styles.dim(
         `(${
           guessedSystemCode
             ? `failed to get system for ${guessedSystemCode}`

--- a/package-lock.json
+++ b/package-lock.json
@@ -122,7 +122,7 @@
     },
     "core/create": {
       "name": "@dotcom-tool-kit/create",
-      "version": "3.5.0",
+      "version": "3.5.2",
       "license": "ISC",
       "dependencies": {
         "@aws-sdk/client-iam": "^3.282.0",


### PR DESCRIPTION
# Description

Main change is to fix the script crashing if you try to migrate a component/package without a Biz Ops code, a bug that was introduced when we started guessing Biz Ops codes in #553.

# Checklist:

- [x] My branch has been rebased onto the latest commit on main (don't merge main into your branch)
- [x] My commit messages are [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/), for example: `feat(circleci): add support for nightly workflows`, `fix: set Heroku app name for staging apps too`
