### PR TITLE
Backwards compatible .toolkitrc options field

### DIFF
--- a/core/cli/src/rc-file.ts
+++ b/core/cli/src/rc-file.ts
@@ -49,6 +49,7 @@ export async function loadToolKitRC(logger: Logger, root: string, isAppRoot: boo
 
   // if a toolkitrc contains a non-empty options field, but not options.{plugins,tasks,hooks},
   // assume it's an old-style, plugins-only options field.
+  // TODO:KB:20240410 remove this legacy options field handling in a future major version
   if (
     config.options &&
     Object.keys(config.options).length > 0 &&


### PR DESCRIPTION
old `.toolkitrc`s contain `options` with just plugin options. these are now nested under `options.plugins`. if an `options` is non-empty, but doesn't contain any of the new top-level fields, assume it's old-style, and nest it.

**nb** this probably won't actually work in most cases, as the options are all moving around in #570. but we'll at least get semi-useful schema errors. maybe?