### PR TITLE
Recommend forcing npx to use the latest version of the migration script

### DIFF
--- a/docs/migrating-to-tool-kit.md
+++ b/docs/migrating-to-tool-kit.md
@@ -28,13 +28,15 @@ to follow along with.
 The migration tool is published to npm as `@dotcom-tool-kit/create`. Thanks to
 some [syntax sugar
 magic](https://docs.npmjs.com/cli/v7/commands/npm-init#description) provided by
-npm's `npm init` script this means you can just run
+npm's `npm init` script this means you can run
 
 ```shell
-npm init @dotcom-tool-kit
+npm init @dotcom-tool-kit@latest
 ```
 
-within your repository to fetch the tool and start migrating. Answer the
+within your repository to fetch the tool and start migrating. We include the
+`@latest` specifier here to make sure you're using the latest version of the
+migration tool, as `npx` has a particularly aggressive cache. Answer the
 questions posed by the tool's prompts to configure Tool Kit in a way that's
 suitable for your app or service. Let's now look in detail at each of the steps
 in the migration process.

--- a/readme.md
+++ b/readme.md
@@ -21,7 +21,7 @@ For general questions about using Tool Kit please see the [Tool Kit FAQs](./docs
 For an empty repository (containing at least a valid `package.json`), or to migrate an existing repo from [n-gage](https://github.com/financial-times/n-gage), you can run the interactive Tool Kit init script:
 
 ```sh
-npm init @dotcom-tool-kit
+npm init @dotcom-tool-kit@latest
 ```
 
 See [the migration guide](./docs/migrating-to-tool-kit.md) for a full explanation of what this script does.


### PR DESCRIPTION
# Description

I always include the `@latest` specifier when people ask the easiest way to migrate to Tool Kit these days, but I never got round to updating the documentation so that this wasn't hidden knowledge. Finally pushed by @apaleslimghost posting about this paper cut!

# Checklist:

- [x] My branch has been rebased onto the latest commit on main (don't merge main into your branch)
- [x] My commit messages are [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/), for example: `feat(circleci): add support for nightly workflows`, `fix: set Heroku app name for staging apps too`
