### PR TITLE
Fix Task options not being unwrapped when returned from Zod

### DIFF
--- a/core/cli/src/tasks.ts
+++ b/core/cli/src/tasks.ts
@@ -42,7 +42,7 @@ const loadTasks = async (
             logger,
             taskId,
             getOptions(entryPoint.plugin.id as OptionKey) ?? {},
-            parsedOptions
+            parsedOptions.data
           )
           return valid([taskId, task])
         } else {


### PR DESCRIPTION
# Description

Should fix experimentation-api [build failures](https://app.circleci.com/pipelines/github/Financial-Times/experimentation-api/36/workflows/9b061683-121b-4f49-a6c4-2fbce1e0c28c/jobs/202).

# Checklist:

- [x] My branch has been rebased onto the latest commit on main (don't merge main into your branch)
- [x] My commit messages are [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/), for example: `feat(circleci): add support for nightly workflows`, `fix: set Heroku app name for staging apps too`
