### PR TITLE
Don't run review jobs on tagged releases

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -47,13 +47,13 @@
     },
     "core/cli": {
       "name": "dotcom-tool-kit",
-      "version": "3.4.0",
+      "version": "3.5.1",
       "license": "MIT",
       "dependencies": {
         "@dotcom-tool-kit/error": "^3.2.0",
-        "@dotcom-tool-kit/logger": "^3.4.0",
-        "@dotcom-tool-kit/options": "^3.2.0",
-        "@dotcom-tool-kit/types": "^3.6.0",
+        "@dotcom-tool-kit/logger": "^3.4.1",
+        "@dotcom-tool-kit/options": "^3.2.1",
+        "@dotcom-tool-kit/types": "^3.6.1",
         "@dotcom-tool-kit/wait-for-ok": "^3.2.0",
         "cosmiconfig": "^7.0.0",
         "lodash": "^4.17.21",
@@ -67,17 +67,17 @@
         "dotcom-tool-kit": "bin/run"
       },
       "devDependencies": {
-        "@dotcom-tool-kit/babel": "^3.2.0",
-        "@dotcom-tool-kit/backend-heroku-app": "^3.1.0",
-        "@dotcom-tool-kit/circleci": "^5.4.0",
-        "@dotcom-tool-kit/circleci-deploy": "^3.3.0",
-        "@dotcom-tool-kit/eslint": "^3.2.0",
-        "@dotcom-tool-kit/frontend-app": "^3.2.0",
-        "@dotcom-tool-kit/heroku": "^3.4.0",
-        "@dotcom-tool-kit/mocha": "^3.2.0",
-        "@dotcom-tool-kit/n-test": "^3.3.0",
-        "@dotcom-tool-kit/npm": "^3.3.0",
-        "@dotcom-tool-kit/webpack": "^3.2.0",
+        "@dotcom-tool-kit/babel": "^3.2.1",
+        "@dotcom-tool-kit/backend-heroku-app": "^3.1.5",
+        "@dotcom-tool-kit/circleci": "^6.0.2",
+        "@dotcom-tool-kit/circleci-deploy": "^3.4.4",
+        "@dotcom-tool-kit/eslint": "^3.2.2",
+        "@dotcom-tool-kit/frontend-app": "^3.2.5",
+        "@dotcom-tool-kit/heroku": "^3.4.2",
+        "@dotcom-tool-kit/mocha": "^3.2.1",
+        "@dotcom-tool-kit/n-test": "^3.3.2",
+        "@dotcom-tool-kit/npm": "^3.3.2",
+        "@dotcom-tool-kit/webpack": "^3.2.1",
         "@jest/globals": "^27.4.6",
         "@types/lodash": "^4.14.185",
         "@types/node": "^16.18.23",
@@ -122,15 +122,15 @@
     },
     "core/create": {
       "name": "@dotcom-tool-kit/create",
-      "version": "3.5.2",
+      "version": "3.8.0",
       "license": "ISC",
       "dependencies": {
         "@aws-sdk/client-iam": "^3.282.0",
         "@aws-sdk/client-sts": "^3.282.0",
-        "@dotcom-tool-kit/doppler": "^1.1.0",
+        "@dotcom-tool-kit/doppler": "^1.1.1",
         "@dotcom-tool-kit/error": "^3.2.0",
-        "@dotcom-tool-kit/logger": "^3.4.0",
-        "@dotcom-tool-kit/types": "^3.6.0",
+        "@dotcom-tool-kit/logger": "^3.4.1",
+        "@dotcom-tool-kit/types": "^3.6.1",
         "@octokit/rest": "^19.0.5",
         "@quarterto/parse-makefile-rules": "^1.1.0",
         "cli-highlight": "^2.1.11",
@@ -157,7 +157,7 @@
         "@types/pacote": "^11.1.3",
         "@types/prompts": "^2.0.14",
         "cosmiconfig": "^7.0.1",
-        "dotcom-tool-kit": "^3.4.0",
+        "dotcom-tool-kit": "^3.5.1",
         "type-fest": "^3.13.1"
       },
       "engines": {
@@ -1101,14 +1101,14 @@
     },
     "lib/doppler": {
       "name": "@dotcom-tool-kit/doppler",
-      "version": "1.1.0",
+      "version": "1.1.1",
       "license": "ISC",
       "dependencies": {
         "@dotcom-tool-kit/error": "^3.2.0",
-        "@dotcom-tool-kit/logger": "^3.4.0",
-        "@dotcom-tool-kit/options": "^3.2.0",
-        "@dotcom-tool-kit/types": "^3.6.0",
-        "@dotcom-tool-kit/vault": "^3.2.0",
+        "@dotcom-tool-kit/logger": "^3.4.1",
+        "@dotcom-tool-kit/options": "^3.2.1",
+        "@dotcom-tool-kit/types": "^3.6.1",
+        "@dotcom-tool-kit/vault": "^3.2.1",
         "tslib": "^2.3.1"
       },
       "devDependencies": {
@@ -1144,7 +1144,7 @@
     },
     "lib/logger": {
       "name": "@dotcom-tool-kit/logger",
-      "version": "3.4.0",
+      "version": "3.4.1",
       "license": "ISC",
       "dependencies": {
         "@dotcom-tool-kit/error": "^3.2.0",
@@ -1170,10 +1170,10 @@
     },
     "lib/options": {
       "name": "@dotcom-tool-kit/options",
-      "version": "3.2.0",
+      "version": "3.2.1",
       "license": "ISC",
       "dependencies": {
-        "@dotcom-tool-kit/types": "^3.6.0",
+        "@dotcom-tool-kit/types": "^3.6.1",
         "tslib": "^2.3.1"
       },
       "engines": {
@@ -1212,7 +1212,7 @@
     },
     "lib/state": {
       "name": "@dotcom-tool-kit/state",
-      "version": "3.2.0",
+      "version": "3.3.0",
       "license": "ISC",
       "dependencies": {
         "tslib": "^2.3.1"
@@ -1229,11 +1229,11 @@
     },
     "lib/types": {
       "name": "@dotcom-tool-kit/types",
-      "version": "3.6.0",
+      "version": "3.6.1",
       "license": "ISC",
       "dependencies": {
         "@dotcom-tool-kit/error": "^3.2.0",
-        "@dotcom-tool-kit/logger": "^3.4.0",
+        "@dotcom-tool-kit/logger": "^3.4.1",
         "semver": "^7.3.7",
         "tslib": "^2.3.1",
         "zod": "^3.20.2"
@@ -1256,12 +1256,12 @@
     },
     "lib/vault": {
       "name": "@dotcom-tool-kit/vault",
-      "version": "3.2.0",
+      "version": "3.2.1",
       "license": "ISC",
       "dependencies": {
         "@dotcom-tool-kit/error": "^3.2.0",
-        "@dotcom-tool-kit/options": "^3.2.0",
-        "@dotcom-tool-kit/types": "^3.6.0",
+        "@dotcom-tool-kit/options": "^3.2.1",
+        "@dotcom-tool-kit/types": "^3.6.1",
         "@financial-times/n-fetch": "^1.0.0",
         "fs": "0.0.1-security",
         "os": "^0.1.2",
@@ -28825,12 +28825,12 @@
     },
     "plugins/babel": {
       "name": "@dotcom-tool-kit/babel",
-      "version": "3.2.0",
+      "version": "3.2.1",
       "license": "MIT",
       "dependencies": {
         "@dotcom-tool-kit/error": "^3.2.0",
-        "@dotcom-tool-kit/logger": "^3.4.0",
-        "@dotcom-tool-kit/types": "^3.6.0",
+        "@dotcom-tool-kit/logger": "^3.4.1",
+        "@dotcom-tool-kit/types": "^3.6.1",
         "fast-glob": "^3.2.11",
         "tslib": "^2.3.1"
       },
@@ -28855,10 +28855,10 @@
     },
     "plugins/backend-app": {
       "name": "@dotcom-tool-kit/backend-app",
-      "version": "3.2.0",
+      "version": "3.2.5",
       "license": "ISC",
       "dependencies": {
-        "@dotcom-tool-kit/backend-heroku-app": "^3.1.0"
+        "@dotcom-tool-kit/backend-heroku-app": "^3.1.5"
       },
       "engines": {
         "node": "16.x || 18.x || 20.x",
@@ -28870,13 +28870,13 @@
     },
     "plugins/backend-heroku-app": {
       "name": "@dotcom-tool-kit/backend-heroku-app",
-      "version": "3.1.0",
+      "version": "3.1.5",
       "license": "ISC",
       "dependencies": {
-        "@dotcom-tool-kit/circleci-deploy": "^3.3.0",
-        "@dotcom-tool-kit/heroku": "^3.4.0",
-        "@dotcom-tool-kit/node": "^3.4.0",
-        "@dotcom-tool-kit/npm": "^3.3.0"
+        "@dotcom-tool-kit/circleci-deploy": "^3.4.4",
+        "@dotcom-tool-kit/heroku": "^3.4.2",
+        "@dotcom-tool-kit/node": "^3.4.2",
+        "@dotcom-tool-kit/npm": "^3.3.2"
       },
       "engines": {
         "node": "16.x || 18.x || 20.x",
@@ -28888,13 +28888,13 @@
     },
     "plugins/backend-serverless-app": {
       "name": "@dotcom-tool-kit/backend-serverless-app",
-      "version": "3.1.0",
+      "version": "3.2.8",
       "license": "ISC",
       "dependencies": {
-        "@dotcom-tool-kit/circleci-deploy": "^3.3.0",
-        "@dotcom-tool-kit/node": "^3.4.0",
-        "@dotcom-tool-kit/npm": "^3.3.0",
-        "@dotcom-tool-kit/serverless": "^2.3.0"
+        "@dotcom-tool-kit/circleci-deploy": "^3.4.4",
+        "@dotcom-tool-kit/node": "^3.4.2",
+        "@dotcom-tool-kit/npm": "^3.3.2",
+        "@dotcom-tool-kit/serverless": "^2.4.5"
       },
       "engines": {
         "node": "16.x || 18.x || 20.x",
@@ -28906,13 +28906,13 @@
     },
     "plugins/circleci": {
       "name": "@dotcom-tool-kit/circleci",
-      "version": "5.4.0",
+      "version": "6.0.2",
       "license": "ISC",
       "dependencies": {
         "@dotcom-tool-kit/error": "^3.2.0",
-        "@dotcom-tool-kit/logger": "^3.4.0",
-        "@dotcom-tool-kit/state": "^3.2.0",
-        "@dotcom-tool-kit/types": "^3.6.0",
+        "@dotcom-tool-kit/logger": "^3.4.1",
+        "@dotcom-tool-kit/state": "^3.3.0",
+        "@dotcom-tool-kit/types": "^3.6.1",
         "jest-diff": "^29.5.0",
         "lodash": "^4.17.21",
         "tslib": "^2.3.1",
@@ -28936,10 +28936,10 @@
     },
     "plugins/circleci-deploy": {
       "name": "@dotcom-tool-kit/circleci-deploy",
-      "version": "3.3.0",
+      "version": "3.4.4",
       "license": "ISC",
       "dependencies": {
-        "@dotcom-tool-kit/circleci": "^5.4.0",
+        "@dotcom-tool-kit/circleci": "^6.0.2",
         "tslib": "^2.3.1"
       },
       "devDependencies": {
@@ -28960,11 +28960,11 @@
     },
     "plugins/circleci-heroku": {
       "name": "@dotcom-tool-kit/circleci-heroku",
-      "version": "3.2.0",
+      "version": "3.2.5",
       "license": "ISC",
       "dependencies": {
-        "@dotcom-tool-kit/circleci-deploy": "^3.3.0",
-        "@dotcom-tool-kit/heroku": "^3.4.0",
+        "@dotcom-tool-kit/circleci-deploy": "^3.4.4",
+        "@dotcom-tool-kit/heroku": "^3.4.2",
         "tslib": "^2.3.1"
       },
       "engines": {
@@ -28982,12 +28982,12 @@
     },
     "plugins/circleci-npm": {
       "name": "@dotcom-tool-kit/circleci-npm",
-      "version": "5.3.0",
+      "version": "5.3.4",
       "license": "ISC",
       "dependencies": {
-        "@dotcom-tool-kit/circleci": "^5.4.0",
-        "@dotcom-tool-kit/npm": "^3.3.0",
-        "@dotcom-tool-kit/types": "^3.6.0",
+        "@dotcom-tool-kit/circleci": "^6.0.2",
+        "@dotcom-tool-kit/npm": "^3.3.2",
+        "@dotcom-tool-kit/types": "^3.6.1",
         "tslib": "^2.3.1"
       },
       "engines": {
@@ -29104,11 +29104,11 @@
     },
     "plugins/component": {
       "name": "@dotcom-tool-kit/component",
-      "version": "4.1.0",
+      "version": "4.1.4",
       "license": "ISC",
       "dependencies": {
-        "@dotcom-tool-kit/circleci-npm": "^5.3.0",
-        "@dotcom-tool-kit/npm": "^3.3.0"
+        "@dotcom-tool-kit/circleci-npm": "^5.3.4",
+        "@dotcom-tool-kit/npm": "^3.3.2"
       },
       "engines": {
         "node": "16.x || 18.x || 20.x",
@@ -29120,13 +29120,13 @@
     },
     "plugins/cypress": {
       "name": "@dotcom-tool-kit/cypress",
-      "version": "3.4.0",
+      "version": "4.0.2",
       "license": "ISC",
       "dependencies": {
-        "@dotcom-tool-kit/doppler": "^1.1.0",
-        "@dotcom-tool-kit/logger": "^3.4.0",
-        "@dotcom-tool-kit/state": "^3.2.0",
-        "@dotcom-tool-kit/types": "^3.6.0"
+        "@dotcom-tool-kit/doppler": "^1.1.1",
+        "@dotcom-tool-kit/logger": "^3.4.1",
+        "@dotcom-tool-kit/state": "^3.3.0",
+        "@dotcom-tool-kit/types": "^3.6.1"
       },
       "engines": {
         "node": "16.x || 18.x || 20.x",
@@ -29138,12 +29138,12 @@
     },
     "plugins/eslint": {
       "name": "@dotcom-tool-kit/eslint",
-      "version": "3.2.0",
+      "version": "3.2.2",
       "license": "ISC",
       "dependencies": {
         "@dotcom-tool-kit/error": "^3.2.0",
-        "@dotcom-tool-kit/logger": "^3.4.0",
-        "@dotcom-tool-kit/types": "^3.6.0",
+        "@dotcom-tool-kit/logger": "^3.4.1",
+        "@dotcom-tool-kit/types": "^3.6.1",
         "tslib": "^2.3.1"
       },
       "devDependencies": {
@@ -29360,12 +29360,12 @@
     },
     "plugins/frontend-app": {
       "name": "@dotcom-tool-kit/frontend-app",
-      "version": "3.2.0",
+      "version": "3.2.5",
       "license": "ISC",
       "dependencies": {
-        "@dotcom-tool-kit/backend-heroku-app": "^3.1.0",
-        "@dotcom-tool-kit/upload-assets-to-s3": "^3.2.0",
-        "@dotcom-tool-kit/webpack": "^3.2.0"
+        "@dotcom-tool-kit/backend-heroku-app": "^3.1.5",
+        "@dotcom-tool-kit/upload-assets-to-s3": "^3.2.1",
+        "@dotcom-tool-kit/webpack": "^3.2.1"
       },
       "engines": {
         "node": "16.x || 18.x || 20.x",
@@ -29377,17 +29377,17 @@
     },
     "plugins/heroku": {
       "name": "@dotcom-tool-kit/heroku",
-      "version": "3.4.0",
+      "version": "3.4.2",
       "license": "ISC",
       "dependencies": {
-        "@dotcom-tool-kit/doppler": "^1.1.0",
+        "@dotcom-tool-kit/doppler": "^1.1.1",
         "@dotcom-tool-kit/error": "^3.2.0",
-        "@dotcom-tool-kit/logger": "^3.4.0",
-        "@dotcom-tool-kit/npm": "^3.3.0",
-        "@dotcom-tool-kit/options": "^3.2.0",
+        "@dotcom-tool-kit/logger": "^3.4.1",
+        "@dotcom-tool-kit/npm": "^3.3.2",
+        "@dotcom-tool-kit/options": "^3.2.1",
         "@dotcom-tool-kit/package-json-hook": "^4.2.0",
-        "@dotcom-tool-kit/state": "^3.2.0",
-        "@dotcom-tool-kit/types": "^3.6.0",
+        "@dotcom-tool-kit/state": "^3.3.0",
+        "@dotcom-tool-kit/types": "^3.6.1",
         "@dotcom-tool-kit/wait-for-ok": "^3.2.0",
         "@octokit/request": "^5.6.0",
         "@octokit/request-error": "^2.1.0",
@@ -29438,11 +29438,11 @@
     },
     "plugins/jest": {
       "name": "@dotcom-tool-kit/jest",
-      "version": "3.4.0",
+      "version": "3.4.1",
       "license": "ISC",
       "dependencies": {
-        "@dotcom-tool-kit/logger": "^3.4.0",
-        "@dotcom-tool-kit/types": "^3.6.0",
+        "@dotcom-tool-kit/logger": "^3.4.1",
+        "@dotcom-tool-kit/types": "^3.6.1",
         "tslib": "^2.3.1"
       },
       "devDependencies": {
@@ -29465,12 +29465,12 @@
     },
     "plugins/lint-staged": {
       "name": "@dotcom-tool-kit/lint-staged",
-      "version": "4.2.0",
+      "version": "4.2.1",
       "license": "ISC",
       "dependencies": {
-        "@dotcom-tool-kit/logger": "^3.4.0",
+        "@dotcom-tool-kit/logger": "^3.4.1",
         "@dotcom-tool-kit/package-json-hook": "^4.2.0",
-        "@dotcom-tool-kit/types": "^3.6.0",
+        "@dotcom-tool-kit/types": "^3.6.1",
         "lint-staged": "^11.2.3",
         "tslib": "^2.3.1"
       },
@@ -29484,12 +29484,12 @@
     },
     "plugins/lint-staged-npm": {
       "name": "@dotcom-tool-kit/lint-staged-npm",
-      "version": "3.2.0",
+      "version": "3.2.1",
       "license": "ISC",
       "dependencies": {
         "@dotcom-tool-kit/husky-npm": "^4.2.0",
-        "@dotcom-tool-kit/lint-staged": "^4.2.0",
-        "@dotcom-tool-kit/options": "^3.2.0",
+        "@dotcom-tool-kit/lint-staged": "^4.2.1",
+        "@dotcom-tool-kit/options": "^3.2.1",
         "tslib": "^2.3.1"
       },
       "engines": {
@@ -29562,12 +29562,12 @@
     },
     "plugins/mocha": {
       "name": "@dotcom-tool-kit/mocha",
-      "version": "3.2.0",
+      "version": "3.2.1",
       "license": "ISC",
       "dependencies": {
         "@dotcom-tool-kit/error": "^3.2.0",
-        "@dotcom-tool-kit/logger": "^3.4.0",
-        "@dotcom-tool-kit/types": "^3.6.0",
+        "@dotcom-tool-kit/logger": "^3.4.1",
+        "@dotcom-tool-kit/types": "^3.6.1",
         "glob": "^7.1.7",
         "tslib": "^2.3.1"
       },
@@ -29593,12 +29593,12 @@
     },
     "plugins/n-test": {
       "name": "@dotcom-tool-kit/n-test",
-      "version": "3.3.0",
+      "version": "3.3.2",
       "license": "ISC",
       "dependencies": {
-        "@dotcom-tool-kit/logger": "^3.4.0",
-        "@dotcom-tool-kit/state": "^3.2.0",
-        "@dotcom-tool-kit/types": "^3.6.0",
+        "@dotcom-tool-kit/logger": "^3.4.1",
+        "@dotcom-tool-kit/state": "^3.3.0",
+        "@dotcom-tool-kit/types": "^3.6.1",
         "@financial-times/n-test": "^6.1.0-beta.1",
         "tslib": "^2.3.1"
       },
@@ -29714,14 +29714,14 @@
     },
     "plugins/next-router": {
       "name": "@dotcom-tool-kit/next-router",
-      "version": "3.4.0",
+      "version": "3.4.2",
       "license": "ISC",
       "dependencies": {
-        "@dotcom-tool-kit/doppler": "^1.1.0",
+        "@dotcom-tool-kit/doppler": "^1.1.1",
         "@dotcom-tool-kit/error": "^3.2.0",
-        "@dotcom-tool-kit/logger": "^3.4.0",
-        "@dotcom-tool-kit/state": "^3.2.0",
-        "@dotcom-tool-kit/types": "^3.6.0",
+        "@dotcom-tool-kit/logger": "^3.4.1",
+        "@dotcom-tool-kit/state": "^3.3.0",
+        "@dotcom-tool-kit/types": "^3.6.1",
         "ft-next-router": "^3.0.0",
         "tslib": "^2.3.1"
       },
@@ -29845,13 +29845,13 @@
     },
     "plugins/node": {
       "name": "@dotcom-tool-kit/node",
-      "version": "3.4.0",
+      "version": "3.4.2",
       "license": "ISC",
       "dependencies": {
-        "@dotcom-tool-kit/doppler": "^1.1.0",
+        "@dotcom-tool-kit/doppler": "^1.1.1",
         "@dotcom-tool-kit/error": "^3.2.0",
-        "@dotcom-tool-kit/state": "^3.2.0",
-        "@dotcom-tool-kit/types": "^3.6.0",
+        "@dotcom-tool-kit/state": "^3.3.0",
+        "@dotcom-tool-kit/types": "^3.6.1",
         "get-port": "^5.1.1",
         "tslib": "^2.3.1",
         "wait-port": "^0.2.9"
@@ -29871,13 +29871,13 @@
     },
     "plugins/nodemon": {
       "name": "@dotcom-tool-kit/nodemon",
-      "version": "3.4.0",
+      "version": "3.4.2",
       "license": "ISC",
       "dependencies": {
-        "@dotcom-tool-kit/doppler": "^1.1.0",
+        "@dotcom-tool-kit/doppler": "^1.1.1",
         "@dotcom-tool-kit/error": "^3.2.0",
-        "@dotcom-tool-kit/state": "^3.2.0",
-        "@dotcom-tool-kit/types": "^3.6.0",
+        "@dotcom-tool-kit/state": "^3.3.0",
+        "@dotcom-tool-kit/types": "^3.6.1",
         "get-port": "^5.1.1",
         "tslib": "^2.3.1"
       },
@@ -29900,14 +29900,14 @@
     },
     "plugins/npm": {
       "name": "@dotcom-tool-kit/npm",
-      "version": "3.3.0",
+      "version": "3.3.2",
       "license": "ISC",
       "dependencies": {
         "@actions/exec": "^1.1.0",
         "@dotcom-tool-kit/error": "^3.2.0",
         "@dotcom-tool-kit/package-json-hook": "^4.2.0",
-        "@dotcom-tool-kit/state": "^3.2.0",
-        "@dotcom-tool-kit/types": "^3.6.0",
+        "@dotcom-tool-kit/state": "^3.3.0",
+        "@dotcom-tool-kit/types": "^3.6.1",
         "libnpmpack": "^3.1.0",
         "libnpmpublish": "^5.0.1",
         "pacote": "^12.0.3",
@@ -30086,10 +30086,10 @@
     },
     "plugins/pa11y": {
       "name": "@dotcom-tool-kit/pa11y",
-      "version": "0.5.2",
+      "version": "0.5.3",
       "license": "ISC",
       "dependencies": {
-        "@dotcom-tool-kit/types": "^3.6.0",
+        "@dotcom-tool-kit/types": "^3.6.1",
         "pa11y-ci": "^3.0.1",
         "tslib": "^2.3.1"
       },
@@ -30111,13 +30111,13 @@
     },
     "plugins/prettier": {
       "name": "@dotcom-tool-kit/prettier",
-      "version": "3.2.0",
+      "version": "3.2.1",
       "license": "ISC",
       "dependencies": {
         "@dotcom-tool-kit/error": "^3.2.0",
-        "@dotcom-tool-kit/logger": "^3.4.0",
+        "@dotcom-tool-kit/logger": "^3.4.1",
         "@dotcom-tool-kit/package-json-hook": "^4.2.0",
-        "@dotcom-tool-kit/types": "^3.6.0",
+        "@dotcom-tool-kit/types": "^3.6.1",
         "fast-glob": "^3.2.7",
         "hook-std": "^2.0.0",
         "prettier": "^2.2.1",
@@ -30163,14 +30163,14 @@
     },
     "plugins/serverless": {
       "name": "@dotcom-tool-kit/serverless",
-      "version": "2.3.0",
+      "version": "2.4.5",
       "license": "ISC",
       "dependencies": {
-        "@dotcom-tool-kit/doppler": "^1.1.0",
+        "@dotcom-tool-kit/doppler": "^1.1.1",
         "@dotcom-tool-kit/error": "^3.2.0",
-        "@dotcom-tool-kit/options": "^3.2.0",
-        "@dotcom-tool-kit/state": "^3.2.0",
-        "@dotcom-tool-kit/types": "^3.6.0",
+        "@dotcom-tool-kit/options": "^3.2.1",
+        "@dotcom-tool-kit/state": "^3.3.0",
+        "@dotcom-tool-kit/types": "^3.6.1",
         "get-port": "^5.1.1",
         "tslib": "^2.3.1",
         "wait-port": "^0.2.9"
@@ -30191,11 +30191,11 @@
     },
     "plugins/typescript": {
       "name": "@dotcom-tool-kit/typescript",
-      "version": "2.2.0",
+      "version": "2.2.1",
       "license": "ISC",
       "dependencies": {
-        "@dotcom-tool-kit/logger": "^3.4.0",
-        "@dotcom-tool-kit/types": "^3.6.0"
+        "@dotcom-tool-kit/logger": "^3.4.1",
+        "@dotcom-tool-kit/types": "^3.6.1"
       },
       "devDependencies": {
         "@jest/globals": "^29.3.1",
@@ -30399,13 +30399,13 @@
     },
     "plugins/upload-assets-to-s3": {
       "name": "@dotcom-tool-kit/upload-assets-to-s3",
-      "version": "3.2.0",
+      "version": "3.2.1",
       "license": "ISC",
       "dependencies": {
         "@aws-sdk/client-s3": "^3.256.0",
         "@dotcom-tool-kit/error": "^3.2.0",
-        "@dotcom-tool-kit/logger": "^3.4.0",
-        "@dotcom-tool-kit/types": "^3.6.0",
+        "@dotcom-tool-kit/logger": "^3.4.1",
+        "@dotcom-tool-kit/types": "^3.6.1",
         "glob": "^7.1.6",
         "mime": "^2.5.2",
         "tslib": "^2.3.1"
@@ -30433,12 +30433,12 @@
     },
     "plugins/webpack": {
       "name": "@dotcom-tool-kit/webpack",
-      "version": "3.2.0",
+      "version": "3.2.1",
       "license": "MIT",
       "dependencies": {
         "@dotcom-tool-kit/error": "^3.2.0",
-        "@dotcom-tool-kit/logger": "^3.4.0",
-        "@dotcom-tool-kit/types": "^3.6.0",
+        "@dotcom-tool-kit/logger": "^3.4.1",
+        "@dotcom-tool-kit/types": "^3.6.1",
         "tslib": "^2.3.1",
         "webpack-cli": "^4.6.0"
       },

--- a/plugins/circleci-deploy/src/index.ts
+++ b/plugins/circleci-deploy/src/index.ts
@@ -41,6 +41,7 @@ export class DeployReview extends CircleCiConfigHook {
       addToNightly: true,
       requires: ['tool-kit/setup', 'waiting-for-approval'],
       splitIntoMatrix: false,
+      skipOnRelease: true,
       additionalFields: { filters: { branches: { ignore: 'main' } }, ...serverlessAdditionalsFields }
     })
   }
@@ -54,6 +55,7 @@ export class DeployStaging extends CircleCiConfigHook {
       addToNightly: false,
       requires: ['tool-kit/setup'],
       splitIntoMatrix: false,
+      skipOnRelease: true,
       additionalFields: { filters: { branches: { only: 'main' } } }
     })
   }
@@ -67,7 +69,8 @@ export class TestReview extends CircleCiConfigHook {
       name: TestReview.job,
       requires: [DeployReview.job],
       addToNightly: false,
-      splitIntoMatrix: false
+      splitIntoMatrix: false,
+      skipOnRelease: true
     }
 
     // CircleCI config generator which will additionally optionally pass Serverless
@@ -96,7 +99,8 @@ export class TestStaging extends CircleCiConfigHook {
       name: TestStaging.job,
       requires: [DeployStaging.job],
       addToNightly: false,
-      splitIntoMatrix: false
+      splitIntoMatrix: false,
+      skipOnRelease: true
     }
 
     const options = getOptions('@dotcom-tool-kit/circleci')
@@ -125,6 +129,7 @@ export class DeployProduction extends CircleCiConfigHook {
       addToNightly: false,
       requires: [TestStaging.job, TestCI.job],
       splitIntoMatrix: false,
+      skipOnRelease: true,
       additionalFields: {
         ...serverlessAdditionalsFields,
         filters: { branches: { only: 'main' } }

--- a/plugins/circleci/src/circleci-config.ts
+++ b/plugins/circleci/src/circleci-config.ts
@@ -90,6 +90,7 @@ export interface JobGeneratorOptions {
   requires: string[]
   /** whether this job can be run multiple times with different Node versions */
   splitIntoMatrix: boolean
+  skipOnRelease?: boolean
   /** other fields to include in the job */
   additionalFields?: JobConfig
 }
@@ -126,7 +127,12 @@ export const generateConfigWithJob = (options: JobGeneratorOptions): CircleCISta
         jobs: [
           {
             // avoid overwriting the jobBase variable
-            [options.name]: merge({}, jobBase, tagFilter, options.additionalFields)
+            [options.name]: merge(
+              {},
+              jobBase,
+              options.skipOnRelease ? {} : tagFilter,
+              options.additionalFields
+            )
           }
         ]
       }


### PR DESCRIPTION
# Description

We are already running staging jobs on tagged releases, so we don't need to run review jobs too. In addition, the `HerokuReview` task will fail as it can't find a branch to associate the review app with. For an example of why this is a problem, see next-router's CI [workflow](https://app.circleci.com/pipelines/github/Financial-Times/next-router/3073/workflows/8deeedd2-4e71-4916-86bd-99c50e2f64d8) with its unnecessary `tool-kit/deploy-review-node` branch.

# Checklist:

- [x] My branch has been rebased onto the latest commit on main (don't merge main into your branch)
- [x] My commit messages are [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/), for example: `feat(circleci): add support for nightly workflows`, `fix: set Heroku app name for staging apps too`
