### PR TITLE
fix: remove check for undefined commands

### DIFF
--- a/core/cli/src/config.ts
+++ b/core/cli/src/config.ts
@@ -12,8 +12,12 @@ import { ToolKitConflictError } from '@dotcom-tool-kit/error'
 import { RawConfig, ValidConfig, ValidPluginsConfig } from '@dotcom-tool-kit/config'
 import {
   formatTaskConflicts,
+<<<<<<< HEAD
   formatUndefinedCommandTasks,
   formatUnusedPluginOptions,
+=======
+  formatUnusedOptions,
+>>>>>>> 6ab84a23 (fix: remove check for undefined commands)
   formatCommandTaskConflicts,
   formatHookConflicts,
   formatPluginOptionConflicts,
@@ -94,21 +98,6 @@ export function validateConfig(config: ValidPluginsConfig, logger: Logger): Vali
     }
   }
 
-  const configuredCommandTasks = withoutConflicts(Object.values(config.commandTasks))
-  const definedHookIds = new Set(Object.keys(config.hooks))
-  const undefinedCommandTasks = configuredCommandTasks.filter(() => {
-    return false //TODO
-    // we only care about undefined hooks that were configured by the app, not default config from plugins
-    // const fromApp = commandTask.plugin.root === process.cwd()
-    // const hookDefined = definedHookIds.has(commandTask.id)
-    // return fromApp && !hookDefined
-  })
-
-  if (undefinedCommandTasks.length > 0) {
-    shouldThrow = true
-    error.details += formatUndefinedCommandTasks(undefinedCommandTasks, Array.from(definedHookIds))
-  }
-
   const invalidOptions = validatePluginOptions(logger, config)
 
   if (invalidOptions.length > 0) {
@@ -138,6 +127,8 @@ export function validateConfig(config: ValidPluginsConfig, logger: Logger): Vali
     shouldThrow = true
     error.details += formatUnusedTaskOptions(unusedTaskOptions, Object.keys(config.tasks))
   }
+
+  const configuredCommandTasks = withoutConflicts(Object.values(config.commandTasks))
 
   const missingTasks = configuredCommandTasks
     .map((hook) => ({

--- a/core/cli/src/config.ts
+++ b/core/cli/src/config.ts
@@ -12,12 +12,7 @@ import { ToolKitConflictError } from '@dotcom-tool-kit/error'
 import { RawConfig, ValidConfig, ValidPluginsConfig } from '@dotcom-tool-kit/config'
 import {
   formatTaskConflicts,
-<<<<<<< HEAD
-  formatUndefinedCommandTasks,
   formatUnusedPluginOptions,
-=======
-  formatUnusedOptions,
->>>>>>> 6ab84a23 (fix: remove check for undefined commands)
   formatCommandTaskConflicts,
   formatHookConflicts,
   formatPluginOptionConflicts,

--- a/core/cli/src/messages.ts
+++ b/core/cli/src/messages.ts
@@ -93,23 +93,6 @@ You must resolve this conflict by providing options in your app's Tool Kit confi
 const formatPlugin = (plugin: Plugin): string =>
   plugin.id === 'app root' ? s.app('your app') : `plugin ${s.plugin(plugin.id)}`
 
-// TODO text similarity "did you mean...?"
-export const formatUndefinedCommandTasks = (
-  undefinedHooks: CommandTask[],
-  definedHooks: string[]
-): string => `TODO Hooks must be defined by a plugin before you can configure a task to run for them. In your Tool Kit configuration you've configured hooks that aren't defined:
-
-${undefinedHooks.map((hook) => `- ${s.hook(hook.id)}`).join('\n')}
-
-They could be misspelt, or defined by a Tool Kit plugin that isn't installed in this app.
-
-${
-  definedHooks.length > 0
-    ? `Hooks that are defined and available for tasks are: ${definedHooks.map(s.hook).join(', ')}`
-    : `There are no hooks defined by this app's plugins. You probably need to install some plugins to define hooks.`
-}.
-`
-
 export type InvalidOption = [string, z.ZodError]
 
 export const formatInvalidOptions = (


### PR DESCRIPTION
since there's no concept of "defining" a command like we had with hooks, we can remove this.