### PR TITLE
Remove extra colon from Doppler SSM IAM ARNs

### DIFF
--- a/core/create/files/oidc-cloudformation.yml
+++ b/core/create/files/oidc-cloudformation.yml
@@ -1,4 +1,4 @@
-AWSTemplateFormatVersion: "2010-09-09"
+AWSTemplateFormatVersion: '2010-09-09'
 
 Description: CircleCI OIDC nested stack role and policy
 
@@ -30,7 +30,7 @@ Resources:
       Roles:
         - Fn::GetAtt: [CircleciOidcNestedStackRole, Outputs.CircleciOidcRole]
       PolicyDocument:
-        Version: "2012-10-17"
+        Version: '2012-10-17'
         Statement:
           - Sid: AllowCloudformationStackActions
             Effect: Allow
@@ -55,7 +55,7 @@ Resources:
             Action:
               - cloudformation:CreateUploadBucket
               - cloudformation:ValidateTemplate
-            Resource: "*"
+            Resource: '*'
           - Sid: AllowRoleManagementActionsWithPermissionsBoundary
             Effect: Allow
             Action:
@@ -123,4 +123,4 @@ Resources:
             Action:
               - ssm:GetParameter
             Resource:
-              - !Sub arn:aws:ssm:eu-west-1:${AWS::AccountId}:parameter:/${SystemCode}/*
+              - !Sub arn:aws:ssm:eu-west-1:${AWS::AccountId}:parameter/${SystemCode}/*

--- a/core/create/src/prompts/oidc.ts
+++ b/core/create/src/prompts/oidc.ts
@@ -255,7 +255,7 @@ export default async function oidcPrompt({ toolKitConfig }: OidcParams): Promise
         setOptions('@dotcom-tool-kit/doppler', toolKitConfig.options['@dotcom-tool-kit/doppler'])
         const dopplerProjectName = new DopplerEnvVars(winstonLogger, 'prod').options.project
         const ssmAction = 'ssm:GetParameter'
-        const ssmResource = `arn:aws:ssm:eu-west-1:\${AWS::AccountId}:parameter:/${dopplerProjectName}/*`
+        const ssmResource = `arn:aws:ssm:eu-west-1:\${AWS::AccountId}:parameter/${dopplerProjectName}/*`
         winstonLogger.info(
           `Adding a permission to allow secrets set by Doppler in Parameter Store to be read so the app is ready for the Doppler migration. Will allow the ${styles.code(
             ssmAction


### PR DESCRIPTION
# Description

The SSM [ARN](https://docs.aws.amazon.com/IAM/latest/UserGuide/reference-arns.html)'s last section specifies the path of the secret with a `parameter/` prefix. I initially thought that `parameter` was its own section delimited by a colon, with `/` signifying the root of the path, but apparently not! Looks like it's [standard](https://docs.aws.amazon.com/IAM/latest/UserGuide/reference-arns.html#arns-syntax) to prefix the resource ID in this way. The [docs](https://docs.aws.amazon.com/systems-manager/latest/userguide/sysman-paramstore-access.html) give an example ARN of `arn:aws:ssm:us-east-2:123456789012:parameter/prod-*`, _not_ `arn:aws:ssm:us-east-2:123456789012:parameter:/prod-*`.

Closes #605.

# Checklist:

- [x] My branch has been rebased onto the latest commit on main (don't merge main into your branch)
- [x] My commit messages are [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/), for example: `feat(circleci): add support for nightly workflows`, `fix: set Heroku app name for staging apps too`
