### PR TITLE
feat: exit running tasks early if the task threw an error with an exitCode

### DIFF
--- a/core/cli/src/index.ts
+++ b/core/cli/src/index.ts
@@ -81,7 +81,12 @@ ${availableHooks}`
       try {
         await task.run(files)
       } catch (error) {
-        // allow subsequent hook tasks to run on error
+        // if there's an exit code, that's a request from the task to exit early
+        if(error instanceof ToolKitError && error.exitCode) {
+          throw error
+        }
+
+        // if not, we allow subsequent hook tasks to run on error
         errors.push({
           hook,
           task: id,

--- a/plugins/eslint/src/tasks/eslint.ts
+++ b/plugins/eslint/src/tasks/eslint.ts
@@ -18,7 +18,6 @@ export default class Eslint extends Task<typeof ESLintSchema> {
     if (errorCount > 0) {
       const error = new ToolKitError('eslint returned linting errors')
       error.details = resultText
-      error.exitCode = errorCount
       throw error
     } else {
       this.logger.info(styles.title('ESLint output was:'))


### PR DESCRIPTION
as requested by @GlynnPhillips. there's currently no way to exit tasks early on error and _not_ run subsequent tasks in the command's task array.