### PR TITLE
Don't generate matrices in CircleCI config if only one Node version is being tested

### DIFF
--- a/plugins/circleci/test/circleci-config.test.ts
+++ b/plugins/circleci/test/circleci-config.test.ts
@@ -116,7 +116,7 @@ describe('CircleCI config hook', () => {
               jobs: expect.arrayContaining([
                 expect.objectContaining({
                   'tool-kit/test-job': expect.objectContaining({
-                    requires: ['waiting-for-approval', 'tool-kit/that-job-node']
+                    requires: ['waiting-for-approval', 'tool-kit/that-job']
                   })
                 })
               ])

--- a/plugins/circleci/test/files/with-hook/.circleci/config.yml
+++ b/plugins/circleci/test/files/with-hook/.circleci/config.yml
@@ -4,5 +4,5 @@ workflows:
       - tool-kit/test-job:
           requires:
             - waiting-for-approval
-            - tool-kit/that-job-node
+            - tool-kit/that-job
           executor: node


### PR DESCRIPTION
# Description

This creates much simpler config for the majority of projects (i.e., projects that don't need to test against multiple versions of Node.) For example, here's the diff for next-static's config after its config is reinstalled:

```patch
diff --git a/.circleci/config.yml b/.circleci/config.yml
index 9aded16..aad31b5 100644
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -32,42 +32,30 @@ workflows:
             branches:
               only: /(^renovate-.*|^nori/.*)/
       - tool-kit/setup:
-          name: tool-kit/setup-<< matrix.executor >>
+          executor: node
           requires:
             - checkout
             - waiting-for-approval
-          matrix:
-            parameters:
-              executor:
-                - node
           filters:
             tags:
               only: /^v\d+\.\d+\.\d+(-.+)?/
       - tool-kit/build:
-          name: tool-kit/build-<< matrix.executor >>
           requires:
-            - tool-kit/setup-<< matrix.executor >>
-          matrix:
-            parameters:
-              executor:
-                - node
+            - tool-kit/setup
+          executor: node
           filters:
             tags:
               only: /^v\d+\.\d+\.\d+(-.+)?/
       - tool-kit/test:
-          name: tool-kit/test-<< matrix.executor >>
           requires:
-            - tool-kit/build-<< matrix.executor >>
-          matrix:
-            parameters:
-              executor:
-                - node
+            - tool-kit/build
+          executor: node
           filters:
             tags:
               only: /^v\d+\.\d+\.\d+(-.+)?/
       - tool-kit/deploy-review:
           requires:
-            - tool-kit/setup-node
+            - tool-kit/setup
             - waiting-for-approval
           executor: node
           filters:
@@ -77,7 +65,7 @@ workflows:
               ignore: main
       - tool-kit/deploy-staging:
           requires:
-            - tool-kit/setup-node
+            - tool-kit/setup
           executor: node
           filters:
             tags:
@@ -100,7 +88,7 @@ workflows:
               only: /^v\d+\.\d+\.\d+(-.+)?/
       - tool-kit/deploy-production:
           requires:
-            - tool-kit/test-node
+            - tool-kit/test
             - tool-kit/e2e-test-staging
           executor: node
           filters:
@@ -120,32 +108,20 @@ workflows:
     jobs:
       - checkout
       - tool-kit/setup:
-          name: tool-kit/setup-<< matrix.executor >>
+          executor: node
           requires:
             - checkout
-          matrix:
-            parameters:
-              executor:
-                - node
       - tool-kit/build:
-          name: tool-kit/build-<< matrix.executor >>
           requires:
-            - tool-kit/setup-<< matrix.executor >>
-          matrix:
-            parameters:
-              executor:
-                - node
+            - tool-kit/setup
+          executor: node
       - tool-kit/test:
-          name: tool-kit/test-<< matrix.executor >>
           requires:
-            - tool-kit/build-<< matrix.executor >>
-          matrix:
-            parameters:
-              executor:
-                - node
+            - tool-kit/build
+          executor: node
       - tool-kit/deploy-review:
           requires:
-            - tool-kit/setup-node
+            - tool-kit/setup
             - waiting-for-approval
           executor: node
           filters:
``` 

# Checklist:

- [x] My branch has been rebased onto the latest commit on ~~main~~ next (don't merge main into your branch)
- [x] My commit messages are [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/), for example: `feat(circleci): add support for nightly workflows`, `fix: set Heroku app name for staging apps too`
