### PR TITLE
feat(wip): add a node-test plugin

### DIFF
--- a/lib/schemas/src/tasks.ts
+++ b/lib/schemas/src/tasks.ts
@@ -5,6 +5,7 @@ import { JestSchema } from './tasks/jest'
 import { MochaSchema } from './tasks/mocha'
 import { NodeSchema } from './tasks/node'
 import { NodemonSchema } from './tasks/nodemon'
+import { NodeTestSchema } from './tasks/node-test'
 import { PrettierSchema } from './tasks/prettier'
 import { TypeScriptSchema } from './tasks/typescript'
 import { UploadAssetsToS3Schema } from './tasks/upload-assets-to-s3'
@@ -29,6 +30,7 @@ export const TaskSchemas = {
   Mocha: MochaSchema,
   Node: NodeSchema,
   Nodemon: NodemonSchema,
+  NodeTest: NodeTestSchema,
   NpmPrune: z.object({}).describe('Prune development npm dependencies.'),
   NpmPublish: z.object({}).describe('Publish package to the npm registry.'),
   NTest: SmokeTestSchema,

--- a/lib/schemas/src/tasks/node-test.ts
+++ b/lib/schemas/src/tasks/node-test.ts
@@ -1,0 +1,30 @@
+import { z } from 'zod'
+
+export const NodeTestSchema = z
+  .object({
+    concurrency: z
+      .number()
+      .int()
+      .or(z.boolean())
+      .default(false)
+      .describe('The number of tests to run in parallel. See https://nodejs.org/api/test.html#runoptions'),
+    files: z
+      .string()
+      .array()
+      .optional()
+      .describe('The glob patterns for test files'),
+    ignore: z
+      .string()
+      .array()
+      .default([])
+      .describe('Glob patterns for test files to ignore'),
+    forceExit: z
+      .boolean()
+      .default(false)
+      .describe('Whether to force exit the process once all tests have finished executing')
+  })
+  .describe('Runs the built-in Node.js test runner to execute tests.')
+
+export type NodeTestOptions = z.infer<typeof NodeTestSchema>
+
+export const Schema = NodeTestSchema

--- a/package-lock.json
+++ b/package-lock.json
@@ -49,18 +49,18 @@
     },
     "core/cli": {
       "name": "dotcom-tool-kit",
-      "version": "4.2.0",
+      "version": "4.3.1",
       "license": "MIT",
       "dependencies": {
-        "@dotcom-tool-kit/base": "^1.1.1",
-        "@dotcom-tool-kit/config": "^1.0.4",
+        "@dotcom-tool-kit/base": "^1.1.2",
+        "@dotcom-tool-kit/config": "^1.0.5",
         "@dotcom-tool-kit/conflict": "^1.0.0",
-        "@dotcom-tool-kit/error": "^4.0.1",
-        "@dotcom-tool-kit/logger": "^4.0.1",
+        "@dotcom-tool-kit/error": "^4.1.0",
+        "@dotcom-tool-kit/logger": "^4.1.0",
         "@dotcom-tool-kit/plugin": "^1.0.0",
-        "@dotcom-tool-kit/state": "^4.0.0",
-        "@dotcom-tool-kit/validated": "^1.0.1",
-        "@dotcom-tool-kit/wait-for-ok": "^4.0.0",
+        "@dotcom-tool-kit/state": "^4.1.0",
+        "@dotcom-tool-kit/validated": "^1.0.2",
+        "@dotcom-tool-kit/wait-for-ok": "^4.1.0",
         "endent": "^2.1.0",
         "lodash": "^4.17.21",
         "minimist": "^1.2.5",
@@ -133,16 +133,16 @@
     },
     "core/create": {
       "name": "@dotcom-tool-kit/create",
-      "version": "4.1.1",
+      "version": "4.2.1",
       "license": "ISC",
       "dependencies": {
         "@aws-sdk/client-iam": "^3.282.0",
         "@aws-sdk/client-sts": "^3.282.0",
-        "@dotcom-tool-kit/doppler": "^2.0.4",
-        "@dotcom-tool-kit/error": "^4.0.1",
-        "@dotcom-tool-kit/logger": "^4.0.1",
+        "@dotcom-tool-kit/doppler": "^2.1.0",
+        "@dotcom-tool-kit/error": "^4.1.0",
+        "@dotcom-tool-kit/logger": "^4.1.0",
         "@dotcom-tool-kit/plugin": "^1.0.0",
-        "@dotcom-tool-kit/schemas": "^1.3.0",
+        "@dotcom-tool-kit/schemas": "^1.4.0",
         "@octokit/rest": "^19.0.5",
         "@quarterto/parse-makefile-rules": "^1.1.0",
         "cli-highlight": "^2.1.11",
@@ -169,7 +169,7 @@
         "@types/node-fetch": "^2.6.2",
         "@types/pacote": "^11.1.3",
         "@types/prompts": "^2.0.14",
-        "dotcom-tool-kit": "^4.2.0",
+        "dotcom-tool-kit": "^4.3.1",
         "type-fest": "^3.13.1"
       },
       "engines": {
@@ -1100,17 +1100,17 @@
     },
     "lib/base": {
       "name": "@dotcom-tool-kit/base",
-      "version": "1.1.1",
+      "version": "1.1.2",
       "license": "ISC",
       "dependencies": {
         "@dotcom-tool-kit/conflict": "^1.0.0",
-        "@dotcom-tool-kit/validated": "^1.0.1",
+        "@dotcom-tool-kit/validated": "^1.0.2",
         "semver": "^7.5.4",
         "winston": "^3.11.0"
       },
       "devDependencies": {
-        "@dotcom-tool-kit/config": "^1.0.4",
-        "@dotcom-tool-kit/logger": "^4.0.1",
+        "@dotcom-tool-kit/config": "^1.0.5",
+        "@dotcom-tool-kit/logger": "^4.1.0",
         "@dotcom-tool-kit/plugin": "^1.0.0",
         "type-fest": "^4.29.1",
         "winston": "^3.11.0",
@@ -1200,13 +1200,13 @@
     },
     "lib/config": {
       "name": "@dotcom-tool-kit/config",
-      "version": "1.0.4",
+      "version": "1.0.5",
       "license": "ISC",
       "dependencies": {
         "@dotcom-tool-kit/conflict": "^1.0.0",
         "@dotcom-tool-kit/plugin": "^1.0.0",
-        "@dotcom-tool-kit/schemas": "^1.3.0",
-        "@dotcom-tool-kit/validated": "^1.0.1"
+        "@dotcom-tool-kit/schemas": "^1.4.0",
+        "@dotcom-tool-kit/validated": "^1.0.2"
       }
     },
     "lib/conflict": {
@@ -1219,15 +1219,15 @@
     },
     "lib/doppler": {
       "name": "@dotcom-tool-kit/doppler",
-      "version": "2.0.4",
+      "version": "2.1.0",
       "license": "ISC",
       "dependencies": {
-        "@dotcom-tool-kit/error": "^4.0.1",
-        "@dotcom-tool-kit/logger": "^4.0.1",
+        "@dotcom-tool-kit/error": "^4.1.0",
+        "@dotcom-tool-kit/logger": "^4.1.0",
         "tslib": "^2.3.1"
       },
       "devDependencies": {
-        "@dotcom-tool-kit/schemas": "^1.3.0",
+        "@dotcom-tool-kit/schemas": "^1.4.0",
         "spawk": "^1.8.1",
         "winston": "^3.5.1"
       },
@@ -1242,7 +1242,7 @@
     },
     "lib/error": {
       "name": "@dotcom-tool-kit/error",
-      "version": "4.0.1",
+      "version": "4.1.0",
       "license": "ISC",
       "dependencies": {
         "tslib": "^2.3.1"
@@ -1258,11 +1258,11 @@
     },
     "lib/logger": {
       "name": "@dotcom-tool-kit/logger",
-      "version": "4.0.1",
+      "version": "4.1.0",
       "license": "ISC",
       "dependencies": {
         "@apaleslimghost/boxen": "^5.1.3",
-        "@dotcom-tool-kit/error": "^4.0.1",
+        "@dotcom-tool-kit/error": "^4.1.0",
         "ansi-regex": "^5.0.1",
         "triple-beam": "^1.3.0",
         "tslib": "^2.3.1",
@@ -1323,10 +1323,10 @@
     },
     "lib/schemas": {
       "name": "@dotcom-tool-kit/schemas",
-      "version": "1.3.0",
+      "version": "1.4.0",
       "license": "ISC",
       "dependencies": {
-        "@dotcom-tool-kit/logger": "^4.0.1"
+        "@dotcom-tool-kit/logger": "^4.1.0"
       },
       "devDependencies": {
         "prompts": "^2.4.2",
@@ -1375,7 +1375,7 @@
     },
     "lib/state": {
       "name": "@dotcom-tool-kit/state",
-      "version": "4.0.0",
+      "version": "4.1.0",
       "license": "ISC",
       "dependencies": {
         "tslib": "^2.3.1"
@@ -1420,10 +1420,10 @@
     },
     "lib/validated": {
       "name": "@dotcom-tool-kit/validated",
-      "version": "1.0.1",
+      "version": "1.0.2",
       "license": "ISC",
       "dependencies": {
-        "@dotcom-tool-kit/error": "^4.0.1"
+        "@dotcom-tool-kit/error": "^4.1.0"
       }
     },
     "lib/vault": {
@@ -1453,7 +1453,7 @@
     },
     "lib/wait-for-ok": {
       "name": "@dotcom-tool-kit/wait-for-ok",
-      "version": "4.0.0",
+      "version": "4.1.0",
       "license": "ISC",
       "dependencies": {
         "tslib": "^2.3.1"
@@ -6507,6 +6507,10 @@
       "resolved": "plugins/node",
       "link": true
     },
+    "node_modules/@dotcom-tool-kit/node-test": {
+      "resolved": "plugins/node-test",
+      "link": true
+    },
     "node_modules/@dotcom-tool-kit/nodemon": {
       "resolved": "plugins/nodemon",
       "link": true
@@ -7441,6 +7445,102 @@
       "version": "2.2.5",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/@isaacs/cliui": {
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/@isaacs/cliui/-/cliui-8.0.2.tgz",
+      "integrity": "sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==",
+      "license": "ISC",
+      "dependencies": {
+        "string-width": "^5.1.2",
+        "string-width-cjs": "npm:string-width@^4.2.0",
+        "strip-ansi": "^7.0.1",
+        "strip-ansi-cjs": "npm:strip-ansi@^6.0.1",
+        "wrap-ansi": "^8.1.0",
+        "wrap-ansi-cjs": "npm:wrap-ansi@^7.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@isaacs/cliui/node_modules/ansi-regex": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.1.0.tgz",
+      "integrity": "sha512-7HSX4QQb4CspciLpVFwyRe79O3xsIZDDLER21kERQ71oaPodF8jL725AgJMFAYbooIqolJoRLuM81SpeUkpkvA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
+      }
+    },
+    "node_modules/@isaacs/cliui/node_modules/ansi-styles": {
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.1.tgz",
+      "integrity": "sha512-bN798gFfQX+viw3R7yrGWRqnrN2oRkEkUjjl4JNn4E8GxxbjtG3FbrEIIY3l8/hrwUwIeCZvi4QuOTP4MErVug==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/@isaacs/cliui/node_modules/emoji-regex": {
+      "version": "9.2.2",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-9.2.2.tgz",
+      "integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==",
+      "license": "MIT"
+    },
+    "node_modules/@isaacs/cliui/node_modules/string-width": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-5.1.2.tgz",
+      "integrity": "sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA==",
+      "license": "MIT",
+      "dependencies": {
+        "eastasianwidth": "^0.2.0",
+        "emoji-regex": "^9.2.2",
+        "strip-ansi": "^7.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@isaacs/cliui/node_modules/strip-ansi": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.1.0.tgz",
+      "integrity": "sha512-iq6eVVI64nQQTRYq2KtEg2d2uU7LElhTJwsH4YzIHZshxlgZms/wIc4VoDQTlG/IvVIrBKG06CrZnp0qv7hkcQ==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
+      }
+    },
+    "node_modules/@isaacs/cliui/node_modules/wrap-ansi": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-8.1.0.tgz",
+      "integrity": "sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^6.1.0",
+        "string-width": "^5.0.1",
+        "strip-ansi": "^7.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
     },
     "node_modules/@istanbuljs/load-nyc-config": {
       "version": "1.1.0",
@@ -14614,8 +14714,7 @@
     "node_modules/eastasianwidth": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/eastasianwidth/-/eastasianwidth-0.2.0.tgz",
-      "integrity": "sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==",
-      "peer": true
+      "integrity": "sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA=="
     },
     "node_modules/ecc-jsbn": {
       "version": "0.1.2",
@@ -16357,6 +16456,84 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/foreground-child": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-3.3.0.tgz",
+      "integrity": "sha512-Ld2g8rrAyMYFXBhEqMz8ZAHBi4J4uS1i/CxGMDnjyFWddMXLVcDp051DZfu+t7+ab7Wv6SMqpWmyFIj5UbfFvg==",
+      "license": "ISC",
+      "dependencies": {
+        "cross-spawn": "^7.0.0",
+        "signal-exit": "^4.0.1"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/foreground-child/node_modules/cross-spawn": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
+      "license": "MIT",
+      "dependencies": {
+        "path-key": "^3.1.0",
+        "shebang-command": "^2.0.0",
+        "which": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/foreground-child/node_modules/shebang-command": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+      "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+      "license": "MIT",
+      "dependencies": {
+        "shebang-regex": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/foreground-child/node_modules/shebang-regex": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/foreground-child/node_modules/signal-exit": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
+      "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/foreground-child/node_modules/which": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+      "license": "ISC",
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "node-which": "bin/node-which"
+      },
+      "engines": {
+        "node": ">= 8"
       }
     },
     "node_modules/forever-agent": {
@@ -18419,6 +18596,21 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/jackspeak": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-4.0.2.tgz",
+      "integrity": "sha512-bZsjR/iRjl1Nk1UkjGpAzLNfQtzuijhn2g+pbZb98HQ1Gk8vM9hfbxeMBP+M2/UUdwj0RqGG3mlvk2MsAqwvEw==",
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "@isaacs/cliui": "^8.0.2"
+      },
+      "engines": {
+        "node": "20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/jake": {
@@ -23580,6 +23772,12 @@
         "node": ">=8"
       }
     },
+    "node_modules/package-json-from-dist": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/package-json-from-dist/-/package-json-from-dist-1.0.1.tgz",
+      "integrity": "sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==",
+      "license": "BlueOak-1.0.0"
+    },
     "node_modules/package-json/node_modules/semver": {
       "version": "6.3.0",
       "license": "ISC",
@@ -24113,6 +24311,40 @@
     "node_modules/path-parse": {
       "version": "1.0.7",
       "license": "MIT"
+    },
+    "node_modules/path-scurry": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-2.0.0.tgz",
+      "integrity": "sha512-ypGJsmGtdXUOeM5u93TyeIEfEhM6s+ljAhrk5vAvSx8uyY/02OvrZnA0YNGUrPXfpJMgI1ODd3nwz8Npx4O4cg==",
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "lru-cache": "^11.0.0",
+        "minipass": "^7.1.2"
+      },
+      "engines": {
+        "node": "20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/path-scurry/node_modules/lru-cache": {
+      "version": "11.0.2",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.0.2.tgz",
+      "integrity": "sha512-123qHRfJBmo2jXDbo/a5YOQrJoHF/GNQTLzQ5+IdK5pWpceK17yRc6ozlWd25FxvGKQbIUs91fDFkXmDHTKcyA==",
+      "license": "ISC",
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
+    "node_modules/path-scurry/node_modules/minipass": {
+      "version": "7.1.2",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.2.tgz",
+      "integrity": "sha512-qOOzS1cBTWYF4BH8fVePDBOO9iptMnGUEZwNc/cMWnTV2nVLZ7VoNWEPHkYczZA0pdoA7dl6e7FL659nX9S2aw==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      }
     },
     "node_modules/path-type": {
       "version": "4.0.0",
@@ -27600,6 +27832,21 @@
         "node": ">=8"
       }
     },
+    "node_modules/string-width-cjs": {
+      "name": "string-width",
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/string.prototype.trim": {
       "version": "1.2.9",
       "resolved": "https://registry.npmjs.org/string.prototype.trim/-/string.prototype.trim-1.2.9.tgz",
@@ -27667,6 +27914,19 @@
     },
     "node_modules/strip-ansi": {
       "version": "6.0.1",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-ansi-cjs": {
+      "name": "strip-ansi",
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
       "license": "MIT",
       "dependencies": {
         "ansi-regex": "^5.0.1"
@@ -30135,6 +30395,24 @@
         "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
       }
     },
+    "node_modules/wrap-ansi-cjs": {
+      "name": "wrap-ansi",
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
     "node_modules/wrappy": {
       "version": "1.0.2",
       "license": "ISC"
@@ -30486,18 +30764,18 @@
     },
     "plugins/babel": {
       "name": "@dotcom-tool-kit/babel",
-      "version": "4.1.1",
+      "version": "4.2.0",
       "license": "MIT",
       "dependencies": {
-        "@dotcom-tool-kit/base": "^1.1.1",
-        "@dotcom-tool-kit/error": "^4.0.1",
-        "@dotcom-tool-kit/logger": "^4.0.1",
+        "@dotcom-tool-kit/base": "^1.1.2",
+        "@dotcom-tool-kit/error": "^4.1.0",
+        "@dotcom-tool-kit/logger": "^4.1.0",
         "fast-glob": "^3.2.11",
         "tslib": "^2.3.1"
       },
       "devDependencies": {
         "@babel/preset-env": "^7.16.11",
-        "@dotcom-tool-kit/schemas": "^1.3.0",
+        "@dotcom-tool-kit/schemas": "^1.4.0",
         "@jest/globals": "^27.4.6",
         "winston": "^3.5.1"
       },
@@ -30532,13 +30810,13 @@
     },
     "plugins/backend-heroku-app": {
       "name": "@dotcom-tool-kit/backend-heroku-app",
-      "version": "4.0.4",
+      "version": "4.1.0",
       "license": "ISC",
       "dependencies": {
-        "@dotcom-tool-kit/circleci-deploy": "^4.0.4",
-        "@dotcom-tool-kit/heroku": "^4.0.4",
-        "@dotcom-tool-kit/node": "^4.1.1",
-        "@dotcom-tool-kit/npm": "^4.1.1"
+        "@dotcom-tool-kit/circleci-deploy": "^4.1.0",
+        "@dotcom-tool-kit/heroku": "^4.1.0",
+        "@dotcom-tool-kit/node": "^4.2.0",
+        "@dotcom-tool-kit/npm": "^4.2.0"
       },
       "engines": {
         "node": "18.x || 20.x || 22.x"
@@ -30549,13 +30827,13 @@
     },
     "plugins/backend-serverless-app": {
       "name": "@dotcom-tool-kit/backend-serverless-app",
-      "version": "4.0.4",
+      "version": "4.1.0",
       "license": "ISC",
       "dependencies": {
-        "@dotcom-tool-kit/circleci-deploy": "^4.0.4",
-        "@dotcom-tool-kit/node": "^4.1.1",
-        "@dotcom-tool-kit/npm": "^4.1.1",
-        "@dotcom-tool-kit/serverless": "^3.1.1"
+        "@dotcom-tool-kit/circleci-deploy": "^4.1.0",
+        "@dotcom-tool-kit/node": "^4.2.0",
+        "@dotcom-tool-kit/npm": "^4.2.0",
+        "@dotcom-tool-kit/serverless": "^3.2.0"
       },
       "engines": {
         "node": "18.x || 20.x || 22.x"
@@ -30566,14 +30844,14 @@
     },
     "plugins/circleci": {
       "name": "@dotcom-tool-kit/circleci",
-      "version": "7.2.0",
+      "version": "7.3.0",
       "license": "ISC",
       "dependencies": {
-        "@dotcom-tool-kit/base": "^1.1.1",
+        "@dotcom-tool-kit/base": "^1.1.2",
         "@dotcom-tool-kit/conflict": "^1.0.0",
-        "@dotcom-tool-kit/error": "^4.0.1",
-        "@dotcom-tool-kit/logger": "^4.0.1",
-        "@dotcom-tool-kit/state": "^4.0.0",
+        "@dotcom-tool-kit/error": "^4.1.0",
+        "@dotcom-tool-kit/logger": "^4.1.0",
+        "@dotcom-tool-kit/state": "^4.1.0",
         "jest-diff": "^29.5.0",
         "lodash": "^4.17.21",
         "tslib": "^2.3.1",
@@ -30582,7 +30860,7 @@
       },
       "devDependencies": {
         "@dotcom-tool-kit/plugin": "^1.0.0",
-        "@dotcom-tool-kit/schemas": "^1.3.0",
+        "@dotcom-tool-kit/schemas": "^1.4.0",
         "@jest/globals": "^27.4.6",
         "@types/jest": "^27.4.0",
         "@types/js-yaml": "^4.0.3",
@@ -30600,10 +30878,10 @@
     },
     "plugins/circleci-deploy": {
       "name": "@dotcom-tool-kit/circleci-deploy",
-      "version": "4.0.4",
+      "version": "4.1.0",
       "license": "ISC",
       "dependencies": {
-        "@dotcom-tool-kit/circleci": "^7.2.0",
+        "@dotcom-tool-kit/circleci": "^7.3.0",
         "tslib": "^2.3.1"
       },
       "devDependencies": {
@@ -30641,11 +30919,11 @@
     },
     "plugins/circleci-npm": {
       "name": "@dotcom-tool-kit/circleci-npm",
-      "version": "6.0.5",
+      "version": "6.1.0",
       "license": "ISC",
       "dependencies": {
-        "@dotcom-tool-kit/circleci": "^7.2.0",
-        "@dotcom-tool-kit/npm": "^4.1.1",
+        "@dotcom-tool-kit/circleci": "^7.3.0",
+        "@dotcom-tool-kit/npm": "^4.2.0",
         "tslib": "^2.3.1"
       },
       "engines": {
@@ -30761,7 +31039,7 @@
     },
     "plugins/cloudsmith": {
       "name": "@dotcom-tool-kit/cloudsmith",
-      "version": "0.1.0",
+      "version": "1.0.1",
       "license": "ISC",
       "engines": {
         "node": "18.x || 20.x",
@@ -30773,11 +31051,11 @@
     },
     "plugins/commitlint": {
       "name": "@dotcom-tool-kit/commitlint",
-      "version": "1.1.1",
+      "version": "1.2.0",
       "license": "ISC",
       "dependencies": {
-        "@dotcom-tool-kit/base": "^1.1.1",
-        "@dotcom-tool-kit/logger": "^4.0.1"
+        "@dotcom-tool-kit/base": "^1.1.2",
+        "@dotcom-tool-kit/logger": "^4.1.0"
       },
       "engines": {
         "node": "18.x || 20.x || 22.x"
@@ -31486,11 +31764,11 @@
     },
     "plugins/component": {
       "name": "@dotcom-tool-kit/component",
-      "version": "5.0.5",
+      "version": "5.1.0",
       "license": "ISC",
       "dependencies": {
-        "@dotcom-tool-kit/circleci-npm": "^6.0.5",
-        "@dotcom-tool-kit/npm": "^4.1.1"
+        "@dotcom-tool-kit/circleci-npm": "^6.1.0",
+        "@dotcom-tool-kit/npm": "^4.2.0"
       },
       "engines": {
         "node": "18.x || 20.x || 22.x"
@@ -31501,17 +31779,17 @@
     },
     "plugins/cypress": {
       "name": "@dotcom-tool-kit/cypress",
-      "version": "5.1.1",
+      "version": "5.2.0",
       "license": "ISC",
       "dependencies": {
-        "@dotcom-tool-kit/base": "^1.1.1",
-        "@dotcom-tool-kit/doppler": "^2.0.4",
-        "@dotcom-tool-kit/logger": "^4.0.1",
-        "@dotcom-tool-kit/package-json-hook": "^5.0.4",
-        "@dotcom-tool-kit/state": "^4.0.0"
+        "@dotcom-tool-kit/base": "^1.1.2",
+        "@dotcom-tool-kit/doppler": "^2.1.0",
+        "@dotcom-tool-kit/logger": "^4.1.0",
+        "@dotcom-tool-kit/package-json-hook": "^5.1.0",
+        "@dotcom-tool-kit/state": "^4.1.0"
       },
       "devDependencies": {
-        "@dotcom-tool-kit/schemas": "^1.3.0"
+        "@dotcom-tool-kit/schemas": "^1.4.0"
       },
       "engines": {
         "node": "18.x || 20.x || 22.x"
@@ -31525,16 +31803,16 @@
     },
     "plugins/eslint": {
       "name": "@dotcom-tool-kit/eslint",
-      "version": "4.1.1",
+      "version": "4.2.0",
       "license": "ISC",
       "dependencies": {
-        "@dotcom-tool-kit/base": "^1.1.1",
-        "@dotcom-tool-kit/error": "^4.0.1",
-        "@dotcom-tool-kit/logger": "^4.0.1",
+        "@dotcom-tool-kit/base": "^1.1.2",
+        "@dotcom-tool-kit/error": "^4.1.0",
+        "@dotcom-tool-kit/logger": "^4.1.0",
         "tslib": "^2.3.1"
       },
       "devDependencies": {
-        "@dotcom-tool-kit/schemas": "^1.3.0",
+        "@dotcom-tool-kit/schemas": "^1.4.0",
         "@jest/globals": "^27.4.6",
         "@types/eslint": "^7.2.13",
         "@types/temp": "^0.9.4",
@@ -31749,12 +32027,12 @@
     },
     "plugins/frontend-app": {
       "name": "@dotcom-tool-kit/frontend-app",
-      "version": "4.0.4",
+      "version": "4.1.0",
       "license": "ISC",
       "dependencies": {
-        "@dotcom-tool-kit/backend-heroku-app": "^4.0.4",
-        "@dotcom-tool-kit/upload-assets-to-s3": "^4.1.1",
-        "@dotcom-tool-kit/webpack": "^4.1.1"
+        "@dotcom-tool-kit/backend-heroku-app": "^4.1.0",
+        "@dotcom-tool-kit/upload-assets-to-s3": "^4.2.0",
+        "@dotcom-tool-kit/webpack": "^4.2.0"
       },
       "engines": {
         "node": "18.x || 20.x || 22.x"
@@ -31765,17 +32043,17 @@
     },
     "plugins/heroku": {
       "name": "@dotcom-tool-kit/heroku",
-      "version": "4.0.4",
+      "version": "4.1.0",
       "license": "ISC",
       "dependencies": {
-        "@dotcom-tool-kit/base": "^1.1.1",
-        "@dotcom-tool-kit/doppler": "^2.0.4",
-        "@dotcom-tool-kit/error": "^4.0.1",
-        "@dotcom-tool-kit/logger": "^4.0.1",
-        "@dotcom-tool-kit/npm": "^4.1.1",
-        "@dotcom-tool-kit/package-json-hook": "^5.0.4",
-        "@dotcom-tool-kit/state": "^4.0.0",
-        "@dotcom-tool-kit/wait-for-ok": "^4.0.0",
+        "@dotcom-tool-kit/base": "^1.1.2",
+        "@dotcom-tool-kit/doppler": "^2.1.0",
+        "@dotcom-tool-kit/error": "^4.1.0",
+        "@dotcom-tool-kit/logger": "^4.1.0",
+        "@dotcom-tool-kit/npm": "^4.2.0",
+        "@dotcom-tool-kit/package-json-hook": "^5.1.0",
+        "@dotcom-tool-kit/state": "^4.1.0",
+        "@dotcom-tool-kit/wait-for-ok": "^4.1.0",
         "@octokit/request": "^8.4.0",
         "@octokit/request-error": "^5.1.0",
         "heroku-client": "^3.1.0",
@@ -31784,7 +32062,7 @@
         "tslib": "^2.3.1"
       },
       "devDependencies": {
-        "@dotcom-tool-kit/schemas": "^1.3.0",
+        "@dotcom-tool-kit/schemas": "^1.4.0",
         "@types/financial-times__package-json": "^1.9.0",
         "@types/p-retry": "^3.0.1",
         "winston": "^3.5.1"
@@ -31855,10 +32133,10 @@
     },
     "plugins/husky-npm": {
       "name": "@dotcom-tool-kit/husky-npm",
-      "version": "5.0.4",
+      "version": "5.1.0",
       "license": "ISC",
       "dependencies": {
-        "@dotcom-tool-kit/package-json-hook": "^5.0.4",
+        "@dotcom-tool-kit/package-json-hook": "^5.1.0",
         "tslib": "^2.3.1"
       },
       "engines": {
@@ -31876,15 +32154,15 @@
     },
     "plugins/jest": {
       "name": "@dotcom-tool-kit/jest",
-      "version": "4.1.1",
+      "version": "4.2.0",
       "license": "ISC",
       "dependencies": {
-        "@dotcom-tool-kit/base": "^1.1.1",
-        "@dotcom-tool-kit/logger": "^4.0.1",
+        "@dotcom-tool-kit/base": "^1.1.2",
+        "@dotcom-tool-kit/logger": "^4.1.0",
         "tslib": "^2.3.1"
       },
       "devDependencies": {
-        "@dotcom-tool-kit/schemas": "^1.3.0",
+        "@dotcom-tool-kit/schemas": "^1.4.0",
         "winston": "^3.5.1"
       },
       "engines": {
@@ -31902,12 +32180,12 @@
     },
     "plugins/lint-staged": {
       "name": "@dotcom-tool-kit/lint-staged",
-      "version": "5.1.1",
+      "version": "5.2.0",
       "license": "ISC",
       "dependencies": {
-        "@dotcom-tool-kit/base": "^1.1.1",
-        "@dotcom-tool-kit/logger": "^4.0.1",
-        "@dotcom-tool-kit/package-json-hook": "^5.0.4",
+        "@dotcom-tool-kit/base": "^1.1.2",
+        "@dotcom-tool-kit/logger": "^4.1.0",
+        "@dotcom-tool-kit/package-json-hook": "^5.1.0",
         "lint-staged": "^11.2.3",
         "tslib": "^2.3.1"
       },
@@ -31920,12 +32198,12 @@
     },
     "plugins/lint-staged-npm": {
       "name": "@dotcom-tool-kit/lint-staged-npm",
-      "version": "4.0.4",
+      "version": "4.1.0",
       "license": "ISC",
       "dependencies": {
-        "@dotcom-tool-kit/husky-npm": "^5.0.4",
-        "@dotcom-tool-kit/lint-staged": "^5.1.1",
-        "@dotcom-tool-kit/package-json-hook": "^5.0.4",
+        "@dotcom-tool-kit/husky-npm": "^5.1.0",
+        "@dotcom-tool-kit/lint-staged": "^5.2.0",
+        "@dotcom-tool-kit/package-json-hook": "^5.1.0",
         "tslib": "^2.3.1"
       },
       "engines": {
@@ -31997,17 +32275,17 @@
     },
     "plugins/mocha": {
       "name": "@dotcom-tool-kit/mocha",
-      "version": "4.1.1",
+      "version": "4.2.0",
       "license": "ISC",
       "dependencies": {
-        "@dotcom-tool-kit/base": "^1.1.1",
-        "@dotcom-tool-kit/error": "^4.0.1",
-        "@dotcom-tool-kit/logger": "^4.0.1",
+        "@dotcom-tool-kit/base": "^1.1.2",
+        "@dotcom-tool-kit/error": "^4.1.0",
+        "@dotcom-tool-kit/logger": "^4.1.0",
         "glob": "^7.1.7",
         "tslib": "^2.3.1"
       },
       "devDependencies": {
-        "@dotcom-tool-kit/schemas": "^1.3.0",
+        "@dotcom-tool-kit/schemas": "^1.4.0",
         "@jest/globals": "^27.4.6",
         "@types/glob": "^7.1.3",
         "@types/mocha": "^8.2.2",
@@ -32031,17 +32309,17 @@
     },
     "plugins/n-test": {
       "name": "@dotcom-tool-kit/n-test",
-      "version": "4.1.1",
+      "version": "4.2.0",
       "license": "ISC",
       "dependencies": {
-        "@dotcom-tool-kit/base": "^1.1.1",
-        "@dotcom-tool-kit/logger": "^4.0.1",
-        "@dotcom-tool-kit/state": "^4.0.0",
+        "@dotcom-tool-kit/base": "^1.1.2",
+        "@dotcom-tool-kit/logger": "^4.1.0",
+        "@dotcom-tool-kit/state": "^4.1.0",
         "@financial-times/n-test": "^6.1.0-beta.1",
         "tslib": "^2.3.1"
       },
       "devDependencies": {
-        "@dotcom-tool-kit/schemas": "^1.3.0",
+        "@dotcom-tool-kit/schemas": "^1.4.0",
         "@jest/globals": "^27.4.6",
         "@types/jest": "^27.4.0",
         "winston": "^3.5.1"
@@ -32152,19 +32430,19 @@
     },
     "plugins/next-router": {
       "name": "@dotcom-tool-kit/next-router",
-      "version": "4.1.1",
+      "version": "4.2.0",
       "license": "ISC",
       "dependencies": {
-        "@dotcom-tool-kit/base": "^1.1.1",
-        "@dotcom-tool-kit/doppler": "^2.0.4",
-        "@dotcom-tool-kit/error": "^4.0.1",
-        "@dotcom-tool-kit/logger": "^4.0.1",
-        "@dotcom-tool-kit/state": "^4.0.0",
+        "@dotcom-tool-kit/base": "^1.1.2",
+        "@dotcom-tool-kit/doppler": "^2.1.0",
+        "@dotcom-tool-kit/error": "^4.1.0",
+        "@dotcom-tool-kit/logger": "^4.1.0",
+        "@dotcom-tool-kit/state": "^4.1.0",
         "ft-next-router": "^3.0.0",
         "tslib": "^2.3.1"
       },
       "devDependencies": {
-        "@dotcom-tool-kit/schemas": "^1.3.0"
+        "@dotcom-tool-kit/schemas": "^1.4.0"
       },
       "engines": {
         "node": "18.x || 20.x || 22.x"
@@ -32285,19 +32563,19 @@
     },
     "plugins/node": {
       "name": "@dotcom-tool-kit/node",
-      "version": "4.1.1",
+      "version": "4.2.0",
       "license": "ISC",
       "dependencies": {
-        "@dotcom-tool-kit/base": "^1.1.1",
-        "@dotcom-tool-kit/doppler": "^2.0.4",
-        "@dotcom-tool-kit/error": "^4.0.1",
-        "@dotcom-tool-kit/state": "^4.0.0",
+        "@dotcom-tool-kit/base": "^1.1.2",
+        "@dotcom-tool-kit/doppler": "^2.1.0",
+        "@dotcom-tool-kit/error": "^4.1.0",
+        "@dotcom-tool-kit/state": "^4.1.0",
         "get-port": "^5.1.1",
         "tslib": "^2.3.1",
         "wait-port": "^0.2.9"
       },
       "devDependencies": {
-        "@dotcom-tool-kit/schemas": "^1.3.0"
+        "@dotcom-tool-kit/schemas": "^1.4.0"
       },
       "engines": {
         "node": "18.x || 20.x || 22.x"
@@ -32306,6 +32584,126 @@
         "dotcom-tool-kit": "4.x"
       }
     },
+    "plugins/node-test": {
+      "name": "@dotcom-tool-kit/node-test",
+      "version": "4.0.0",
+      "license": "ISC",
+      "dependencies": {
+        "@dotcom-tool-kit/base": "^1.1.2",
+        "@dotcom-tool-kit/error": "^4.1.0",
+        "@dotcom-tool-kit/logger": "^4.1.0",
+        "glob": "^11.0.0",
+        "tslib": "^2.3.1"
+      },
+      "devDependencies": {
+        "@dotcom-tool-kit/schemas": "^1.4.0",
+        "@types/glob": "^8.1.0",
+        "@types/node": "^22.10.5"
+      },
+      "engines": {
+        "node": "20.x || 22.x"
+      },
+      "peerDependencies": {
+        "dotcom-tool-kit": "4.x"
+      }
+    },
+    "plugins/node-test/node_modules/@types/glob": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/@types/glob/-/glob-8.1.0.tgz",
+      "integrity": "sha512-IO+MJPVhoqz+28h1qLAcBEH2+xHMK6MTyHJc7MTnnYb6wsoLR29POVGJ7LycmVXIqyy/4/2ShP5sUwTXuOwb/w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/minimatch": "^5.1.2",
+        "@types/node": "*"
+      }
+    },
+    "plugins/node-test/node_modules/@types/minimatch": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/@types/minimatch/-/minimatch-5.1.2.tgz",
+      "integrity": "sha512-K0VQKziLUWkVKiRVrx4a40iPaxTUefQmjtkQofBkYRcoaaL/8rhwDWww9qWbrgicNOgnpIsMxyNIUM4+n6dUIA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "plugins/node-test/node_modules/@types/node": {
+      "version": "22.10.5",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.10.5.tgz",
+      "integrity": "sha512-F8Q+SeGimwOo86fiovQh8qiXfFEh2/ocYv7tU5pJ3EXMSSxk1Joj5wefpFK2fHTf/N6HKGSxIDBT9f3gCxXPkQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.20.0"
+      }
+    },
+    "plugins/node-test/node_modules/brace-expansion": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
+      "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0"
+      }
+    },
+    "plugins/node-test/node_modules/glob": {
+      "version": "11.0.0",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-11.0.0.tgz",
+      "integrity": "sha512-9UiX/Bl6J2yaBbxKoEBRm4Cipxgok8kQYcOPEhScPwebu2I0HoQOuYdIO6S3hLuWoZgpDpwQZMzTFxgpkyT76g==",
+      "license": "ISC",
+      "dependencies": {
+        "foreground-child": "^3.1.0",
+        "jackspeak": "^4.0.1",
+        "minimatch": "^10.0.0",
+        "minipass": "^7.1.2",
+        "package-json-from-dist": "^1.0.0",
+        "path-scurry": "^2.0.0"
+      },
+      "bin": {
+        "glob": "dist/esm/bin.mjs"
+      },
+      "engines": {
+        "node": "20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "plugins/node-test/node_modules/minimatch": {
+      "version": "10.0.1",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.0.1.tgz",
+      "integrity": "sha512-ethXTt3SGGR+95gudmqJ1eNhRO7eGEGIgYA9vnPatK4/etz2MEVDno5GMCibdMTuBMyElzIlgxMna3K94XDIDQ==",
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^2.0.1"
+      },
+      "engines": {
+        "node": "20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "plugins/node-test/node_modules/minipass": {
+      "version": "7.1.2",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.2.tgz",
+      "integrity": "sha512-qOOzS1cBTWYF4BH8fVePDBOO9iptMnGUEZwNc/cMWnTV2nVLZ7VoNWEPHkYczZA0pdoA7dl6e7FL659nX9S2aw==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      }
+    },
+    "plugins/node-test/node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD"
+    },
+    "plugins/node-test/node_modules/undici-types": {
+      "version": "6.20.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.20.0.tgz",
+      "integrity": "sha512-Ny6QZ2Nju20vw1SRHe3d9jVu6gJ+4e3+MMpqu7pqE5HT6WsTSlce++GQmK5UXS8mzV8DSYHrQH+Xrf2jVcuKNg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "plugins/node/node_modules/tslib": {
       "version": "2.4.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
@@ -32313,18 +32711,18 @@
     },
     "plugins/nodemon": {
       "name": "@dotcom-tool-kit/nodemon",
-      "version": "4.0.4",
+      "version": "4.1.0",
       "license": "ISC",
       "dependencies": {
-        "@dotcom-tool-kit/base": "^1.1.1",
-        "@dotcom-tool-kit/doppler": "^2.0.4",
-        "@dotcom-tool-kit/error": "^4.0.1",
-        "@dotcom-tool-kit/state": "^4.0.0",
+        "@dotcom-tool-kit/base": "^1.1.2",
+        "@dotcom-tool-kit/doppler": "^2.1.0",
+        "@dotcom-tool-kit/error": "^4.1.0",
+        "@dotcom-tool-kit/state": "^4.1.0",
         "get-port": "^5.1.1",
         "tslib": "^2.3.1"
       },
       "devDependencies": {
-        "@dotcom-tool-kit/schemas": "^1.3.0",
+        "@dotcom-tool-kit/schemas": "^1.4.0",
         "@types/nodemon": "^1.19.1"
       },
       "engines": {
@@ -32342,13 +32740,13 @@
     },
     "plugins/npm": {
       "name": "@dotcom-tool-kit/npm",
-      "version": "4.1.1",
+      "version": "4.2.0",
       "license": "ISC",
       "dependencies": {
-        "@dotcom-tool-kit/base": "^1.1.1",
-        "@dotcom-tool-kit/error": "^4.0.1",
-        "@dotcom-tool-kit/package-json-hook": "^5.0.4",
-        "@dotcom-tool-kit/state": "^4.0.0",
+        "@dotcom-tool-kit/base": "^1.1.2",
+        "@dotcom-tool-kit/error": "^4.1.0",
+        "@dotcom-tool-kit/package-json-hook": "^5.1.0",
+        "@dotcom-tool-kit/state": "^4.1.0",
         "libnpmpack": "^3.1.0",
         "libnpmpublish": "^5.0.1",
         "pacote": "^12.0.3",
@@ -32578,10 +32976,10 @@
     },
     "plugins/package-json-hook": {
       "name": "@dotcom-tool-kit/package-json-hook",
-      "version": "5.0.4",
+      "version": "5.1.0",
       "license": "ISC",
       "dependencies": {
-        "@dotcom-tool-kit/base": "^1.1.1",
+        "@dotcom-tool-kit/base": "^1.1.2",
         "@dotcom-tool-kit/conflict": "^1.0.0",
         "@dotcom-tool-kit/plugin": "^1.0.0",
         "@financial-times/package-json": "^3.0.0",
@@ -32589,7 +32987,7 @@
         "tslib": "^2.3.1"
       },
       "devDependencies": {
-        "@dotcom-tool-kit/schemas": "^1.3.0",
+        "@dotcom-tool-kit/schemas": "^1.4.0",
         "@jest/globals": "^27.4.6",
         "@types/lodash": "^4.14.185",
         "winston": "^3.5.1",
@@ -32612,13 +33010,13 @@
     },
     "plugins/prettier": {
       "name": "@dotcom-tool-kit/prettier",
-      "version": "4.1.1",
+      "version": "4.2.0",
       "license": "ISC",
       "dependencies": {
-        "@dotcom-tool-kit/base": "^1.1.1",
-        "@dotcom-tool-kit/error": "^4.0.1",
-        "@dotcom-tool-kit/logger": "^4.0.1",
-        "@dotcom-tool-kit/package-json-hook": "^5.0.4",
+        "@dotcom-tool-kit/base": "^1.1.2",
+        "@dotcom-tool-kit/error": "^4.1.0",
+        "@dotcom-tool-kit/logger": "^4.1.0",
+        "@dotcom-tool-kit/package-json-hook": "^5.1.0",
         "fast-glob": "^3.2.7",
         "hook-std": "^2.0.0",
         "prettier": "^2.2.1",
@@ -32667,19 +33065,19 @@
     },
     "plugins/serverless": {
       "name": "@dotcom-tool-kit/serverless",
-      "version": "3.1.1",
+      "version": "3.2.0",
       "license": "ISC",
       "dependencies": {
-        "@dotcom-tool-kit/base": "^1.1.1",
-        "@dotcom-tool-kit/doppler": "^2.0.4",
-        "@dotcom-tool-kit/error": "^4.0.1",
-        "@dotcom-tool-kit/state": "^4.0.0",
+        "@dotcom-tool-kit/base": "^1.1.2",
+        "@dotcom-tool-kit/doppler": "^2.1.0",
+        "@dotcom-tool-kit/error": "^4.1.0",
+        "@dotcom-tool-kit/state": "^4.1.0",
         "get-port": "^5.1.1",
         "tslib": "^2.3.1",
         "wait-port": "^0.2.9"
       },
       "devDependencies": {
-        "@dotcom-tool-kit/schemas": "^1.3.0"
+        "@dotcom-tool-kit/schemas": "^1.4.0"
       },
       "engines": {
         "node": "18.x || 20.x || 22.x"
@@ -32696,14 +33094,14 @@
     },
     "plugins/typescript": {
       "name": "@dotcom-tool-kit/typescript",
-      "version": "3.1.1",
+      "version": "3.2.0",
       "license": "ISC",
       "dependencies": {
-        "@dotcom-tool-kit/base": "^1.1.1",
-        "@dotcom-tool-kit/logger": "^4.0.1"
+        "@dotcom-tool-kit/base": "^1.1.2",
+        "@dotcom-tool-kit/logger": "^4.1.0"
       },
       "devDependencies": {
-        "@dotcom-tool-kit/schemas": "^1.3.0",
+        "@dotcom-tool-kit/schemas": "^1.4.0",
         "@jest/globals": "^29.3.1",
         "typescript": "^4.9.4",
         "winston": "^3.8.2"
@@ -32917,20 +33315,20 @@
     },
     "plugins/upload-assets-to-s3": {
       "name": "@dotcom-tool-kit/upload-assets-to-s3",
-      "version": "4.1.1",
+      "version": "4.2.0",
       "license": "ISC",
       "dependencies": {
         "@aws-sdk/client-s3": "^3.256.0",
-        "@dotcom-tool-kit/base": "^1.1.1",
-        "@dotcom-tool-kit/error": "^4.0.1",
-        "@dotcom-tool-kit/logger": "^4.0.1",
+        "@dotcom-tool-kit/base": "^1.1.2",
+        "@dotcom-tool-kit/error": "^4.1.0",
+        "@dotcom-tool-kit/logger": "^4.1.0",
         "glob": "^7.1.6",
         "mime": "^2.5.2",
         "tslib": "^2.3.1"
       },
       "devDependencies": {
         "@aws-sdk/types": "^3.13.1",
-        "@dotcom-tool-kit/schemas": "^1.3.0",
+        "@dotcom-tool-kit/schemas": "^1.4.0",
         "@jest/globals": "^27.4.6",
         "@types/glob": "^7.1.3",
         "@types/jest": "^27.4.0",
@@ -32951,17 +33349,17 @@
     },
     "plugins/webpack": {
       "name": "@dotcom-tool-kit/webpack",
-      "version": "4.1.1",
+      "version": "4.2.0",
       "license": "MIT",
       "dependencies": {
-        "@dotcom-tool-kit/base": "^1.1.1",
-        "@dotcom-tool-kit/error": "^4.0.1",
-        "@dotcom-tool-kit/logger": "^4.0.1",
+        "@dotcom-tool-kit/base": "^1.1.2",
+        "@dotcom-tool-kit/error": "^4.1.0",
+        "@dotcom-tool-kit/logger": "^4.1.0",
         "tslib": "^2.3.1",
         "webpack-cli": "^4.6.0"
       },
       "devDependencies": {
-        "@dotcom-tool-kit/schemas": "^1.3.0",
+        "@dotcom-tool-kit/schemas": "^1.4.0",
         "@jest/globals": "^27.4.6",
         "ts-node": "^10.0.0",
         "webpack": "^4.42.1",

--- a/plugins/node-test/.toolkitrc.yml
+++ b/plugins/node-test/.toolkitrc.yml
@@ -1,0 +1,8 @@
+tasks:
+  NodeTest: './lib/tasks/node-test'
+
+commands:
+  'test:local': NodeTest
+  'test:ci': NodeTest
+
+version: 2

--- a/plugins/node-test/jest.config.js
+++ b/plugins/node-test/jest.config.js
@@ -1,0 +1,5 @@
+const base = require('../../jest.config.base')
+
+module.exports = {
+  ...base.config
+}

--- a/plugins/node-test/package.json
+++ b/plugins/node-test/package.json
@@ -1,0 +1,44 @@
+{
+  "name": "@dotcom-tool-kit/node-test",
+  "version": "4.0.0",
+  "description": "",
+  "main": "lib",
+  "scripts": {
+    "test": "cd ../../ ; npx jest --silent --projects plugins/node-test"
+  },
+  "keywords": [],
+  "author": "FT.com Platforms Team <platforms-team.customer-products@ft.com>",
+  "license": "ISC",
+  "dependencies": {
+    "@dotcom-tool-kit/base": "^1.1.2",
+    "@dotcom-tool-kit/error": "^4.1.0",
+    "@dotcom-tool-kit/logger": "^4.1.0",
+    "glob": "^11.0.0",
+    "tslib": "^2.3.1"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/financial-times/dotcom-tool-kit.git",
+    "directory": "plugins/node-test"
+  },
+  "bugs": "https://github.com/financial-times/dotcom-tool-kit/issues",
+  "homepage": "https://github.com/financial-times/dotcom-tool-kit/tree/main/plugins/node-test",
+  "devDependencies": {
+    "@dotcom-tool-kit/schemas": "^1.4.0",
+    "@types/glob": "^8.1.0",
+    "@types/node": "^22.10.5"
+  },
+  "files": [
+    "/lib",
+    ".toolkitrc.yml"
+  ],
+  "volta": {
+    "extends": "../../package.json"
+  },
+  "peerDependencies": {
+    "dotcom-tool-kit": "4.x"
+  },
+  "engines": {
+    "node": "20.x || 22.x"
+  }
+}

--- a/plugins/node-test/src/tasks/node-test.ts
+++ b/plugins/node-test/src/tasks/node-test.ts
@@ -1,0 +1,56 @@
+import { glob } from 'glob'
+import { NodeTestSchema } from '@dotcom-tool-kit/schemas/lib/tasks/node-test'
+import { run } from 'node:test'
+import { spec } from 'node:test/reporters'
+import { Task } from '@dotcom-tool-kit/base'
+import { ToolKitError } from '@dotcom-tool-kit/error'
+
+// This is a nasty list of file patterns to maintain however it's unavoidable
+// if we want to make this plugin work consistently between Node.js 20–22. In
+// future (when we drop Node.js 20 support) we will be able to remove this and
+// rely on the build-in patterns.
+//
+// See https://nodejs.org/api/test.html#running-tests-from-the-command-line
+const defaultFilePatterns = [
+  '**/*.test.?(c|m)js',
+  '**/*-test.?(c|m)js',
+  '**/*_test.?(c|m)js',
+  '**/test-*.?(c|m)js',
+  '**/test.?(c|m)js',
+  '**/test/**/*.?(c|m)js'
+]
+
+// We don't want to run tests against files under "node_modules"
+const defaultIgnorePatterns = [
+  '**/node_modules/**'
+]
+
+export default class NodeTest extends Task<{ task: typeof NodeTestSchema }> {
+  async run(): Promise<void> {
+    try {
+      const cwd = process.cwd()
+      const filePatterns = this.options.files ?? defaultFilePatterns
+      const ignore = [...this.options.ignore, ...defaultIgnorePatterns];
+      const files = await glob(filePatterns, { cwd, ignore })
+      return new Promise((resolve, reject) => {
+        run({ files })
+          .on('test:fail', () => {
+            reject(new ToolKitError('Tests did not pass'))
+          })
+          .on('test:pass', () => {
+            resolve()
+          })
+          .compose(spec)
+          .pipe(process.stdout)
+      })
+    } catch (err) {
+      if (err instanceof Error) {
+        const error = new ToolKitError('node test failed to run')
+        error.details = err.message
+        throw error
+      } else {
+        throw err
+      }
+    }
+  }
+}

--- a/plugins/node-test/tsconfig.json
+++ b/plugins/node-test/tsconfig.json
@@ -1,0 +1,23 @@
+{
+  "extends": "../../tsconfig.settings.json",
+  "references": [
+    {
+      "path": "../../lib/base"
+    },
+    {
+      "path": "../../lib/error"
+    },
+    {
+      "path": "../../lib/logger"
+    },
+    {
+      "path": "../../lib/schemas"
+    }
+  ],
+  "include": ["src/**/*"],
+  "compilerOptions": {
+    "outDir": "lib",
+    "rootDir": "src",
+    "types": ["glob", "node"]
+  }
+}

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -45,6 +45,7 @@
     "plugins/n-test": {},
     "plugins/next-router": {},
     "plugins/node": {},
+    "plugins/node-test": {},
     "plugins/nodemon": {},
     "plugins/npm": {},
     "plugins/package-json-hook": {},

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -80,6 +80,9 @@
       "path": "plugins/node"
     },
     {
+      "path": "plugins/node-test"
+    },
+    {
       "path": "plugins/next-router"
     },
     {


### PR DESCRIPTION
> [!NOTE]
> This is a draft because I'm looking for early feedback on my approach before writing tests.

# Description

This adds a node-test plugin using `node:test#run()`. There are quite a few gotchas with this one:

  * If we want to support Node.js 18 and 20 then we can't use glob patterns (the `globPatterns` option) because it's only supported in Node.js 22. I think glob patterns are important so I've replicated with the glob package.

  * We don't support Node.js 18 less than v18.17.0, this is because there wasn't a consistent JavaScript API for the built-in test reporters before this version. This is captured in the engines. An alternative would be to drop Node.js 18 support in this package as we'll be doing this in April 2025 anyway.

  * There is no way of configuring the built-in test runner via a config file or similar. This means we need to expose more options than Jest or Mocha in the Tool Kit config file.

# Checklist:

- [ ] My branch has been rebased onto the latest commit on main (don't merge main into your branch)
- [x] My commit messages are [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/), for example: `feat(circleci): add support for nightly workflows`, `fix: set Heroku app name for staging apps too`
