### PR TITLE
CPP-1748 Define hook options for all packages previously using PackageJsonHelper hook

### DIFF
--- a/core/cli/bin/run
+++ b/core/cli/bin/run
@@ -1,5 +1,9 @@
 #!/usr/bin/env node
 
+/* eslint-disable @typescript-eslint/no-var-requires --
+ * this is raw CJS so the lint doesn't apply
+ */
+
 const argv = require('minimist')(process.argv.slice(2), {
   boolean: ['help', 'install', 'listPlugins'],
   '--': true

--- a/core/cli/src/config.ts
+++ b/core/cli/src/config.ts
@@ -32,7 +32,8 @@ export const createConfig = (): RawConfig => ({
   resolutionTrackers: {
     resolvedPluginOptions: new Set(),
     substitutedPlugins: new Set(),
-    resolvedPlugins: new Set()
+    resolvedPlugins: new Set(),
+    reducedInstallationPlugins: new Set()
   },
   tasks: {},
   commandTasks: {},

--- a/core/cli/src/install.ts
+++ b/core/cli/src/install.ts
@@ -63,7 +63,13 @@ export const loadHookInstallations = async (
     const conflicts = findConflicts(installations)
 
     if (conflicts.length) {
-      return invalid<[]>([])
+      return invalid<[]>(
+        conflicts.map(
+          // TODO:20240429:IM format a more helpful error message here
+          (conflict) =>
+            `conflicts between ${conflict.conflicting.map((installation) => installation.forHook).join(', ')}`
+        )
+      )
     }
 
     return valid(withoutConflicts(installations))

--- a/core/cli/src/plugin/reduce-installations.ts
+++ b/core/cli/src/plugin/reduce-installations.ts
@@ -41,9 +41,10 @@ export async function reducePluginHookInstallations(
   hookClasses: Record<string, HookClass>,
   plugin: Plugin
 ): Promise<(HookInstallation | Conflict<HookInstallation>)[]> {
-  if (!plugin.rcFile) {
+  if (!plugin.rcFile || config.resolutionTrackers.reducedInstallationPlugins.has(plugin.id)) {
     return []
   }
+  config.resolutionTrackers.reducedInstallationPlugins.add(plugin.id)
 
   const rawChildInstallations = await Promise.all(
     (plugin.children ?? []).map((child) => reducePluginHookInstallations(logger, config, hookClasses, child))

--- a/core/cli/src/rc-file.ts
+++ b/core/cli/src/rc-file.ts
@@ -38,7 +38,7 @@ const toolKitOption = {
   tag: '!toolkit/option',
   // wrap option path with identifier so we can substitute the option's value
   // once it's been resolved later
-  resolve: (option) => ({ [toolKitOptionIdent]: option })
+  resolve: (option) => `${toolKitOptionIdent}${option}`
 } satisfies YAML.ScalarTag
 const toolKitIfDefined = {
   identify: () => false,

--- a/lib/config/src/index.ts
+++ b/lib/config/src/index.ts
@@ -16,6 +16,7 @@ export interface RawConfig {
     resolvedPluginOptions: Set<string>
     substitutedPlugins: Set<string>
     resolvedPlugins: Set<string>
+    reducedInstallationPlugins: Set<string>
   }
   tasks: { [id: string]: EntryPoint | Conflict<EntryPoint> }
   commandTasks: { [id: string]: CommandTask | Conflict<CommandTask> }

--- a/lib/schemas/src/plugins/lint-staged-npm.ts
+++ b/lib/schemas/src/plugins/lint-staged-npm.ts
@@ -1,8 +1,8 @@
 import { z } from 'zod'
 
 export const LintStagedNpmSchema = z.object({
-  testGlob: z.string().optional(),
-  formatGlob: z.string().optional()
+  testGlob: z.string().default('**/*.js'),
+  formatGlob: z.string().default('**/*.js')
 })
 export type LintStagedNpmOptions = z.infer<typeof LintStagedNpmSchema>
 

--- a/plugins/heroku/.toolkitrc.yml
+++ b/plugins/heroku/.toolkitrc.yml
@@ -11,4 +11,13 @@ tasks:
 commands:
   'cleanup:remote': NpmPrune
 
+options:
+  hooks:
+    - PackageJson:
+        scripts:
+          heroku-postbuild:
+            - 'build:remote'
+            - 'release:remote'
+            - 'cleanup:remote'
+
 version: 2

--- a/plugins/husky-npm/.toolkitrc.yml
+++ b/plugins/husky-npm/.toolkitrc.yml
@@ -1,2 +1,8 @@
+options:
+  hooks:
+    - PackageJson:
+        husky.hooks:
+          pre-commit: 'git:precommit'
+          commit-msg: 'git:commitmsg'
 
 version: 2

--- a/plugins/lint-staged-npm/.toolkitrc.yml
+++ b/plugins/lint-staged-npm/.toolkitrc.yml
@@ -2,4 +2,15 @@ plugins:
   - '@dotcom-tool-kit/lint-staged'
   - '@dotcom-tool-kit/husky-npm'
 
+options:
+  hooks:
+    - PackageJson:
+        lint-staged:
+          !toolkit/option '@dotcom-tool-kit/lint-staged-npm.testGlob':
+            commands: 'test:staged'
+            trailingString: '--'
+          !toolkit/option '@dotcom-tool-kit/lint-staged-npm.formatGlob':
+            commands: 'format:staged'
+            trailingString: '--'
+
 version: 2

--- a/plugins/npm/.toolkitrc.yml
+++ b/plugins/npm/.toolkitrc.yml
@@ -2,4 +2,12 @@ tasks:
   NpmPrune: './lib/tasks/prune'
   NpmPublish: './lib/tasks/publish'
 
+options:
+  hooks:
+    - PackageJson:
+        scripts:
+          build: 'build:local'
+          test: 'test:local'
+          start: 'run:local'
+
 version: 2

--- a/plugins/package-json-hook/src/package-json-helper.ts
+++ b/plugins/package-json-hook/src/package-json-helper.ts
@@ -195,7 +195,8 @@ export default class PackageJson extends Hook<typeof PackageJsonSchema, PackageJ
 
         update(
           state,
-          [field + '.' + key],
+          // full stops in the key shouldn't be treated as path separators
+          [field + '.' + key.replace('.', '\\.')],
           (hookState?: PackageJsonStateValue): PackageJsonStateValue => ({
             // prepend each command to maintain the same order as previous implementations
             commands: [...commands, ...(hookState?.commands ?? [])],
@@ -215,7 +216,8 @@ export default class PackageJson extends Hook<typeof PackageJsonSchema, PackageJ
     for (const [path, installation] of Object.entries(state)) {
       set(
         packageJson,
-        path,
+        // split the path on unescaped full stops
+        path.split(/(?<!\\)\./).map((component) => component.replace('\\.', '.')),
         `dotcom-tool-kit ${installation.commands.join(' ')}${
           installation.trailingString ? ' ' + installation.trailingString : ''
         }`

--- a/plugins/prettier/.toolkitrc.yml
+++ b/plugins/prettier/.toolkitrc.yml
@@ -5,4 +5,9 @@ commands:
   'format:local': Prettier
   'format:staged': Prettier
 
+options:
+  - PackageJson:
+      scripts:
+        format: 'format:local'
+
 version: 2


### PR DESCRIPTION
# Description

Along with adding the hook options so that plugins that use `package-json-hook`'s `PackageJson` hook will now install their commands into the user's `package.json`, I've also fixed any bugs I found with the Tool Kit code that was preventing the installation from running successfully. I used `next-url-mgmt-service` (with the `lint-staged-npm` plugin added) as a test case. 

# Checklist:

- [x] My branch has been rebased onto the latest commit on main (don't merge main into your branch)
- [x] My commit messages are [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/), for example: `feat(circleci): add support for nightly workflows`, `fix: set Heroku app name for staging apps too`
