### PR TITLE
change nested stack template to v2

### DIFF
--- a/core/create/files/oidc-cloudformation.yml
+++ b/core/create/files/oidc-cloudformation.yml
@@ -17,7 +17,7 @@ Resources:
   CircleciOidcNestedStackRole:
     Type: AWS::CloudFormation::Stack
     Properties:
-      TemplateURL: https://circleci-nested-stack-template-bucket.s3.eu-west-1.amazonaws.com/circleci-nested-stack-role.yaml
+      TemplateURL: https://circleci-nested-stack-template-bucket.s3.eu-west-1.amazonaws.com/circleci-nested-stack-role-v2.yaml
       Parameters:
         SystemCode: !Ref SystemCode
         CircleciProjectId: !Ref CircleciProjectId


### PR DESCRIPTION
# Description

We've changed the permissions in our OIDC nested stack role, in order to remove legacy role assumptions by the old ft-engineer and ft-iam-admin roles. This PR updates to the latest template (v2).

The v2 template has slightly differing permissions, but should affect apps role assumptions, and there should be no effect on deployments.

PR for template changes here: https://github.com/Financial-Times/circleci-nested-stack-template/pull/25
