### PR TITLE
CPP-1941 Include permission to read Doppler secrets when importing deployment role during migration

### DIFF
--- a/core/create/src/index.ts
+++ b/core/create/src/index.ts
@@ -201,7 +201,7 @@ async function main() {
     await scheduledPipelinePrompt()
   }
   if (Object.keys(config.plugins).some((id) => id.includes('serverless'))) {
-    const oidcCancelled = await oidcInfrastructurePrompt()
+    const oidcCancelled = await oidcInfrastructurePrompt({ toolKitConfig })
     if (oidcCancelled) {
       return
     }


### PR DESCRIPTION
# Description

Even though the Tool Kit and Doppler migrations are separate, it makes sense to preempt the latter migration here to save confusing error messages and additional PRs to aws-composer repositories. [Suggested](https://financialtimes.slack.com/archives/C3TJ6KXEU/p1707737143735799?thread_ts=1707476589.356479&cid=C3TJ6KXEU) by @danieleruiz.

# Checklist:

- [x] My branch has been rebased onto the latest commit on main (don't merge main into your branch)
- [x] My commit messages are [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/), for example: `feat(circleci): add support for nightly workflows`, `fix: set Heroku app name for staging apps too`
