### PR TITLE
Slightly more backwards compatible

### DIFF
--- a/core/cli/src/plugin.ts
+++ b/core/cli/src/plugin.ts
@@ -77,7 +77,7 @@ export function resolvePlugin(plugin: Plugin, config: ValidPluginsConfig, logger
 
   mergeTasks(config, plugin)
   mergeHooks(config, plugin)
-  mergeCommands(config, plugin)
+  mergeCommands(config, plugin, logger)
   mergePluginOptions(config, plugin)
   mergeTaskOptions(config, plugin)
   mergeInits(config, plugin)

--- a/core/cli/src/plugin/merge-commands.ts
+++ b/core/cli/src/plugin/merge-commands.ts
@@ -2,10 +2,24 @@ import type { CommandTask, Plugin } from '@dotcom-tool-kit/plugin'
 import type { ValidPluginsConfig } from '@dotcom-tool-kit/config'
 import { Conflict, isConflict } from '@dotcom-tool-kit/conflict'
 import { isDescendent } from './is-descendent'
+import { Logger } from 'winston'
+import { styles as s } from '@dotcom-tool-kit/logger'
+import path from 'path'
 
-export const mergeCommands = (config: ValidPluginsConfig, plugin: Plugin) => {
+export const mergeCommands = (config: ValidPluginsConfig, plugin: Plugin, logger: Logger) => {
   if (plugin.rcFile) {
-    for (const [id, configCommandTask] of Object.entries(plugin.rcFile.commands)) {
+    let commands = plugin.rcFile.commands
+
+    if (plugin.rcFile.hooks) {
+      commands = plugin.rcFile.hooks
+      logger.warn(
+        `${s.code('hooks')} is deprecated in ${s.filepath('.toolkitrc.yml')}. please rename ${s.code(
+          'hooks'
+        )} to ${s.code('commands')} in ${s.filepath(path.join(plugin.root, '.toolkitrc.yml'))}.`
+      )
+    }
+
+    for (const [id, configCommandTask] of Object.entries(commands)) {
       // handle conflicts between commands from different plugins
       const existingCommandTask = config.commandTasks[id]
       const newCommandTask: CommandTask = {

--- a/core/cli/src/plugin/merge-commands.ts
+++ b/core/cli/src/plugin/merge-commands.ts
@@ -10,6 +10,8 @@ export const mergeCommands = (config: ValidPluginsConfig, plugin: Plugin, logger
   if (plugin.rcFile) {
     let commands = plugin.rcFile.commands
 
+    // TODO:KB:20240410 remove this legacy hooks field handling and the associated
+    // field in the type definitions in a future major version
     if (plugin.rcFile.hooks) {
       commands = plugin.rcFile.hooks
       logger.warn(

--- a/core/cli/src/plugin/reduce-installations.ts
+++ b/core/cli/src/plugin/reduce-installations.ts
@@ -56,11 +56,11 @@ export async function reducePluginHookInstallations(
     return hookClass.mergeChildInstallations(plugin, installations)
   })
 
-  if (plugin.rcFile.hooks.length === 0) {
+  if (plugin.rcFile.options.hooks.length === 0) {
     return childInstallations
   }
 
-  return plugin.rcFile.hooks.flatMap((hookEntry) =>
+  return plugin.rcFile.options.hooks.flatMap((hookEntry) =>
     Object.entries(hookEntry).flatMap(([id, configHookOptions]) => {
       const hookClass = hookClasses[id]
       const parsedOptions = HookSchemas[id as keyof HookOptions].parse(configHookOptions)

--- a/core/cli/src/rc-file.ts
+++ b/core/cli/src/rc-file.ts
@@ -10,8 +10,7 @@ const emptyConfig = {
   installs: {},
   tasks: {},
   commands: {},
-  options: { plugins: {}, tasks: {} },
-  hooks: [],
+  options: { plugins: {}, tasks: {}, hooks: [] },
   init: []
 } satisfies RCFile
 let rootConfig: string | undefined
@@ -51,9 +50,13 @@ export async function loadToolKitRC(logger: Logger, root: string, isAppRoot: boo
     tasks: config.tasks ?? {},
     commands: config.commands ?? {},
     options: config.options
-      ? { plugins: config.options.plugins ?? {}, tasks: config.options.tasks ?? {} }
-      : { plugins: {}, tasks: {} },
-    hooks: config.hooks ?? [],
+      ? {
+          plugins: config.options.plugins ?? {},
+          tasks: config.options.tasks ?? {},
+          hooks: config.options.hooks ?? []
+        }
+      : { plugins: {}, tasks: {}, hooks: [] },
+    hooks: config.hooks ?? undefined,
     init: config.init ?? []
   }
 }

--- a/core/create/src/index.ts
+++ b/core/create/src/index.ts
@@ -47,9 +47,11 @@ function getEslintConfigContent(): string {
 function clearConfigCache() {
   // we need to import explorer from the app itself instead of npx as this is
   // the object used by installHooks()
-  return (importCwd('dotcom-tool-kit/lib/rc-file') as {
-    explorer: ReturnType<typeof cosmiconfig>
-  }).explorer.clearSearchCache()
+  return (
+    importCwd('dotcom-tool-kit/lib/rc-file') as {
+      explorer: ReturnType<typeof cosmiconfig>
+    }
+  ).explorer.clearSearchCache()
 }
 
 async function executeMigration(
@@ -116,8 +118,7 @@ async function main() {
     installs: {},
     tasks: {},
     commands: {},
-    options: { plugins: {}, tasks: {} },
-    hooks: [],
+    options: { plugins: {}, tasks: {}, hooks: [] },
     init: []
   }
 

--- a/lib/plugin/src/index.ts
+++ b/lib/plugin/src/index.ts
@@ -3,11 +3,12 @@ export type RCFile = {
   installs: { [id: string]: string }
   tasks: { [id: string]: string }
   commands: { [id: string]: string | string[] }
+  hooks?: { [id: string]: string | string[] }
   options: {
     plugins: { [id: string]: Record<string, unknown> }
     tasks: { [id: string]: Record<string, unknown> }
+    hooks: { [id: string]: Record<string, unknown> }[]
   }
-  hooks: { [id: string]: Record<string, unknown> }[]
   init: string[]
 }
 


### PR DESCRIPTION
this Should<sup>TM</sup> allow most<sup>[citation needed]</sup> apps' toolkitrcs to load without any changes, just by updating Tool Kit

- renames the new .toolkitrc field `hooks` to `options.hooks`
- reënables specifying the old-style `hooks` in .toolkitrc, treating it as equivalent to the new `commands`, printing a warning