### PR TITLE
Use correct name when logging Cypress URL in CI

### DIFF
--- a/plugins/cypress/src/tasks/cypress.ts
+++ b/plugins/cypress/src/tasks/cypress.ts
@@ -34,7 +34,7 @@ export class CypressCi extends Task<typeof CypressSchema> {
       cypressEnv.CYPRESS_BASE_URL = `https://${process.env.CY_CUSTOM_DOMAIN_STAGING}`
     }
 
-    this.logger.info(`running cypress against ${cypressEnv.CYPRESS_BASEURL}`)
+    this.logger.info(`running cypress against ${cypressEnv.CYPRESS_BASE_URL}`)
     const testProcess = spawn('cypress', ['run'], { env: { ...process.env, ...cypressEnv } })
     hookFork(this.logger, 'cypress', testProcess)
     return waitOnExit('cypress', testProcess)


### PR DESCRIPTION
# Description

This fixes the CypressCi task [always logging](https://app.circleci.com/pipelines/github/Financial-Times/next-newsletter-signup/4926/workflows/5a200d63-ca98-41d3-976c-69fc04cc60d9/jobs/18402?invite=true#step-102-808_45) that the URL it's testing is `undefined`. 

# Checklist:

- [x] My branch has been rebased onto the latest commit on main (don't merge main into your branch)
- [x] My commit messages are [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/), for example: `feat(circleci): add support for nightly workflows`, `fix: set Heroku app name for staging apps too`
