### PR TITLE
Fix lack of newlines in subprocess logging

### DIFF
--- a/lib/logger/src/format.ts
+++ b/lib/logger/src/format.ts
@@ -21,9 +21,12 @@ export const createFormatter = (thisLogger: winston.Logger) =>
       }
       if (info.process) {
         labels += `[${styles.dim(info.process)}]`
-      } else {
+      }
+
+      if (!info.process) {
         // simulate the newline present in a normal console.log (which we've
-        // removed from the Console transport)
+        // removed from the Console transport to support logging forked
+        // processes which don't necessarilly flush on a newline)
         message += '\n'
       }
 

--- a/lib/logger/src/helpers.ts
+++ b/lib/logger/src/helpers.ts
@@ -116,7 +116,7 @@ export function hookFork(
           transform: (message, _enc, callback) => {
             // add the log level and wrap the message for the winston stream to
             // consume
-            callback(null, { level, message: cleanupLogs(message) })
+            callback(null, { level, message: stripAnsiReset(message) })
           }
         })
       )

--- a/lib/logger/src/helpers.ts
+++ b/lib/logger/src/helpers.ts
@@ -115,7 +115,9 @@ export function hookFork(
           readableObjectMode: true,
           transform: (message, _enc, callback) => {
             // add the log level and wrap the message for the winston stream to
-            // consume
+            // consume. we preserve newlines here as, unlike other cases, this
+            // logger can be called in the middle of a line depending on when
+            // the stream is flushed.
             callback(null, { level, message: stripAnsiReset(message) })
           }
         })

--- a/lib/logger/src/helpers.ts
+++ b/lib/logger/src/helpers.ts
@@ -8,16 +8,16 @@ import { HookTransport, consoleTransport } from './transports'
 import ansiRegex from 'ansi-regex'
 
 const ansiRegexText = ansiRegex().source
-const whitespaceRegex = /\s|\n/g
-const startRegex = new RegExp(`^(?:(?:${ansiRegexText})|\s|\n)+`)
-const endRegex = new RegExp(`(?:(?:${ansiRegexText})|\s|\n)+$`)
+const ansiOrWhitespaceRegexText = `(?:(?:${ansiRegexText})|\\n)+`
+const startRegex = new RegExp(`^${ansiOrWhitespaceRegexText}`)
+const endRegex = new RegExp(`${ansiOrWhitespaceRegexText}$`)
 
 // RIS escape code to effectively do a clear (^L) on the terminal. TypeScript's
 // watch mode does this and it's annoying to have the logs shunted around when
 // tracking multiple tasks.
 const ansiReset = /\x1Bc/g
 
-// Trim whitespace whilst preserving ANSI escape codes
+// Trim newlines whilst preserving ANSI escape codes
 function ansiTrim(message: string): string {
   let start = 0
   let ansiStart = ''
@@ -33,9 +33,7 @@ function ansiTrim(message: string): string {
     ansiEnd = endResult[0]
     end = -ansiEnd.length
   }
-  return (
-    ansiStart.replace(whitespaceRegex, '') + message.slice(start, end) + ansiEnd.replace(whitespaceRegex, '')
-  )
+  return ansiStart.replace('\n', '') + message.slice(start, end) + ansiEnd.replace('\n', '')
 }
 
 // Remove ANSI escape codes that mess with the terminal state. This selectively


### PR DESCRIPTION
# Description

This partially reverts https://github.com/Financial-Times/dotcom-tool-kit/commit/d1374d143d75d9abc018fb7c3a62a97be10c432d, which I think was a mistake as we already remove the EOL character normally added by `winston`, and we skip appending a newline character to messages if it has a `process` attribute. So it meant that the only newlines that would be preserved were ones that happened to not be at the end (or start) of a stream flush.

Running the `Mocha` task in next-static before this change:
<img width="952" alt="Screenshot 2024-05-20 at 13 59 00" src="https://github.com/Financial-Times/dotcom-tool-kit/assets/7020796/3d1bafdb-d449-4c1c-9082-63657d69a80f">
Running the `Mocha` task in next-static after this change:
<img width="579" alt="Screenshot 2024-05-20 at 13 59 11" src="https://github.com/Financial-Times/dotcom-tool-kit/assets/7020796/b4302943-59eb-4f30-8efa-82223fcc2a8a">
And here is what the output looks like when `mocha` is run directly instead. Note the matching amount of whitespace.
<img width="500" alt="Screenshot 2024-05-20 at 14 09 56" src="https://github.com/Financial-Times/dotcom-tool-kit/assets/7020796/8741b129-eba6-4f96-9764-9824b0636762">

# Checklist:

- [x] My branch has been rebased onto the latest commit on main (don't merge main into your branch)
- [x] My commit messages are [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/), for example: `feat(circleci): add support for nightly workflows`, `fix: set Heroku app name for staging apps too`
