### PR TITLE
Fixes to next to unblock experimentation-api

### DIFF
--- a/core/cli/src/tasks.ts
+++ b/core/cli/src/tasks.ts
@@ -50,22 +50,6 @@ const loadTasks = async (
 export async function runTasks(logger: Logger, commands: string[], files?: string[]): Promise<void> {
   const config = await loadConfig(logger)
 
-  const availableCommands = Object.keys(config.commandTasks)
-    .sort()
-    .map((id) => `- ${id}`)
-    .join('\n')
-
-  const missingCommands = commands.filter((id) => !config.commandTasks[id])
-
-  if (missingCommands.length > 0) {
-    const error = new ToolKitError(`commands ${missingCommands} do not exist`)
-    error.details = `maybe you need to install a plugin to define these commands, or configure them in your Tool Kit configuration.
-
-commands that are available are:
-${availableCommands}`
-    throw error
-  }
-
   for (const pluginOptions of Object.values(config.pluginOptions)) {
     if (pluginOptions.forPlugin) {
       setOptions(pluginOptions.forPlugin.id as OptionKey, pluginOptions.options)


### PR DESCRIPTION
# Description

The build is currently [failing](https://app.circleci.com/pipelines/github/Financial-Times/experimentation-api/4/workflows/6a001f36-f504-4c29-8db6-0d62ab83b180/jobs/18) _because of us!!_ I'll cut another prerelease for the relevant packages after this is merged.

# Checklist:

- [x] My branch has been rebased onto the latest commit on main (don't merge main into your branch)
- [x] My commit messages are [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/), for example: `feat(circleci): add support for nightly workflows`, `fix: set Heroku app name for staging apps too`
