### PR TITLE
chore: remove duplicate runInit call in runTasks

### DIFF
--- a/core/cli/src/tasks.ts
+++ b/core/cli/src/tasks.ts
@@ -72,7 +72,6 @@ ${availableCommands}`
 
   await runInit(logger, config)
   await checkInstall(logger, config)
-  await runInit(logger, config)
 
   if (shouldDisableNativeFetch()) {
     process.execArgv.push('--no-experimental-fetch')


### PR DESCRIPTION
how did that get there