### PR TITLE
docs(serverless): correct the regions option documentation

### DIFF
--- a/plugins/serverless/readme.md
+++ b/plugins/serverless/readme.md
@@ -25,7 +25,7 @@ plugins:
 |-|-|-|
 | `awsAccountId` | [required] the ID of the AWS account you wish to deploy to (account IDs can be found at the [FT login page](https://awslogin.in.ft.com/)) | none |
 | `systemCode` | [required] the system code for your app | none |
-| `region` | [require] what AWS region you want to deploy to (usually `eu-west-1`) | none |
+| `regions` | [optional] an array of AWS regions you want to deploy to | `['eu-west-1']` |
 | `configPath` | [optional] path to your serverless config file. If this is not provided aws defaults to `./serverless.yml` but [other config fomats are accepted](https://www.serverless.com/framework/docs/providers/aws/guide/intro#alternative-configuration-format)| |
 | `useVault` | option to run the application with environment variables from Vault | `true` |
 | `ports` | ports to try to bind to for this application | `[3001, 3002, 3003]` |


### PR DESCRIPTION
# Description

The `regions` option was renamed but the documentation wasn't updated alongside it. I've also corrected the fact that this option isn't required – it defaults to `['eu-west-1']` in the code.

# Checklist:

- [x] My branch has been rebased onto the latest commit on main (don't merge main into your branch)
- [x] My commit messages are [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/), for example: `feat(circleci): add support for nightly workflows`, `fix: set Heroku app name for staging apps too`
