### PR TITLE
CPP-2041 CPP-2030 Add support for tags in Tool Kit config that resolve to values of options

### DIFF
--- a/core/cli/package.json
+++ b/core/cli/package.json
@@ -50,14 +50,13 @@
     "@dotcom-tool-kit/plugin": "^1.0.0",
     "@dotcom-tool-kit/validated": "^1.0.0",
     "@dotcom-tool-kit/wait-for-ok": "^3.2.0",
-    "cosmiconfig": "^7.0.0",
     "endent": "^2.1.0",
     "lodash": "^4.17.21",
     "minimist": "^1.2.5",
     "resolve-from": "^5.0.0",
     "resolve-pkg": "^2.0.0",
     "tslib": "^2.3.1",
-    "yaml": "^1.10.2",
+    "yaml": "^2.4.1",
     "zod-validation-error": "^2.1.0"
   },
   "engines": {

--- a/core/cli/src/plugin.ts
+++ b/core/cli/src/plugin.ts
@@ -37,7 +37,7 @@ export async function loadPlugin(
     id,
     root: pluginRoot,
     parent,
-    rcFile: await loadToolKitRC(logger, pluginRoot, isAppRoot),
+    rcFile: await loadToolKitRC(logger, pluginRoot),
     children: [] as Plugin[]
   }
 

--- a/core/cli/src/plugin.ts
+++ b/core/cli/src/plugin.ts
@@ -71,10 +71,29 @@ export async function loadPlugin(
     })
 }
 
+export function resolvePluginOptions(plugin: Plugin, config: ValidPluginsConfig): void {
+  // don't resolve plugins that have already been resolved to prevent self-conflicts
+  // between plugins included at multiple points in the tree
+  if (config.resolutionTrackers.resolvedPluginOptions.has(plugin.id)) {
+    return
+  }
+
+  if (plugin.children) {
+    // resolve child plugins first so parents can override the things their children set
+    for (const child of plugin.children) {
+      resolvePluginOptions(child, config)
+    }
+  }
+
+  mergePluginOptions(config, plugin)
+
+  config.resolutionTrackers.resolvedPluginOptions.add(plugin.id)
+}
+
 export function resolvePlugin(plugin: Plugin, config: ValidPluginsConfig, logger: Logger): void {
   // don't resolve plugins that have already been resolved to prevent self-conflicts
   // between plugins included at multiple points in the tree
-  if (config.resolvedPlugins.has(plugin.id)) {
+  if (config.resolutionTrackers.resolvedPlugins.has(plugin.id)) {
     return
   }
 
@@ -88,9 +107,8 @@ export function resolvePlugin(plugin: Plugin, config: ValidPluginsConfig, logger
   mergeTasks(config, plugin)
   mergeHooks(config, plugin)
   mergeCommands(config, plugin, logger)
-  mergePluginOptions(config, plugin)
   mergeTaskOptions(config, plugin)
   mergeInits(config, plugin)
 
-  config.resolvedPlugins.add(plugin.id)
+  config.resolutionTrackers.resolvedPlugins.add(plugin.id)
 }

--- a/core/cli/src/plugin/options.ts
+++ b/core/cli/src/plugin/options.ts
@@ -1,10 +1,15 @@
 import { ValidPluginsConfig } from '@dotcom-tool-kit/config'
-import { InvalidOption } from '../messages'
-import { type PluginOptions, PluginSchemas, legacyPluginOptions } from '@dotcom-tool-kit/schemas'
 import { isConflict } from '@dotcom-tool-kit/conflict'
+import { ToolKitError } from '@dotcom-tool-kit/error'
+import { OptionsForPlugin, RCFile, type Plugin } from '@dotcom-tool-kit/plugin'
+import { type PluginOptions, PluginSchemas, legacyPluginOptions } from '@dotcom-tool-kit/schemas'
+
 import type { Logger } from 'winston'
 import { ZodError, ZodIssueCode } from 'zod'
 import { styles } from '@dotcom-tool-kit/logger'
+
+import { toolKitIfDefinedIdent, toolKitOptionIdent } from '../rc-file'
+import { InvalidOption } from '../messages'
 
 export const validatePluginOptions = (logger: Logger, config: ValidPluginsConfig): InvalidOption[] => {
   const invalidOptions: InvalidOption[] = []
@@ -58,4 +63,74 @@ export const validatePluginOptions = (logger: Logger, config: ValidPluginsConfig
   }
 
   return invalidOptions
+}
+
+export const substituteOptionTags = (plugin: Plugin, config: ValidPluginsConfig): void => {
+  // foo.bar gets the 'bar' option set for the 'foo' plugin
+  const resolveOptionPath = (optionPath: string): unknown => {
+    const [pluginName, optionName] = optionPath.split('.', 2)
+    return (config.pluginOptions[pluginName] as OptionsForPlugin)?.options[optionName]
+  }
+
+  // throw an error if there are tags in plugin option fields to avoid circular
+  // references
+  const validateTagPath = (path: (string | number)[]) => {
+    if (path[0] === 'options' && path[1] === 'plugins') {
+      const error = new ToolKitError('cannot reference plugin options when specifying options')
+      error.details = `YAML tag referencing options used at path '${path.join('.')}'`
+      throw error
+    }
+  }
+
+  // recursively walk through the parsed config, searching for the tag
+  // identifiers we've inserted during parsing, and substitute them for
+  // resolved option values
+  const deeplySubstitute = (node: unknown, path: (string | number)[]): unknown => {
+    if (Array.isArray(node)) {
+      return node.map((item, i) => deeplySubstitute(item, [...path, i]))
+    } else if (node && typeof node === 'object') {
+      const entries = Object.entries(node)
+      // !toolkit/option will be marked as a single entry within an object
+      // e.g., { foo: { '__toolkit/option__': 'foo.bar' } }
+      if (entries[0]?.[0] === toolKitOptionIdent) {
+        validateTagPath(path)
+        const optionPath = entries[0][1] as string
+        return resolveOptionPath(optionPath)
+      } else {
+        const substituted: Record<string, unknown> = {}
+        for (const [key, value] of entries) {
+          if (key.startsWith(toolKitIfDefinedIdent)) {
+            validateTagPath(path)
+            // the option path is concatenated after the !toolkit/if-defined
+            // identifier
+            const optionPath = key.slice(toolKitIfDefinedIdent.length)
+            const optionValue = resolveOptionPath(optionPath)
+            if (optionValue) {
+              Object.assign(substituted, deeplySubstitute(value, path))
+            } // don't include the node if !optionValue
+          } else {
+            substituted[key] = deeplySubstitute(value, [...path, key])
+          }
+        }
+        return substituted
+      }
+    } else {
+      return node
+    }
+  }
+
+  // avoid running substitution over a config repeatedly – all substitutions
+  // will have been made in the first pass
+  if (config.resolutionTrackers.substitutedPlugins.has(plugin.id)) {
+    return
+  }
+  if (plugin.children) {
+    for (const child of plugin.children) {
+      substituteOptionTags(child, config)
+    }
+  }
+  if (plugin.rcFile) {
+    plugin.rcFile = deeplySubstitute(plugin.rcFile, []) as RCFile
+  }
+  config.resolutionTrackers.substitutedPlugins.add(plugin.id)
 }

--- a/core/cli/src/plugin/options.ts
+++ b/core/cli/src/plugin/options.ts
@@ -1,8 +1,8 @@
 import { ValidPluginsConfig } from '@dotcom-tool-kit/config'
 import { isConflict } from '@dotcom-tool-kit/conflict'
-import { ToolKitError } from '@dotcom-tool-kit/error'
 import { OptionsForPlugin, RCFile, type Plugin } from '@dotcom-tool-kit/plugin'
 import { type PluginOptions, PluginSchemas, legacyPluginOptions } from '@dotcom-tool-kit/schemas'
+import { invalid, reduceValidated, valid, Validated } from '@dotcom-tool-kit/validated'
 
 import type { Logger } from 'winston'
 import { ZodError, ZodIssueCode } from 'zod'
@@ -74,48 +74,64 @@ export const substituteOptionTags = (plugin: Plugin, config: ValidPluginsConfig)
 
   // throw an error if there are tags in plugin option fields to avoid circular
   // references
-  const validateTagPath = (path: (string | number)[]) => {
+  const validateTagPath = (path: (string | number)[]): string | void => {
     if (path[0] === 'options' && path[1] === 'plugins') {
-      const error = new ToolKitError('cannot reference plugin options when specifying options')
-      error.details = `YAML tag referencing options used at path '${path.join('.')}'`
-      throw error
+      return `YAML tag referencing options used at path '${path.join('.')}'`
     }
   }
 
   // recursively walk through the parsed config, searching for the tag
   // identifiers we've inserted during parsing, and substitute them for
   // resolved option values
-  const deeplySubstitute = (node: unknown, path: (string | number)[]): unknown => {
+  const deeplySubstitute = (node: unknown, path: (string | number)[]): Validated<unknown> => {
     if (Array.isArray(node)) {
-      return node.map((item, i) => deeplySubstitute(item, [...path, i]))
+      return reduceValidated(node.map((item, i) => deeplySubstitute(item, [...path, i])))
     } else if (node && typeof node === 'object') {
       const entries = Object.entries(node)
       // !toolkit/option will be marked as a single entry within an object
       // e.g., { foo: { '__toolkit/option__': 'foo.bar' } }
       if (entries[0]?.[0] === toolKitOptionIdent) {
-        validateTagPath(path)
-        const optionPath = entries[0][1] as string
-        return resolveOptionPath(optionPath)
+        const validationError = validateTagPath(path)
+        if (validationError) {
+          return invalid([validationError])
+        } else {
+          const optionPath = entries[0][1] as string
+          return valid(resolveOptionPath(optionPath))
+        }
       } else {
-        const substituted: Record<string, unknown> = {}
+        const substituted: Validated<[string, unknown]>[] = []
         for (const [key, value] of entries) {
           if (key.startsWith(toolKitIfDefinedIdent)) {
-            validateTagPath(path)
+            const validationError = validateTagPath(path)
+            if (validationError) {
+              substituted.push(invalid([validationError]))
+            }
             // the option path is concatenated after the !toolkit/if-defined
             // identifier
             const optionPath = key.slice(toolKitIfDefinedIdent.length)
             const optionValue = resolveOptionPath(optionPath)
-            if (optionValue) {
-              Object.assign(substituted, deeplySubstitute(value, path))
-            } // don't include the node if !optionValue
+            // keep walking the path if we've found an error here so we can
+            // gather even more errors to show the user. else skip traversal if
+            // we aren't going to include the node
+            if (optionValue || validationError) {
+              const subbedValues = deeplySubstitute(value, path)
+              if (subbedValues.valid) {
+                substituted.push(...Object.entries(subbedValues.value as object).map((v) => valid(v)))
+              } else {
+                /* eslint-disable-next-line @typescript-eslint/no-explicit-any --
+                 * Invalid objects don't need to match the inner type
+                 **/
+                substituted.push(subbedValues as Validated<any>)
+              }
+            }
           } else {
-            substituted[key] = deeplySubstitute(value, [...path, key])
+            substituted.push(deeplySubstitute(value, [...path, key]).map((subbedValue) => [key, subbedValue]))
           }
         }
-        return substituted
+        return reduceValidated(substituted).map(Object.fromEntries)
       }
     } else {
-      return node
+      return valid(node)
     }
   }
 
@@ -130,7 +146,9 @@ export const substituteOptionTags = (plugin: Plugin, config: ValidPluginsConfig)
     }
   }
   if (plugin.rcFile) {
-    plugin.rcFile = deeplySubstitute(plugin.rcFile, []) as RCFile
+    plugin.rcFile = deeplySubstitute(plugin.rcFile, []).unwrap(
+      'cannot reference plugin options when specifying options'
+    ) as RCFile
   }
   config.resolutionTrackers.substitutedPlugins.add(plugin.id)
 }

--- a/core/cli/src/rc-file.ts
+++ b/core/cli/src/rc-file.ts
@@ -14,6 +14,8 @@ const emptyConfig = {
   init: []
 } satisfies RCFile
 
+// TODO:IM:20240418 define another type that accounts for the custom tags
+// existing deeply within the file
 type RawRCFile = {
   [key in Exclude<keyof RCFile, 'options'>]?: RCFile[key] | null
 } & {
@@ -24,6 +26,28 @@ type RawRCFile = {
     | null
 }
 
+// yaml will automatically stringify any symbols in keys so just use strings
+// that won't be used normally
+export const toolKitOptionIdent = '__toolkit/option__'
+export const toolKitIfDefinedIdent = '__toolkit/if-defined__'
+
+// minimally define the two custom tags' identify callback so that yaml will
+// parse them without warning but will never be use them when stringifying
+const toolKitOption = {
+  identify: () => false,
+  tag: '!toolkit/option',
+  // wrap option path with identifier so we can substitute the option's value
+  // once it's been resolved later
+  resolve: (option) => ({ [toolKitOptionIdent]: option })
+} satisfies YAML.ScalarTag
+const toolKitIfDefined = {
+  identify: () => false,
+  tag: '!toolkit/if-defined',
+  // the resolve callback doesn't allow us to manipulate the whole YAML.Pair
+  // with this tagged key, so just return it unchanged now and find the tag in
+  // a YAML.visit later
+  resolve: (value) => value
+} satisfies YAML.ScalarTag
 
 export async function loadToolKitRC(logger: Logger, root: string): Promise<RCFile> {
   let rawConfig: string
@@ -37,7 +61,20 @@ export async function loadToolKitRC(logger: Logger, root: string): Promise<RCFil
     }
   }
 
-  const config: RawRCFile = YAML.parse(rawConfig)
+  const configDoc = YAML.parseDocument(rawConfig, { customTags: [toolKitOption, toolKitIfDefined] })
+  // go back and search for the parsed if-defined tag and include a string
+  // identifier so we can resolve all the tags in a JS object once we've loaded
+  // plugin options
+  YAML.visit(configDoc, {
+    Pair(_, pair) {
+      if (YAML.isScalar(pair.key) && pair.key.tag === '!toolkit/if-defined') {
+        // mangle the option name with the identifier so that multiple
+        // !toolkit/if-defined tags can be used in the same map with unique keys
+        return configDoc.createPair(`${toolKitIfDefinedIdent}${pair.key.value}`, pair.value)
+      }
+    }
+  })
+  const config: RawRCFile = configDoc.toJS() ?? {}
 
   // if a toolkitrc contains a non-empty options field, but not options.{plugins,tasks,hooks},
   // assume it's an old-style, plugins-only options field.

--- a/core/cli/test/index.test.ts
+++ b/core/cli/test/index.test.ts
@@ -6,7 +6,7 @@ import { describe, expect, it, jest } from '@jest/globals'
 import * as path from 'path'
 import winston, { Logger } from 'winston'
 import { createConfig, validateConfig } from '../src/config'
-import { loadPlugin, resolvePlugin } from '../src/plugin'
+import { loadPlugin, resolvePlugin, resolvePluginOptions } from '../src/plugin'
 import { validatePlugins } from '../src/config/validate-plugins'
 
 const logger = winston as unknown as Logger
@@ -30,6 +30,7 @@ describe('cli', () => {
     expect(validatedPluginConfig.valid).toBe(true)
     const validPluginConfig = (validatedPluginConfig as Valid<ValidPluginsConfig>).value
 
+    resolvePluginOptions((plugin as Valid<Plugin>).value, validPluginConfig)
     resolvePlugin((plugin as Valid<Plugin>).value, validPluginConfig, logger)
 
     expect(() => validateConfig(validPluginConfig, logger)).toThrow(ToolKitError)
@@ -51,6 +52,7 @@ describe('cli', () => {
     expect(validatedPluginConfig.valid).toBe(true)
     const validPluginConfig = (validatedPluginConfig as Valid<ValidPluginsConfig>).value
 
+    resolvePluginOptions((plugin as Valid<Plugin>).value, validPluginConfig)
     resolvePlugin((plugin as Valid<Plugin>).value, validPluginConfig, logger)
 
     expect(() => validateConfig(validPluginConfig, logger)).toThrow(ToolKitError)
@@ -72,6 +74,7 @@ describe('cli', () => {
     expect(validatedPluginConfig.valid).toBe(true)
     const validPluginConfig = (validatedPluginConfig as Valid<ValidPluginsConfig>).value
 
+    resolvePluginOptions((plugin as Valid<Plugin>).value, validPluginConfig)
     resolvePlugin((plugin as Valid<Plugin>).value, validPluginConfig, logger)
 
     try {
@@ -99,6 +102,7 @@ describe('cli', () => {
     expect(validatedPluginConfig.valid).toBe(true)
     const validPluginConfig = (validatedPluginConfig as Valid<ValidPluginsConfig>).value
 
+    resolvePluginOptions((plugin as Valid<Plugin>).value, validPluginConfig)
     resolvePlugin((plugin as Valid<Plugin>).value, validPluginConfig, logger)
 
     try {

--- a/core/cli/test/options.test.ts
+++ b/core/cli/test/options.test.ts
@@ -1,0 +1,109 @@
+import { loadConfig } from '../src/config'
+
+import * as fs from 'node:fs/promises'
+
+import type { Valid } from '@dotcom-tool-kit/validated'
+import type { Plugin } from '@dotcom-tool-kit/plugin'
+
+import winston, { type Logger } from 'winston'
+
+const logger = winston as unknown as Logger
+
+jest.mock('node:fs/promises')
+const mockedFs = jest.mocked(fs)
+
+// convince text editors (well, nvim) to highlight strings as YAML
+const yaml = (str) => str
+
+describe('option substitution', () => {
+  it('should substitute option tag with option value', async () => {
+    mockedFs.readFile.mockResolvedValueOnce(
+      yaml(`
+options:
+  plugins:
+    test:
+      foo: bar
+  hooks:
+    - Test:
+        baz: !toolkit/option 'test.foo'
+`)
+    )
+
+    const config = await loadConfig(logger, { validate: false })
+    const plugin = config.plugins['app root']
+    expect(plugin.valid).toBe(true)
+    expect((plugin as Valid<Plugin>).value.rcFile?.options.hooks[0].Test.baz).toEqual('bar')
+  })
+
+  it('should substitute defined tag with value when defined', async () => {
+    mockedFs.readFile.mockResolvedValueOnce(
+      yaml(`
+options:
+  plugins:
+    test:
+      foo: bar
+  hooks:
+    - Test:
+        !toolkit/if-defined 'test.foo':
+          hello: world
+`)
+    )
+
+    const config = await loadConfig(logger, { validate: false })
+    const plugin = config.plugins['app root']
+    expect(plugin.valid).toBe(true)
+    expect((plugin as Valid<Plugin>).value.rcFile?.options.hooks[0].Test.hello).toEqual('world')
+  })
+
+  it('should delete defined tag when not defined', async () => {
+    mockedFs.readFile.mockResolvedValueOnce(
+      yaml(`
+options:
+  hooks:
+    - Test:
+        !toolkit/if-defined 'test.foo':
+          hello: world
+`)
+    )
+
+    const config = await loadConfig(logger, { validate: false })
+    const plugin = config.plugins['app root']
+    expect(plugin.valid).toBe(true)
+    expect((plugin as Valid<Plugin>).value.rcFile?.options.hooks[0].Test.hello).toBeUndefined()
+  })
+
+  it('should support nested tags', async () => {
+    mockedFs.readFile.mockResolvedValueOnce(
+      yaml(`
+options:
+  plugins:
+    test:
+      foo: bar
+  hooks:
+    - Test:
+        !toolkit/if-defined 'test.foo':
+          hello: !toolkit/option 'test.foo'
+`)
+    )
+
+    const config = await loadConfig(logger, { validate: false })
+    const plugin = config.plugins['app root']
+    expect(plugin.valid).toBe(true)
+    expect((plugin as Valid<Plugin>).value.rcFile?.options.hooks[0].Test.hello).toEqual('bar')
+  })
+
+  it('should disallow tags within plugin options', async () => {
+    mockedFs.readFile.mockResolvedValueOnce(
+      yaml(`
+options:
+  plugins:
+    test:
+      foo: !toolkit/option 'test.foo'
+`)
+    )
+
+    expect(loadConfig(logger, { validate: false })).rejects.toThrowErrorMatchingInlineSnapshot(
+      `"cannot reference plugin options when specifying options"`
+    )
+  })
+})

--- a/core/create/package.json
+++ b/core/create/package.json
@@ -16,7 +16,6 @@
     "@dotcom-tool-kit/doppler": "^1.1.0",
     "@dotcom-tool-kit/error": "^3.2.0",
     "@dotcom-tool-kit/logger": "^3.4.0",
-    "@dotcom-tool-kit/schemas": "^1.0.0",
     "@dotcom-tool-kit/plugin": "^1.0.0",
     "@dotcom-tool-kit/schemas": "^1.0.0",
     "@octokit/rest": "^19.0.5",
@@ -53,7 +52,6 @@
     "@types/node-fetch": "^2.6.2",
     "@types/pacote": "^11.1.3",
     "@types/prompts": "^2.0.14",
-    "cosmiconfig": "^7.0.1",
     "dotcom-tool-kit": "^3.4.5",
     "type-fest": "^3.13.1"
   },

--- a/core/create/src/index.ts
+++ b/core/create/src/index.ts
@@ -2,7 +2,6 @@ import * as ToolkitErrorModule from '@dotcom-tool-kit/error'
 import { rootLogger as winstonLogger, styles } from '@dotcom-tool-kit/logger'
 import type { RCFile } from '@dotcom-tool-kit/plugin'
 import { exec as _exec } from 'child_process'
-import type { cosmiconfig } from 'cosmiconfig'
 import type { loadConfig as loadConfigType } from 'dotcom-tool-kit/lib/config'
 import fs, { promises as fsp } from 'fs'
 import importCwd from 'import-cwd'
@@ -42,16 +41,6 @@ function getEslintConfigContent(): string {
   }
 };`
   return eslintContentString
-}
-
-function clearConfigCache() {
-  // we need to import explorer from the app itself instead of npx as this is
-  // the object used by installHooks()
-  return (
-    importCwd('dotcom-tool-kit/lib/rc-file') as {
-      explorer: ReturnType<typeof cosmiconfig>
-    }
-  ).explorer.clearSearchCache()
 }
 
 async function executeMigration(
@@ -173,7 +162,6 @@ async function main() {
   if (optionsCancelled) {
     return
   }
-  clearConfigCache()
   try {
     await catchToolKitErrorsInLogger(logger, installHooks(winstonLogger), 'installing Tool Kit hooks', true)
   } catch (error) {
@@ -189,14 +177,12 @@ async function main() {
       if (conflictsCancelled) {
         return
       }
-      clearConfigCache()
       await catchToolKitErrorsInLogger(
         logger,
         installHooks(winstonLogger),
         'installing Tool Kit hooks again',
         false
       )
-      clearConfigCache()
     } else {
       throw error
     }

--- a/lib/config/src/index.ts
+++ b/lib/config/src/index.ts
@@ -12,7 +12,11 @@ import type { Conflict } from '@dotcom-tool-kit/conflict'
 export interface RawConfig {
   root: string
   plugins: { [id: string]: Validated<Plugin> }
-  resolvedPlugins: Set<string>
+  resolutionTrackers: {
+    resolvedPluginOptions: Set<string>
+    substitutedPlugins: Set<string>
+    resolvedPlugins: Set<string>
+  }
   tasks: { [id: string]: EntryPoint | Conflict<EntryPoint> }
   commandTasks: { [id: string]: CommandTask | Conflict<CommandTask> }
   pluginOptions: { [id: string]: OptionsForPlugin | Conflict<OptionsForPlugin> | undefined }

--- a/package-lock.json
+++ b/package-lock.json
@@ -186,7 +186,6 @@
         "@types/node-fetch": "^2.6.2",
         "@types/pacote": "^11.1.3",
         "@types/prompts": "^2.0.14",
-        "cosmiconfig": "^7.0.1",
         "dotcom-tool-kit": "^3.4.5",
         "type-fest": "^3.13.1"
       },

--- a/package-lock.json
+++ b/package-lock.json
@@ -59,14 +59,13 @@
         "@dotcom-tool-kit/plugin": "^1.0.0",
         "@dotcom-tool-kit/validated": "^1.0.0",
         "@dotcom-tool-kit/wait-for-ok": "^3.2.0",
-        "cosmiconfig": "^7.0.0",
         "endent": "^2.1.0",
         "lodash": "^4.17.21",
         "minimist": "^1.2.5",
         "resolve-from": "^5.0.0",
         "resolve-pkg": "^2.0.0",
         "tslib": "^2.3.1",
-        "yaml": "^1.10.2",
+        "yaml": "^2.4.1",
         "zod-validation-error": "^2.1.0"
       },
       "bin": {
@@ -126,6 +125,17 @@
       "version": "2.4.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
       "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA=="
+    },
+    "core/cli/node_modules/yaml": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.4.1.tgz",
+      "integrity": "sha512-pIXzoImaqmfOrL7teGUBt/T7ZDnyeGBWyXQBvOVhLkWLN37GXv8NMLK406UY6dS51JfcQHsmcW5cJ441bHg6Lg==",
+      "bin": {
+        "yaml": "bin.mjs"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
     },
     "core/cli/node_modules/zod-validation-error": {
       "version": "2.1.0",
@@ -1092,6 +1102,7 @@
     },
     "core/sandbox": {
       "version": "1.0.0",
+      "extraneous": true,
       "license": "ISC",
       "dependencies": {
         "@dotcom-tool-kit/base": "file:../../lib/base",
@@ -24457,10 +24468,6 @@
       "version": "2.1.2",
       "license": "MIT"
     },
-    "node_modules/sandbox": {
-      "resolved": "core/sandbox",
-      "link": true
-    },
     "node_modules/sax": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/sax/-/sax-1.2.1.tgz",
@@ -30747,7 +30754,7 @@
       },
       "peerDependencies": {
         "dotcom-tool-kit": "3.x",
-        "typescript": "3.x || 4.x"
+        "typescript": "3.x || 4.x || 5.x"
       }
     },
     "plugins/typescript/node_modules/@babel/code-frame": {

--- a/plugins/circleci-deploy/.toolkitrc.yml
+++ b/plugins/circleci-deploy/.toolkitrc.yml
@@ -40,11 +40,20 @@ options:
                   - 'deploy-review'
                 splitIntoMatrix: false
                 custom:
+                  !toolkit/if-defined '@dotcom-tool-kit/circleci.cypressImage':
+                    executor: cypress
+                  !toolkit/if-defined '@dotcom-tool-kit/serverless.awsAccountId':
+                    aws-account-id: !toolkit/option '@dotcom-tool-kit/serverless.awsAccountId'
+                    system-code: !toolkit/option '@dotcom-tool-kit/serverless.systemCode'
+                  !toolkit/if-defined '@dotcom-tool-kit/next-router.appName':
+                    appName: !toolkit/option '@dotcom-tool-kit/next-router.appName'
               - name: 'e2e-test-staging'
                 splitIntoMatrix: false
                 requires:
                   - 'deploy-staging'
                 custom:
+                  !toolkit/if-defined '@dotcom-tool-kit/circleci.cypressImage':
+                    executor: cypress
               - name: 'deploy-production'
                 requires:
                   - 'test'
@@ -54,6 +63,9 @@ options:
                   filters:
                     branches:
                       only: main
+                  !toolkit/if-defined '@dotcom-tool-kit/serverless.awsAccountId':
+                    aws-account-id: !toolkit/option '@dotcom-tool-kit/serverless.awsAccountId'
+                    system-code: !toolkit/option '@dotcom-tool-kit/serverless.systemCode'
           - name: 'nightly'
             jobs:
               - name: 'deploy-review'
@@ -65,5 +77,12 @@ options:
                   filters:
                     branches:
                       ignore: main
+                  !toolkit/if-defined '@dotcom-tool-kit/serverless.awsAccountId':
+                    aws-account-id: !toolkit/option '@dotcom-tool-kit/serverless.awsAccountId'
+                    system-code: !toolkit/option '@dotcom-tool-kit/serverless.systemCode'
+      !toolkit/if-defined '@dotcom-tool-kit/circleci.cypressImage':
+        executors:
+          - name: cypress
+            image: !toolkit/option '@dotcom-tool-kit/circleci.cypressImage'
 
 version: 2


### PR DESCRIPTION
# Description

These two custom YAML tags allow us to define all the different combinations of Serverless and Cypress configuration needed to be added to CircleCI config. These were previously defined in JavaScript functions that were hard to compose but now they can be specified in a declarative, readable syntax along with the rest of the config.

There are two tags available currently: `!toolkit/option` will substitute the specified option as a string into your config, whilst `!toolkit/defined` will conditionally include its value in your config if the specified option is defined. You can see how they can be used in the test cases and in `circleci-deploy`'s updated config (scroll down all the way to the end of the PR for that!)

# Checklist:

- [x] My branch has been rebased onto the latest commit on main (don't merge main into your branch)
- [x] My commit messages are [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/), for example: `feat(circleci): add support for nightly workflows`, `fix: set Heroku app name for staging apps too`
