### PR TITLE
fix: pass through unparsed merged options if no schema

### DIFF
--- a/core/cli/src/tasks.ts
+++ b/core/cli/src/tasks.ts
@@ -31,7 +31,8 @@ const loadTasks = async (
       return taskResult.map((Task) => {
         const taskSchema = TaskSchemas[taskId as keyof TaskOptions]
         const configOptions = config.taskOptions[taskId]?.options ?? {}
-        const parsedOptions = taskSchema ? taskSchema.parse({ ...configOptions, ...options }) : {}
+        const mergedOptions = { ...configOptions, ...options }
+        const parsedOptions = taskSchema ? taskSchema.parse(mergedOptions) : mergedOptions
 
         const task = new (Task as unknown as TaskConstructor)(
           logger,


### PR DESCRIPTION
to allow custom plugins to use task/command options
