### PR TITLE
fix: upgrade serverless-framework orb

### DIFF
--- a/orb/src/@orb.yml
+++ b/orb/src/@orb.yml
@@ -14,4 +14,4 @@ orbs:
   node: circleci/node@5.0.2
   change-api: financial-times/change-api@1.0.9
   aws-cli: circleci/aws-cli@3.1.4
-  serverless-framework: circleci/serverless-framework@2.0.1
+  serverless-framework: circleci/serverless-framework@2.0.2


### PR DESCRIPTION
# Description

https://github.com/CircleCI-Public/serverless-framework-orb/compare/v2.0.1...v2.0.2

This mitigates incident 2724 because a Serverless URL stopped working, which broke deployments.

# Checklist:

- [ ] My branch has been rebased onto the latest commit on main (don't merge main into your branch)
- [ ] My commit messages are [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/), for example: `feat(circleci): add support for nightly workflows`, `fix: set Heroku app name for staging apps too`
