### PR TITLE
Remove Renovate/nori workflow

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -206,33 +206,6 @@ workflows:
           filters:
             <<: *filters_only_main
 
-  renovate-nori-build-test:
-    when:
-      not:
-        equal:
-          - scheduled_pipeline
-          - << pipeline.trigger_source >>
-    jobs:
-      - build:
-          name: build-v<< matrix.node-version >>
-          matrix:
-            parameters:
-              node-version: [ '18.20', '20.12' ]
-      - test:
-          requires:
-            - build-v<< matrix.node-version >>
-          name: test-v<< matrix.node-version >>
-          matrix:
-            parameters:
-              node-version: [ '18.20', '20.12' ]
-      - lint:
-          requires:
-            - build-v<< matrix.node-version >>
-          name: lint-v<< matrix.node-version >>
-          matrix:
-            parameters:
-              node-version: [ '18.20', '20.12' ]
-
   build-test-publish:
     when:
       not:


### PR DESCRIPTION
# Description

We had previously [removed the filter for Renovate and nori PRs](https://github.com/Financial-Times/dotcom-tool-kit/commit/0716ad29155fe605f705fd47bfdd8f7eadbb98b3) but not the workflow that only ran when the filter was true. Without the filter it is now running unconditionally for every PR, causing duplicated CI work.

# Checklist:

- [x] My branch has been rebased onto the latest commit on main (don't merge main into your branch)
- [x] My commit messages are [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/), for example: `feat(circleci): add support for nightly workflows`, `fix: set Heroku app name for staging apps too`
