### PR TITLE
fix: allow tasks with schemas not to have options provided in the config

### DIFF
--- a/core/cli/src/tasks.ts
+++ b/core/cli/src/tasks.ts
@@ -30,9 +30,8 @@ const loadTasks = async (
 
       return taskResult.map((Task) => {
         const taskSchema = TaskSchemas[taskId as keyof TaskOptions]
-        const parsedOptions = taskSchema
-          ? taskSchema.parse({ ...config.taskOptions[taskId].options, ...options })
-          : {}
+        const configOptions = config.taskOptions[taskId]?.options ?? {}
+        const parsedOptions = taskSchema ? taskSchema.parse({ ...configOptions, ...options }) : {}
 
         const task = new (Task as unknown as TaskConstructor)(
           logger,


### PR DESCRIPTION
for some reason i committed this to the monorepos branch not fixing it separately