### PR TITLE
Fix up some some missing options in CircleCI config

### DIFF
--- a/plugins/circleci-deploy/.toolkitrc.yml
+++ b/plugins/circleci-deploy/.toolkitrc.yml
@@ -27,6 +27,9 @@ options:
                   filters:
                     branches:
                       ignore: main
+                  !toolkit/if-defined '@dotcom-tool-kit/serverless.awsAccountId':
+                    aws-account-id: !toolkit/option '@dotcom-tool-kit/serverless.awsAccountId'
+                    system-code: !toolkit/option '@dotcom-tool-kit/serverless.systemCode'
               - name: 'deploy-staging'
                 requires:
                   - 'setup'

--- a/plugins/circleci-deploy/.toolkitrc.yml
+++ b/plugins/circleci-deploy/.toolkitrc.yml
@@ -48,8 +48,6 @@ options:
                   !toolkit/if-defined '@dotcom-tool-kit/serverless.awsAccountId':
                     aws-account-id: !toolkit/option '@dotcom-tool-kit/serverless.awsAccountId'
                     system-code: !toolkit/option '@dotcom-tool-kit/serverless.systemCode'
-                  !toolkit/if-defined '@dotcom-tool-kit/next-router.appName':
-                    appName: !toolkit/option '@dotcom-tool-kit/next-router.appName'
               - name: 'e2e-test-staging'
                 splitIntoMatrix: false
                 requires:


### PR DESCRIPTION
# Description

Adds back some missing Serverless parameters to the `deploy-review` job in CircleCI.

Fixes the issue reported in https://github.com/Financial-Times/cp-healthchecks/pull/5.

# Checklist:

- [x] My branch has been rebased onto the latest commit on main (don't merge main into your branch)
- [x] My commit messages are [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/), for example: `feat(circleci): add support for nightly workflows`, `fix: set Heroku app name for staging apps too`
