### PR TITLE
fix: allow multiple instances of task with different options

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1091,14 +1091,12 @@
     },
     "core/sandbox": {
       "version": "1.0.0",
-      "extraneous": true,
       "license": "ISC",
       "workspaces": [
         "packages/*"
       ],
       "dependencies": {
         "@dotcom-tool-kit/base": "file:../../lib/base",
-        "@dotcom-tool-kit/monorepo": "file:../../plugins/monorepo",
         "@dotcom-tool-kit/node": "file:../../plugins/node",
         "@dotcom-tool-kit/package-json-hook": "file:../../plugins/package-json-hook",
         "dotcom-tool-kit": "file:../cli"
@@ -26275,6 +26273,10 @@
       "version": "2.1.2",
       "license": "MIT"
     },
+    "node_modules/sandbox": {
+      "resolved": "core/sandbox",
+      "link": true
+    },
     "node_modules/sax": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/sax/-/sax-1.2.1.tgz",
@@ -31119,10 +31121,10 @@
     },
     "plugins/backend-app": {
       "name": "@dotcom-tool-kit/backend-app",
-      "version": "4.0.0-beta.5",
+      "version": "4.0.0-beta.6",
       "license": "ISC",
       "dependencies": {
-        "@dotcom-tool-kit/backend-heroku-app": "4.0.0-beta.5"
+        "@dotcom-tool-kit/backend-heroku-app": "4.0.0-beta.6"
       },
       "engines": {
         "node": "18.x || 20.x",
@@ -31134,10 +31136,10 @@
     },
     "plugins/backend-heroku-app": {
       "name": "@dotcom-tool-kit/backend-heroku-app",
-      "version": "4.0.0-beta.5",
+      "version": "4.0.0-beta.6",
       "license": "ISC",
       "dependencies": {
-        "@dotcom-tool-kit/circleci-deploy": "4.0.0-beta.5",
+        "@dotcom-tool-kit/circleci-deploy": "4.0.0-beta.6",
         "@dotcom-tool-kit/heroku": "4.0.0-beta.5",
         "@dotcom-tool-kit/node": "4.0.0-beta.5",
         "@dotcom-tool-kit/npm": "4.0.0-beta.5"
@@ -31152,10 +31154,10 @@
     },
     "plugins/backend-serverless-app": {
       "name": "@dotcom-tool-kit/backend-serverless-app",
-      "version": "4.0.0-beta.5",
+      "version": "4.0.0-beta.6",
       "license": "ISC",
       "dependencies": {
-        "@dotcom-tool-kit/circleci-deploy": "4.0.0-beta.5",
+        "@dotcom-tool-kit/circleci-deploy": "4.0.0-beta.6",
         "@dotcom-tool-kit/node": "4.0.0-beta.5",
         "@dotcom-tool-kit/npm": "4.0.0-beta.5",
         "@dotcom-tool-kit/serverless": "3.0.0-beta.5"
@@ -31170,7 +31172,7 @@
     },
     "plugins/circleci": {
       "name": "@dotcom-tool-kit/circleci",
-      "version": "7.0.0-beta.5",
+      "version": "7.0.0-beta.6",
       "license": "ISC",
       "dependencies": {
         "@dotcom-tool-kit/base": "4.0.0-beta.0",
@@ -31206,10 +31208,10 @@
     },
     "plugins/circleci-deploy": {
       "name": "@dotcom-tool-kit/circleci-deploy",
-      "version": "4.0.0-beta.5",
+      "version": "4.0.0-beta.6",
       "license": "ISC",
       "dependencies": {
-        "@dotcom-tool-kit/circleci": "7.0.0-beta.5",
+        "@dotcom-tool-kit/circleci": "7.0.0-beta.6",
         "tslib": "^2.3.1"
       },
       "devDependencies": {
@@ -31230,10 +31232,10 @@
     },
     "plugins/circleci-heroku": {
       "name": "@dotcom-tool-kit/circleci-heroku",
-      "version": "4.0.0-beta.5",
+      "version": "4.0.0-beta.6",
       "license": "ISC",
       "dependencies": {
-        "@dotcom-tool-kit/circleci-deploy": "4.0.0-beta.5",
+        "@dotcom-tool-kit/circleci-deploy": "4.0.0-beta.6",
         "@dotcom-tool-kit/heroku": "4.0.0-beta.5",
         "tslib": "^2.3.1"
       },
@@ -31252,10 +31254,10 @@
     },
     "plugins/circleci-npm": {
       "name": "@dotcom-tool-kit/circleci-npm",
-      "version": "6.0.0-beta.5",
+      "version": "6.0.0-beta.6",
       "license": "ISC",
       "dependencies": {
-        "@dotcom-tool-kit/circleci": "7.0.0-beta.5",
+        "@dotcom-tool-kit/circleci": "7.0.0-beta.6",
         "@dotcom-tool-kit/npm": "4.0.0-beta.5",
         "tslib": "^2.3.1"
       },
@@ -31373,10 +31375,10 @@
     },
     "plugins/component": {
       "name": "@dotcom-tool-kit/component",
-      "version": "5.0.0-beta.5",
+      "version": "5.0.0-beta.6",
       "license": "ISC",
       "dependencies": {
-        "@dotcom-tool-kit/circleci-npm": "6.0.0-beta.5",
+        "@dotcom-tool-kit/circleci-npm": "6.0.0-beta.6",
         "@dotcom-tool-kit/npm": "4.0.0-beta.5"
       },
       "engines": {
@@ -31636,10 +31638,10 @@
     },
     "plugins/frontend-app": {
       "name": "@dotcom-tool-kit/frontend-app",
-      "version": "4.0.0-beta.5",
+      "version": "4.0.0-beta.6",
       "license": "ISC",
       "dependencies": {
-        "@dotcom-tool-kit/backend-heroku-app": "4.0.0-beta.5",
+        "@dotcom-tool-kit/backend-heroku-app": "4.0.0-beta.6",
         "@dotcom-tool-kit/upload-assets-to-s3": "4.0.0-beta.5",
         "@dotcom-tool-kit/webpack": "4.0.0-beta.5"
       },


### PR DESCRIPTION
`loadTasks` returned a `Record<string, Task>`, meaning that a command with multiple instances of the same task would just load the last created instance (with the last specified options), meaning tasks couldn't be called multiple times with different options.