### PR TITLE
refactor!: pass task files in as part of a run context object

### DIFF
--- a/core/cli/src/tasks.ts
+++ b/core/cli/src/tasks.ts
@@ -93,7 +93,7 @@ export async function runTasks(logger: Logger, commands: string[], files?: strin
     for (const task of tasks) {
       try {
         logger.info(styles.taskHeader(`running ${styles.task(task.id)} task`))
-        await task.run(files)
+        await task.run({ files })
       } catch (error) {
         // if there's an exit code, that's a request from the task to exit early
         if (error instanceof ToolKitError && error.exitCode) {

--- a/lib/base/src/task.ts
+++ b/lib/base/src/task.ts
@@ -5,6 +5,10 @@ import type { Logger } from 'winston'
 
 type Default<T, D> = T extends undefined ? D : T
 
+export type TaskRunContext = {
+  files?: string[]
+}
+
 export abstract class Task<
   Options extends {
     plugin?: z.ZodTypeAny
@@ -31,7 +35,7 @@ export abstract class Task<
     this.logger = logger.child({ task: id })
   }
 
-  abstract run(files?: string[]): Promise<void>
+  abstract run(runContext: TaskRunContext): Promise<void>
 }
 
 export type TaskConstructor = {

--- a/plugins/eslint/src/tasks/eslint.ts
+++ b/plugins/eslint/src/tasks/eslint.ts
@@ -1,11 +1,11 @@
 import { ToolKitError } from '@dotcom-tool-kit/error'
 import { styles } from '@dotcom-tool-kit/logger'
-import { Task } from '@dotcom-tool-kit/base'
+import { Task, TaskRunContext } from '@dotcom-tool-kit/base'
 import { ESLintSchema } from '@dotcom-tool-kit/schemas/lib/tasks/eslint'
 import { ESLint } from 'eslint'
 
 export default class Eslint extends Task<{ task: typeof ESLintSchema }> {
-  async run(files?: string[]): Promise<void> {
+  async run({ files }: TaskRunContext): Promise<void> {
     const eslint = new ESLint({ overrideConfigFile: this.options.configPath })
     const results = await eslint.lintFiles(files ?? this.options.files)
     const formatter = await eslint.loadFormatter('stylish')

--- a/plugins/eslint/test/tasks/eslint.test.ts
+++ b/plugins/eslint/test/tasks/eslint.test.ts
@@ -42,7 +42,7 @@ describe('eslint', () => {
       }
     )
 
-    await expect(task.run()).resolves.toBeUndefined()
+    await expect(task.run({ command: 'test:local' })).resolves.toBeUndefined()
   })
 
   it('should fail on linter error', async () => {
@@ -56,7 +56,7 @@ describe('eslint', () => {
       }
     )
 
-    await expect(task.run()).rejects.toHaveProperty(
+    await expect(task.run({ command: 'test:local' })).rejects.toHaveProperty(
       'details',
       expect.stringContaining('1 problem (1 error, 0 warnings)')
     )

--- a/plugins/prettier/src/tasks/prettier.ts
+++ b/plugins/prettier/src/tasks/prettier.ts
@@ -2,12 +2,12 @@ import prettier from 'prettier'
 import { PrettierOptions, PrettierSchema } from '@dotcom-tool-kit/schemas/lib/tasks/prettier'
 import { promises as fsp } from 'fs'
 import fg from 'fast-glob'
-import { hookConsole, styles } from '@dotcom-tool-kit/logger'
-import { Task } from '@dotcom-tool-kit/base'
+import { hookConsole } from '@dotcom-tool-kit/logger'
+import { Task, TaskRunContext } from '@dotcom-tool-kit/base'
 import { ToolKitError } from '@dotcom-tool-kit/error'
 
 export default class Prettier extends Task<{ task: typeof PrettierSchema }> {
-  async run(files?: string[]): Promise<void> {
+  async run({ files }: TaskRunContext): Promise<void> {
     try {
       const filepaths = await fg(files ?? this.options.files)
       for (const filepath of filepaths) {

--- a/plugins/prettier/test/tasks/prettier.test.ts
+++ b/plugins/prettier/test/tasks/prettier.test.ts
@@ -38,7 +38,7 @@ describe('prettier', () => {
         ignoreFile: 'nonexistent prettierignore'
       }
     )
-    await task.run()
+    await task.run({ command: 'format:local' })
     const prettified = await fsp.readFile(path.join(testDirectory, 'unformatted.ts'), 'utf8')
     expect(prettified).toEqual(formattedDefaultFixture)
   })
@@ -56,7 +56,7 @@ describe('prettier', () => {
       }
     )
 
-    await task.run()
+    await task.run({ command: 'format:local' })
     const prettified = await fsp.readFile(path.join(testDirectory, 'unformatted.ts'), 'utf8')
     expect(prettified).toEqual(formattedConfigFileFixture)
   })


### PR DESCRIPTION
group the `files` argument for `Task.run` into a "task context" object so we can pass more things into tasks later on. extracted from #630 