### PR TITLE
Manually bump updated prerelease packages

### DIFF
--- a/core/cli/package.json
+++ b/core/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dotcom-tool-kit",
-  "version": "4.0.0-beta.1",
+  "version": "4.0.0-beta.2",
   "description": "modern, maintainable, modular developer tooling for FT.com projects",
   "author": "FT.com Platforms Team <platforms-team.customer-products@ft.com>",
   "license": "MIT",

--- a/core/create/package.json
+++ b/core/create/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dotcom-tool-kit/create",
-  "version": "4.0.0-beta.1",
+  "version": "4.0.0-beta.2",
   "description": "",
   "main": "lib",
   "bin": "./bin/create-tool-kit",
@@ -52,7 +52,7 @@
     "@types/node-fetch": "^2.6.2",
     "@types/pacote": "^11.1.3",
     "@types/prompts": "^2.0.14",
-    "dotcom-tool-kit": "4.0.0-beta.1",
+    "dotcom-tool-kit": "4.0.0-beta.2",
     "type-fest": "^3.13.1"
   },
   "volta": {

--- a/plugins/babel/package.json
+++ b/plugins/babel/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dotcom-tool-kit/babel",
-  "version": "4.0.0-beta.1",
+  "version": "4.0.0-beta.2",
   "description": "",
   "author": "FT.com Platforms Team <platforms-team.customer-products@ft.com>",
   "license": "MIT",
@@ -37,7 +37,7 @@
   },
   "peerDependencies": {
     "@babel/core": "7.x",
-    "dotcom-tool-kit": "4.0.0-beta.1"
+    "dotcom-tool-kit": "4.0.0-beta.2"
   },
   "engines": {
     "node": "18.x || 20.x",

--- a/plugins/backend-app/package.json
+++ b/plugins/backend-app/package.json
@@ -1,13 +1,13 @@
 {
   "name": "@dotcom-tool-kit/backend-app",
-  "version": "4.0.0-beta.1",
+  "version": "4.0.0-beta.2",
   "description": "",
   "main": "index.js",
   "keywords": [],
   "author": "FT.com Platforms Team <platforms-team.customer-products@ft.com>",
   "license": "ISC",
   "dependencies": {
-    "@dotcom-tool-kit/backend-heroku-app": "4.0.0-beta.1"
+    "@dotcom-tool-kit/backend-heroku-app": "4.0.0-beta.2"
   },
   "repository": {
     "type": "git",
@@ -17,7 +17,7 @@
   "bugs": "https://github.com/financial-times/dotcom-tool-kit/issues",
   "homepage": "https://github.com/financial-times/dotcom-tool-kit/tree/main/plugins/backend-app",
   "peerDependencies": {
-    "dotcom-tool-kit": "4.0.0-beta.1"
+    "dotcom-tool-kit": "4.0.0-beta.2"
   },
   "engines": {
     "node": "18.x || 20.x",

--- a/plugins/backend-heroku-app/package.json
+++ b/plugins/backend-heroku-app/package.json
@@ -1,16 +1,16 @@
 {
   "name": "@dotcom-tool-kit/backend-heroku-app",
-  "version": "4.0.0-beta.1",
+  "version": "4.0.0-beta.2",
   "description": "",
   "main": "index.js",
   "keywords": [],
   "author": "FT.com Platforms Team <platforms-team.customer-products@ft.com>",
   "license": "ISC",
   "dependencies": {
-    "@dotcom-tool-kit/circleci-deploy": "4.0.0-beta.1",
-    "@dotcom-tool-kit/heroku": "4.0.0-beta.1",
-    "@dotcom-tool-kit/node": "4.0.0-beta.1",
-    "@dotcom-tool-kit/npm": "4.0.0-beta.1"
+    "@dotcom-tool-kit/circleci-deploy": "4.0.0-beta.2",
+    "@dotcom-tool-kit/heroku": "4.0.0-beta.2",
+    "@dotcom-tool-kit/node": "4.0.0-beta.2",
+    "@dotcom-tool-kit/npm": "4.0.0-beta.2"
   },
   "repository": {
     "type": "git",
@@ -20,7 +20,7 @@
   "bugs": "https://github.com/financial-times/dotcom-tool-kit/issues",
   "homepage": "https://github.com/financial-times/dotcom-tool-kit/tree/main/plugins/backend-heroku-app",
   "peerDependencies": {
-    "dotcom-tool-kit": "4.0.0-beta.1"
+    "dotcom-tool-kit": "4.0.0-beta.2"
   },
   "engines": {
     "node": "18.x || 20.x",

--- a/plugins/backend-serverless-app/package.json
+++ b/plugins/backend-serverless-app/package.json
@@ -1,16 +1,16 @@
 {
   "name": "@dotcom-tool-kit/backend-serverless-app",
-  "version": "4.0.0-beta.1",
+  "version": "4.0.0-beta.2",
   "description": "",
   "main": "index.js",
   "keywords": [],
   "author": "FT.com Platforms Team <platforms-team.customer-products@ft.com>",
   "license": "ISC",
   "dependencies": {
-    "@dotcom-tool-kit/circleci-deploy": "4.0.0-beta.1",
-    "@dotcom-tool-kit/node": "4.0.0-beta.1",
-    "@dotcom-tool-kit/npm": "4.0.0-beta.1",
-    "@dotcom-tool-kit/serverless": "3.0.0-beta.1"
+    "@dotcom-tool-kit/circleci-deploy": "4.0.0-beta.2",
+    "@dotcom-tool-kit/node": "4.0.0-beta.2",
+    "@dotcom-tool-kit/npm": "4.0.0-beta.2",
+    "@dotcom-tool-kit/serverless": "3.0.0-beta.2"
   },
   "repository": {
     "type": "git",
@@ -20,7 +20,7 @@
   "bugs": "https://github.com/financial-times/dotcom-tool-kit/issues",
   "homepage": "https://github.com/financial-times/dotcom-tool-kit/tree/main/plugins/backend-serverless-app",
   "peerDependencies": {
-    "dotcom-tool-kit": "4.0.0-beta.1"
+    "dotcom-tool-kit": "4.0.0-beta.2"
   },
   "engines": {
     "node": "18.x || 20.x",

--- a/plugins/circleci-deploy/package.json
+++ b/plugins/circleci-deploy/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dotcom-tool-kit/circleci-deploy",
-  "version": "4.0.0-beta.1",
+  "version": "4.0.0-beta.2",
   "description": "",
   "main": "lib",
   "scripts": {
@@ -10,7 +10,7 @@
   "author": "FT.com Platforms Team <platforms-team.customer-products@ft.com>",
   "license": "ISC",
   "dependencies": {
-    "@dotcom-tool-kit/circleci": "7.0.0-beta.1",
+    "@dotcom-tool-kit/circleci": "7.0.0-beta.2",
     "tslib": "^2.3.1"
   },
   "repository": {
@@ -31,7 +31,7 @@
     "winston": "^3.5.1"
   },
   "peerDependencies": {
-    "dotcom-tool-kit": "4.0.0-beta.1"
+    "dotcom-tool-kit": "4.0.0-beta.2"
   },
   "engines": {
     "node": "18.x || 20.x",

--- a/plugins/circleci-heroku/package.json
+++ b/plugins/circleci-heroku/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dotcom-tool-kit/circleci-heroku",
-  "version": "4.0.0-beta.1",
+  "version": "4.0.0-beta.2",
   "description": "",
   "main": "index.js",
   "scripts": {
@@ -10,8 +10,8 @@
   "author": "FT.com Platforms Team <platforms-team.customer-products@ft.com>",
   "license": "ISC",
   "dependencies": {
-    "@dotcom-tool-kit/circleci-deploy": "4.0.0-beta.1",
-    "@dotcom-tool-kit/heroku": "4.0.0-beta.1",
+    "@dotcom-tool-kit/circleci-deploy": "4.0.0-beta.2",
+    "@dotcom-tool-kit/heroku": "4.0.0-beta.2",
     "tslib": "^2.3.1"
   },
   "repository": {
@@ -25,7 +25,7 @@
     "extends": "../../package.json"
   },
   "peerDependencies": {
-    "dotcom-tool-kit": "4.0.0-beta.1"
+    "dotcom-tool-kit": "4.0.0-beta.2"
   },
   "engines": {
     "node": "18.x || 20.x",

--- a/plugins/circleci-npm/package.json
+++ b/plugins/circleci-npm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dotcom-tool-kit/circleci-npm",
-  "version": "6.0.0-beta.1",
+  "version": "6.0.0-beta.2",
   "description": "",
   "main": "lib",
   "scripts": {
@@ -10,8 +10,8 @@
   "author": "FT.com Platforms Team <platforms-team.customer-products@ft.com>",
   "license": "ISC",
   "dependencies": {
-    "@dotcom-tool-kit/circleci": "7.0.0-beta.1",
-    "@dotcom-tool-kit/npm": "4.0.0-beta.1",
+    "@dotcom-tool-kit/circleci": "7.0.0-beta.2",
+    "@dotcom-tool-kit/npm": "4.0.0-beta.2",
     "tslib": "^2.3.1"
   },
   "repository": {
@@ -26,7 +26,7 @@
     ".toolkitrc.yml"
   ],
   "peerDependencies": {
-    "dotcom-tool-kit": "4.0.0-beta.1"
+    "dotcom-tool-kit": "4.0.0-beta.2"
   },
   "engines": {
     "node": "18.x || 20.x",

--- a/plugins/circleci/package.json
+++ b/plugins/circleci/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dotcom-tool-kit/circleci",
-  "version": "7.0.0-beta.1",
+  "version": "7.0.0-beta.2",
   "description": "",
   "main": "lib",
   "scripts": {
@@ -47,7 +47,7 @@
     "extends": "../../package.json"
   },
   "peerDependencies": {
-    "dotcom-tool-kit": "4.0.0-beta.1",
+    "dotcom-tool-kit": "4.0.0-beta.2",
     "zod": "^3.22.4"
   },
   "engines": {

--- a/plugins/component/package.json
+++ b/plugins/component/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dotcom-tool-kit/component",
-  "version": "5.0.0-beta.1",
+  "version": "5.0.0-beta.2",
   "description": "",
   "main": "index.js",
   "keywords": [],
@@ -17,11 +17,11 @@
     ".toolkitrc.yml"
   ],
   "peerDependencies": {
-    "dotcom-tool-kit": "4.0.0-beta.1"
+    "dotcom-tool-kit": "4.0.0-beta.2"
   },
   "dependencies": {
-    "@dotcom-tool-kit/circleci-npm": "6.0.0-beta.1",
-    "@dotcom-tool-kit/npm": "4.0.0-beta.1"
+    "@dotcom-tool-kit/circleci-npm": "6.0.0-beta.2",
+    "@dotcom-tool-kit/npm": "4.0.0-beta.2"
   },
   "engines": {
     "node": "18.x || 20.x",

--- a/plugins/cypress/package.json
+++ b/plugins/cypress/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dotcom-tool-kit/cypress",
-  "version": "5.0.0-beta.1",
+  "version": "5.0.0-beta.2",
   "description": "",
   "main": "lib",
   "scripts": {
@@ -21,7 +21,7 @@
     ".toolkitrc.yml"
   ],
   "peerDependencies": {
-    "dotcom-tool-kit": "4.0.0-beta.1"
+    "dotcom-tool-kit": "4.0.0-beta.2"
   },
   "engines": {
     "node": "18.x || 20.x",
@@ -31,7 +31,7 @@
     "@dotcom-tool-kit/base": "4.0.0-beta.0",
     "@dotcom-tool-kit/doppler": "2.0.0-beta.0",
     "@dotcom-tool-kit/logger": "4.0.0-beta.0",
-    "@dotcom-tool-kit/package-json-hook": "5.0.0-beta.1",
+    "@dotcom-tool-kit/package-json-hook": "5.0.0-beta.2",
     "@dotcom-tool-kit/state": "4.0.0-beta.0"
   },
   "devDependencies": {

--- a/plugins/eslint/package.json
+++ b/plugins/eslint/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dotcom-tool-kit/eslint",
-  "version": "4.0.0-beta.1",
+  "version": "4.0.0-beta.2",
   "description": "",
   "main": "lib",
   "scripts": {
@@ -39,7 +39,7 @@
     "extends": "../../package.json"
   },
   "peerDependencies": {
-    "dotcom-tool-kit": "4.0.0-beta.1",
+    "dotcom-tool-kit": "4.0.0-beta.2",
     "eslint": "7.x || 8.x"
   },
   "engines": {

--- a/plugins/frontend-app/package.json
+++ b/plugins/frontend-app/package.json
@@ -1,15 +1,15 @@
 {
   "name": "@dotcom-tool-kit/frontend-app",
-  "version": "4.0.0-beta.1",
+  "version": "4.0.0-beta.2",
   "description": "",
   "main": "index.js",
   "keywords": [],
   "author": "FT.com Platforms Team <platforms-team.customer-products@ft.com>",
   "license": "ISC",
   "dependencies": {
-    "@dotcom-tool-kit/backend-heroku-app": "4.0.0-beta.1",
-    "@dotcom-tool-kit/upload-assets-to-s3": "4.0.0-beta.1",
-    "@dotcom-tool-kit/webpack": "4.0.0-beta.1"
+    "@dotcom-tool-kit/backend-heroku-app": "4.0.0-beta.2",
+    "@dotcom-tool-kit/upload-assets-to-s3": "4.0.0-beta.2",
+    "@dotcom-tool-kit/webpack": "4.0.0-beta.2"
   },
   "repository": {
     "type": "git",
@@ -22,7 +22,7 @@
     "extends": "../../package.json"
   },
   "peerDependencies": {
-    "dotcom-tool-kit": "4.0.0-beta.1"
+    "dotcom-tool-kit": "4.0.0-beta.2"
   },
   "engines": {
     "node": "18.x || 20.x",

--- a/plugins/heroku/package.json
+++ b/plugins/heroku/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dotcom-tool-kit/heroku",
-  "version": "4.0.0-beta.1",
+  "version": "4.0.0-beta.2",
   "description": "",
   "main": "lib",
   "scripts": {
@@ -14,9 +14,9 @@
     "@dotcom-tool-kit/doppler": "2.0.0-beta.0",
     "@dotcom-tool-kit/error": "4.0.0-beta.0",
     "@dotcom-tool-kit/logger": "4.0.0-beta.0",
-    "@dotcom-tool-kit/npm": "4.0.0-beta.1",
+    "@dotcom-tool-kit/npm": "4.0.0-beta.2",
     "@dotcom-tool-kit/options": "4.0.0-beta.0",
-    "@dotcom-tool-kit/package-json-hook": "5.0.0-beta.1",
+    "@dotcom-tool-kit/package-json-hook": "5.0.0-beta.2",
     "@dotcom-tool-kit/state": "4.0.0-beta.0",
     "@dotcom-tool-kit/wait-for-ok": "4.0.0-beta.0",
     "@octokit/request": "^5.6.0",
@@ -47,7 +47,7 @@
     "extends": "../../package.json"
   },
   "peerDependencies": {
-    "dotcom-tool-kit": "4.0.0-beta.1"
+    "dotcom-tool-kit": "4.0.0-beta.2"
   },
   "engines": {
     "node": "18.x || 20.x",

--- a/plugins/husky-npm/package.json
+++ b/plugins/husky-npm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dotcom-tool-kit/husky-npm",
-  "version": "5.0.0-beta.1",
+  "version": "5.0.0-beta.2",
   "description": "",
   "main": "lib",
   "scripts": {
@@ -10,11 +10,11 @@
   "author": "FT.com Platforms Team <platforms-team.customer-products@ft.com>",
   "license": "ISC",
   "dependencies": {
-    "@dotcom-tool-kit/package-json-hook": "5.0.0-beta.1",
+    "@dotcom-tool-kit/package-json-hook": "5.0.0-beta.2",
     "tslib": "^2.3.1"
   },
   "peerDependencies": {
-    "dotcom-tool-kit": "4.0.0-beta.1",
+    "dotcom-tool-kit": "4.0.0-beta.2",
     "husky": "4.x"
   },
   "repository": {

--- a/plugins/jest/package.json
+++ b/plugins/jest/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dotcom-tool-kit/jest",
-  "version": "4.0.0-beta.1",
+  "version": "4.0.0-beta.2",
   "description": "",
   "main": "lib",
   "scripts": {
@@ -15,7 +15,7 @@
     "tslib": "^2.3.1"
   },
   "peerDependencies": {
-    "dotcom-tool-kit": "4.0.0-beta.1",
+    "dotcom-tool-kit": "4.0.0-beta.2",
     "jest-cli": "27.x || 28.x || 29.x"
   },
   "repository": {

--- a/plugins/lint-staged-npm/package.json
+++ b/plugins/lint-staged-npm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dotcom-tool-kit/lint-staged-npm",
-  "version": "4.0.0-beta.1",
+  "version": "4.0.0-beta.2",
   "description": "",
   "main": "lib",
   "scripts": {
@@ -10,10 +10,10 @@
   "author": "FT.com Platforms Team <platforms-team.customer-products@ft.com>",
   "license": "ISC",
   "dependencies": {
-    "@dotcom-tool-kit/husky-npm": "5.0.0-beta.1",
-    "@dotcom-tool-kit/lint-staged": "5.0.0-beta.1",
+    "@dotcom-tool-kit/husky-npm": "5.0.0-beta.2",
+    "@dotcom-tool-kit/lint-staged": "5.0.0-beta.2",
     "@dotcom-tool-kit/options": "4.0.0-beta.0",
-    "@dotcom-tool-kit/package-json-hook": "5.0.0-beta.1",
+    "@dotcom-tool-kit/package-json-hook": "5.0.0-beta.2",
     "tslib": "^2.3.1"
   },
   "repository": {
@@ -31,7 +31,7 @@
     "extends": "../../package.json"
   },
   "peerDependencies": {
-    "dotcom-tool-kit": "4.0.0-beta.1"
+    "dotcom-tool-kit": "4.0.0-beta.2"
   },
   "engines": {
     "node": "18.x || 20.x",

--- a/plugins/lint-staged/package.json
+++ b/plugins/lint-staged/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dotcom-tool-kit/lint-staged",
-  "version": "5.0.0-beta.1",
+  "version": "5.0.0-beta.2",
   "description": "",
   "main": "lib",
   "scripts": {
@@ -11,7 +11,7 @@
   "license": "ISC",
   "dependencies": {
     "@dotcom-tool-kit/base": "4.0.0-beta.0",
-    "@dotcom-tool-kit/package-json-hook": "5.0.0-beta.1",
+    "@dotcom-tool-kit/package-json-hook": "5.0.0-beta.2",
     "@dotcom-tool-kit/logger": "4.0.0-beta.0",
     "lint-staged": "^11.2.3",
     "tslib": "^2.3.1"
@@ -31,7 +31,7 @@
     "extends": "../../package.json"
   },
   "peerDependencies": {
-    "dotcom-tool-kit": "4.0.0-beta.1"
+    "dotcom-tool-kit": "4.0.0-beta.2"
   },
   "engines": {
     "node": "18.x || 20.x",

--- a/plugins/mocha/package.json
+++ b/plugins/mocha/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dotcom-tool-kit/mocha",
-  "version": "4.0.0-beta.1",
+  "version": "4.0.0-beta.2",
   "description": "",
   "main": "lib",
   "scripts": {
@@ -38,7 +38,7 @@
     "extends": "../../package.json"
   },
   "peerDependencies": {
-    "dotcom-tool-kit": "4.0.0-beta.1",
+    "dotcom-tool-kit": "4.0.0-beta.2",
     "mocha": ">=6.x <=10.x"
   },
   "engines": {

--- a/plugins/n-test/package.json
+++ b/plugins/n-test/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dotcom-tool-kit/n-test",
-  "version": "4.0.0-beta.1",
+  "version": "4.0.0-beta.2",
   "description": "",
   "main": "lib",
   "scripts": {
@@ -37,7 +37,7 @@
     "extends": "../../package.json"
   },
   "peerDependencies": {
-    "dotcom-tool-kit": "4.0.0-beta.1"
+    "dotcom-tool-kit": "4.0.0-beta.2"
   },
   "engines": {
     "node": "18.x || 20.x",

--- a/plugins/next-router/package.json
+++ b/plugins/next-router/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dotcom-tool-kit/next-router",
-  "version": "4.0.0-beta.1",
+  "version": "4.0.0-beta.2",
   "description": "",
   "main": "lib",
   "scripts": {
@@ -30,7 +30,7 @@
     ".toolkitrc.yml"
   ],
   "peerDependencies": {
-    "dotcom-tool-kit": "4.0.0-beta.1"
+    "dotcom-tool-kit": "4.0.0-beta.2"
   },
   "engines": {
     "node": "18.x || 20.x",

--- a/plugins/node/package.json
+++ b/plugins/node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dotcom-tool-kit/node",
-  "version": "4.0.0-beta.1",
+  "version": "4.0.0-beta.2",
   "description": "",
   "main": "lib",
   "scripts": {
@@ -30,7 +30,7 @@
     ".toolkitrc.yml"
   ],
   "peerDependencies": {
-    "dotcom-tool-kit": "4.0.0-beta.1"
+    "dotcom-tool-kit": "4.0.0-beta.2"
   },
   "engines": {
     "node": "18.x || 20.x",

--- a/plugins/nodemon/package.json
+++ b/plugins/nodemon/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dotcom-tool-kit/nodemon",
-  "version": "4.0.0-beta.1",
+  "version": "4.0.0-beta.2",
   "description": "",
   "main": "lib",
   "scripts": {
@@ -18,7 +18,7 @@
     "tslib": "^2.3.1"
   },
   "peerDependencies": {
-    "dotcom-tool-kit": "4.0.0-beta.1",
+    "dotcom-tool-kit": "4.0.0-beta.2",
     "nodemon": "2.x"
   },
   "repository": {

--- a/plugins/npm/package.json
+++ b/plugins/npm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dotcom-tool-kit/npm",
-  "version": "4.0.0-beta.1",
+  "version": "4.0.0-beta.2",
   "description": "",
   "main": "lib",
   "scripts": {
@@ -13,7 +13,7 @@
     "@actions/exec": "^1.1.0",
     "@dotcom-tool-kit/base": "4.0.0-beta.0",
     "@dotcom-tool-kit/error": "4.0.0-beta.0",
-    "@dotcom-tool-kit/package-json-hook": "5.0.0-beta.1",
+    "@dotcom-tool-kit/package-json-hook": "5.0.0-beta.2",
     "@dotcom-tool-kit/state": "4.0.0-beta.0",
     "libnpmpack": "^3.1.0",
     "libnpmpublish": "^5.0.1",
@@ -43,7 +43,7 @@
     "extends": "../../package.json"
   },
   "peerDependencies": {
-    "dotcom-tool-kit": "4.0.0-beta.1"
+    "dotcom-tool-kit": "4.0.0-beta.2"
   },
   "engines": {
     "node": "18.x || 20.x",

--- a/plugins/pa11y/package.json
+++ b/plugins/pa11y/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dotcom-tool-kit/pa11y",
-  "version": "1.0.0-beta.1",
+  "version": "1.0.0-beta.2",
   "description": "pa11y",
   "main": "lib",
   "scripts": {
@@ -28,7 +28,7 @@
     ".toolkitrc.yml"
   ],
   "peerDependencies": {
-    "dotcom-tool-kit": "4.0.0-beta.1"
+    "dotcom-tool-kit": "4.0.0-beta.2"
   },
   "devDependencies": {
     "@types/pa11y": "^5.3.4"

--- a/plugins/package-json-hook/package.json
+++ b/plugins/package-json-hook/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dotcom-tool-kit/package-json-hook",
-  "version": "5.0.0-beta.1",
+  "version": "5.0.0-beta.2",
   "description": "",
   "main": "lib",
   "scripts": {

--- a/plugins/prettier/package.json
+++ b/plugins/prettier/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dotcom-tool-kit/prettier",
-  "version": "4.0.0-beta.1",
+  "version": "4.0.0-beta.2",
   "description": "",
   "main": "lib",
   "scripts": {
@@ -13,7 +13,7 @@
     "@dotcom-tool-kit/base": "4.0.0-beta.0",
     "@dotcom-tool-kit/error": "4.0.0-beta.0",
     "@dotcom-tool-kit/logger": "4.0.0-beta.0",
-    "@dotcom-tool-kit/package-json-hook": "5.0.0-beta.1",
+    "@dotcom-tool-kit/package-json-hook": "5.0.0-beta.2",
     "fast-glob": "^3.2.7",
     "hook-std": "^2.0.0",
     "prettier": "^2.2.1",
@@ -38,7 +38,7 @@
     "extends": "../../package.json"
   },
   "peerDependencies": {
-    "dotcom-tool-kit": "4.0.0-beta.1"
+    "dotcom-tool-kit": "4.0.0-beta.2"
   },
   "engines": {
     "node": "18.x || 20.x",

--- a/plugins/serverless/package.json
+++ b/plugins/serverless/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dotcom-tool-kit/serverless",
-  "version": "3.0.0-beta.1",
+  "version": "3.0.0-beta.2",
   "description": "a plugin to manage and deploy apps using AWS Serverless",
   "main": "lib",
   "scripts": {
@@ -21,7 +21,7 @@
     ".toolkitrc.yml"
   ],
   "peerDependencies": {
-    "dotcom-tool-kit": "4.0.0-beta.1",
+    "dotcom-tool-kit": "4.0.0-beta.2",
     "serverless-offline": "^12.0.4"
   },
   "dependencies": {

--- a/plugins/typescript/package.json
+++ b/plugins/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dotcom-tool-kit/typescript",
-  "version": "3.0.0-beta.1",
+  "version": "3.0.0-beta.2",
   "description": "",
   "main": "lib",
   "scripts": {
@@ -21,7 +21,7 @@
     ".toolkitrc.yml"
   ],
   "peerDependencies": {
-    "dotcom-tool-kit": "4.0.0-beta.1",
+    "dotcom-tool-kit": "4.0.0-beta.2",
     "typescript": "3.x || 4.x || 5.x"
   },
   "dependencies": {

--- a/plugins/upload-assets-to-s3/package.json
+++ b/plugins/upload-assets-to-s3/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dotcom-tool-kit/upload-assets-to-s3",
-  "version": "4.0.0-beta.1",
+  "version": "4.0.0-beta.2",
   "description": "",
   "main": "lib",
   "scripts": {
@@ -42,7 +42,7 @@
     "extends": "../../package.json"
   },
   "peerDependencies": {
-    "dotcom-tool-kit": "4.0.0-beta.1"
+    "dotcom-tool-kit": "4.0.0-beta.2"
   },
   "engines": {
     "node": "18.x || 20.x",

--- a/plugins/webpack/package.json
+++ b/plugins/webpack/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dotcom-tool-kit/webpack",
-  "version": "4.0.0-beta.1",
+  "version": "4.0.0-beta.2",
   "main": "lib",
   "description": "",
   "author": "FT.com Platforms Team <platforms-team.customer-products@ft.com>",
@@ -24,7 +24,7 @@
     "tslib": "^2.3.1"
   },
   "peerDependencies": {
-    "dotcom-tool-kit": "4.0.0-beta.1",
+    "dotcom-tool-kit": "4.0.0-beta.2",
     "webpack": "4.x.x || 5.x.x"
   },
   "devDependencies": {


### PR DESCRIPTION
# Description

Bumping the next versions to include #645. That PR also removes the dev dependencies from `core/cli` so hopefully the next bump will require fewer tags.

# Checklist:

- [x] My branch has been rebased onto the latest commit on main (don't merge main into your branch)
- [x] My commit messages are [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/), for example: `feat(circleci): add support for nightly workflows`, `fix: set Heroku app name for staging apps too`
