### PR TITLE
Use different format for Doppler-managed AWS keys to read previous IAM permissions

### DIFF
--- a/core/create/src/prompts/oidc.ts
+++ b/core/create/src/prompts/oidc.ts
@@ -180,8 +180,8 @@ export default async function oidcPrompt({ toolKitConfig }: OidcParams): Promise
   const dopplerSecretsSchema = z.object({
     CIRCLECI_AUTH_TOKEN: z.string(),
     GITHUB_ACCESS_TOKEN: z.string(),
-    [`AWS_ACCESS_KEY_ID_${awsAccountDopplerName}`]: z.string(),
-    [`AWS_SECRET_KEY_${awsAccountDopplerName}`]: z.string()
+    [`AWS_${awsAccountDopplerName}_ACCESS_KEY_ID`]: z.string(),
+    [`AWS_${awsAccountDopplerName}_SECRET_ACCESS_KEY`]: z.string()
   })
   const dopplerEnv = dopplerSecretsSchema.parse(await dopplerEnvVars.get())
 
@@ -235,8 +235,8 @@ export default async function oidcPrompt({ toolKitConfig }: OidcParams): Promise
     }
     if (fetchOldPermissions) {
       const previousDocument = await getPreviousIAMPermissions(
-        dopplerEnv[`AWS_ACCESS_KEY_ID_${awsAccountDopplerName}`],
-        dopplerEnv[`AWS_SECRET_KEY_${awsAccountDopplerName}`],
+        dopplerEnv[`AWS_${awsAccountDopplerName}_ACCESS_KEY_ID`],
+        dopplerEnv[`AWS_${awsAccountDopplerName}_SECRET_ACCESS_KEY`],
         serviceName
       )
       if (previousDocument) {


### PR DESCRIPTION
# Description

Doppler requires all IAM user keys it rotates automatically to use the same suffix with a custom prefix. Our suffix was previously the name of the AWS account the user was associated with but now that needs to be the prefix. You can see the new secrets in the [`dotcom-tool-kit` `prod` config](https://dashboard.doppler.com/workplace/99fbb11f5bea112e94dd/projects/dotcom-tool-kit/configs/prod). These secrets will probably never be needed seeing as the migration has been done but it made sense to use them as a test case of Doppler-managed secrets!

# Checklist:

- [x] My branch has been rebased onto the latest commit on main (don't merge main into your branch)
- [x] My commit messages are [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/), for example: `feat(circleci): add support for nightly workflows`, `fix: set Heroku app name for staging apps too`
