### PR TITLE
fix(cli): add missing dependency on @dotcom-tool-kit/state

### DIFF
--- a/core/cli/package.json
+++ b/core/cli/package.json
@@ -37,6 +37,7 @@
     "@dotcom-tool-kit/logger": "^4.0.0",
     "@dotcom-tool-kit/options": "^4.0.2",
     "@dotcom-tool-kit/plugin": "^1.0.0",
+    "@dotcom-tool-kit/state": "^4.0.0",
     "@dotcom-tool-kit/validated": "^1.0.0",
     "@dotcom-tool-kit/wait-for-ok": "^4.0.0",
     "endent": "^2.1.0",

--- a/core/cli/tsconfig.json
+++ b/core/cli/tsconfig.json
@@ -21,6 +21,9 @@
     },
     {
       "path": "../../lib/conflict"
+    },
+    {
+      "path": "../../lib/state"
     }
   ],
   "compilerOptions": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -50,16 +50,17 @@
     },
     "core/cli": {
       "name": "dotcom-tool-kit",
-      "version": "4.0.1",
+      "version": "4.0.2",
       "license": "MIT",
       "dependencies": {
         "@dotcom-tool-kit/base": "^1.0.0",
-        "@dotcom-tool-kit/config": "^1.0.1",
+        "@dotcom-tool-kit/config": "^1.0.2",
         "@dotcom-tool-kit/conflict": "^1.0.0",
         "@dotcom-tool-kit/error": "^4.0.0",
         "@dotcom-tool-kit/logger": "^4.0.0",
-        "@dotcom-tool-kit/options": "^4.0.1",
+        "@dotcom-tool-kit/options": "^4.0.2",
         "@dotcom-tool-kit/plugin": "^1.0.0",
+        "@dotcom-tool-kit/state": "^4.0.0",
         "@dotcom-tool-kit/validated": "^1.0.0",
         "@dotcom-tool-kit/wait-for-ok": "^4.0.0",
         "endent": "^2.1.0",
@@ -140,16 +141,16 @@
     },
     "core/create": {
       "name": "@dotcom-tool-kit/create",
-      "version": "4.0.1",
+      "version": "4.0.2",
       "license": "ISC",
       "dependencies": {
         "@aws-sdk/client-iam": "^3.282.0",
         "@aws-sdk/client-sts": "^3.282.0",
-        "@dotcom-tool-kit/doppler": "^2.0.1",
+        "@dotcom-tool-kit/doppler": "^2.0.2",
         "@dotcom-tool-kit/error": "^4.0.0",
         "@dotcom-tool-kit/logger": "^4.0.0",
         "@dotcom-tool-kit/plugin": "^1.0.0",
-        "@dotcom-tool-kit/schemas": "^1.1.0",
+        "@dotcom-tool-kit/schemas": "^1.1.1",
         "@octokit/rest": "^19.0.5",
         "@quarterto/parse-makefile-rules": "^1.1.0",
         "cli-highlight": "^2.1.11",
@@ -176,7 +177,7 @@
         "@types/node-fetch": "^2.6.2",
         "@types/pacote": "^11.1.3",
         "@types/prompts": "^2.0.14",
-        "dotcom-tool-kit": "^4.0.1",
+        "dotcom-tool-kit": "^4.0.2",
         "type-fest": "^3.13.1"
       },
       "engines": {
@@ -1091,16 +1092,15 @@
     },
     "core/sandbox": {
       "version": "1.0.0",
-      "extraneous": true,
       "license": "ISC",
       "workspaces": [
         "packages/*"
       ],
       "dependencies": {
         "@dotcom-tool-kit/base": "file:../../lib/base",
-        "@dotcom-tool-kit/monorepo": "file:../../plugins/monorepo",
         "@dotcom-tool-kit/node": "file:../../plugins/node",
         "@dotcom-tool-kit/package-json-hook": "file:../../plugins/package-json-hook",
+        "@dotcom-tool-kit/parallel": "file:../../plugins/parallel",
         "dotcom-tool-kit": "file:../cli"
       }
     },
@@ -1192,12 +1192,12 @@
     },
     "lib/config": {
       "name": "@dotcom-tool-kit/config",
-      "version": "1.0.1",
+      "version": "1.0.2",
       "license": "ISC",
       "dependencies": {
         "@dotcom-tool-kit/conflict": "^1.0.0",
         "@dotcom-tool-kit/plugin": "^1.0.0",
-        "@dotcom-tool-kit/schemas": "^1.1.0",
+        "@dotcom-tool-kit/schemas": "^1.1.1",
         "@dotcom-tool-kit/validated": "^1.0.0"
       }
     },
@@ -1211,16 +1211,16 @@
     },
     "lib/doppler": {
       "name": "@dotcom-tool-kit/doppler",
-      "version": "2.0.1",
+      "version": "2.0.2",
       "license": "ISC",
       "dependencies": {
         "@dotcom-tool-kit/error": "^4.0.0",
         "@dotcom-tool-kit/logger": "^4.0.0",
-        "@dotcom-tool-kit/options": "^4.0.1",
+        "@dotcom-tool-kit/options": "^4.0.2",
         "tslib": "^2.3.1"
       },
       "devDependencies": {
-        "@dotcom-tool-kit/schemas": "^1.1.0",
+        "@dotcom-tool-kit/schemas": "^1.1.1",
         "spawk": "^1.8.1",
         "winston": "^3.5.1"
       },
@@ -1280,10 +1280,10 @@
     },
     "lib/options": {
       "name": "@dotcom-tool-kit/options",
-      "version": "4.0.1",
+      "version": "4.0.2",
       "license": "ISC",
       "dependencies": {
-        "@dotcom-tool-kit/schemas": "^1.1.0",
+        "@dotcom-tool-kit/schemas": "^1.1.1",
         "tslib": "^2.3.1"
       },
       "engines": {
@@ -1324,7 +1324,7 @@
     },
     "lib/schemas": {
       "name": "@dotcom-tool-kit/schemas",
-      "version": "1.1.0",
+      "version": "1.1.1",
       "license": "ISC",
       "dependencies": {
         "@dotcom-tool-kit/logger": "^4.0.0"
@@ -6540,6 +6540,10 @@
     },
     "node_modules/@dotcom-tool-kit/package-json-hook": {
       "resolved": "plugins/package-json-hook",
+      "link": true
+    },
+    "node_modules/@dotcom-tool-kit/parallel": {
+      "resolved": "plugins/parallel",
       "link": true
     },
     "node_modules/@dotcom-tool-kit/plugin": {
@@ -25752,6 +25756,10 @@
       "version": "2.1.2",
       "license": "MIT"
     },
+    "node_modules/sandbox": {
+      "resolved": "core/sandbox",
+      "link": true
+    },
     "node_modules/sax": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/sax/-/sax-1.2.1.tgz",
@@ -30465,7 +30473,7 @@
     },
     "plugins/babel": {
       "name": "@dotcom-tool-kit/babel",
-      "version": "4.0.1",
+      "version": "4.0.2",
       "license": "MIT",
       "dependencies": {
         "@dotcom-tool-kit/base": "^1.0.0",
@@ -30476,7 +30484,7 @@
       },
       "devDependencies": {
         "@babel/preset-env": "^7.16.11",
-        "@dotcom-tool-kit/schemas": "^1.1.0",
+        "@dotcom-tool-kit/schemas": "^1.1.1",
         "@jest/globals": "^27.4.6",
         "winston": "^3.5.1"
       },
@@ -30512,13 +30520,13 @@
     },
     "plugins/backend-heroku-app": {
       "name": "@dotcom-tool-kit/backend-heroku-app",
-      "version": "4.0.1",
+      "version": "4.0.2",
       "license": "ISC",
       "dependencies": {
-        "@dotcom-tool-kit/circleci-deploy": "^4.0.1",
-        "@dotcom-tool-kit/heroku": "^4.0.1",
-        "@dotcom-tool-kit/node": "^4.0.1",
-        "@dotcom-tool-kit/npm": "^4.0.1"
+        "@dotcom-tool-kit/circleci-deploy": "^4.0.2",
+        "@dotcom-tool-kit/heroku": "^4.0.2",
+        "@dotcom-tool-kit/node": "^4.0.2",
+        "@dotcom-tool-kit/npm": "^4.0.2"
       },
       "engines": {
         "node": "18.x || 20.x",
@@ -30530,13 +30538,13 @@
     },
     "plugins/backend-serverless-app": {
       "name": "@dotcom-tool-kit/backend-serverless-app",
-      "version": "4.0.1",
+      "version": "4.0.2",
       "license": "ISC",
       "dependencies": {
-        "@dotcom-tool-kit/circleci-deploy": "^4.0.1",
-        "@dotcom-tool-kit/node": "^4.0.1",
-        "@dotcom-tool-kit/npm": "^4.0.1",
-        "@dotcom-tool-kit/serverless": "^3.0.1"
+        "@dotcom-tool-kit/circleci-deploy": "^4.0.2",
+        "@dotcom-tool-kit/node": "^4.0.2",
+        "@dotcom-tool-kit/npm": "^4.0.2",
+        "@dotcom-tool-kit/serverless": "^3.0.2"
       },
       "engines": {
         "node": "18.x || 20.x",
@@ -30548,14 +30556,14 @@
     },
     "plugins/circleci": {
       "name": "@dotcom-tool-kit/circleci",
-      "version": "7.0.1",
+      "version": "7.0.2",
       "license": "ISC",
       "dependencies": {
         "@dotcom-tool-kit/base": "^1.0.0",
         "@dotcom-tool-kit/conflict": "^1.0.0",
         "@dotcom-tool-kit/error": "^4.0.0",
         "@dotcom-tool-kit/logger": "^4.0.0",
-        "@dotcom-tool-kit/options": "^4.0.1",
+        "@dotcom-tool-kit/options": "^4.0.2",
         "@dotcom-tool-kit/state": "^4.0.0",
         "jest-diff": "^29.5.0",
         "lodash": "^4.17.21",
@@ -30565,7 +30573,7 @@
       },
       "devDependencies": {
         "@dotcom-tool-kit/plugin": "^1.0.0",
-        "@dotcom-tool-kit/schemas": "^1.1.0",
+        "@dotcom-tool-kit/schemas": "^1.1.1",
         "@jest/globals": "^27.4.6",
         "@types/jest": "^27.4.0",
         "@types/js-yaml": "^4.0.3",
@@ -30584,10 +30592,10 @@
     },
     "plugins/circleci-deploy": {
       "name": "@dotcom-tool-kit/circleci-deploy",
-      "version": "4.0.1",
+      "version": "4.0.2",
       "license": "ISC",
       "dependencies": {
-        "@dotcom-tool-kit/circleci": "^7.0.1",
+        "@dotcom-tool-kit/circleci": "^7.0.2",
         "tslib": "^2.3.1"
       },
       "devDependencies": {
@@ -30626,11 +30634,11 @@
     },
     "plugins/circleci-npm": {
       "name": "@dotcom-tool-kit/circleci-npm",
-      "version": "6.0.1",
+      "version": "6.0.3",
       "license": "ISC",
       "dependencies": {
-        "@dotcom-tool-kit/circleci": "^7.0.1",
-        "@dotcom-tool-kit/npm": "^4.0.1",
+        "@dotcom-tool-kit/circleci": "^7.0.2",
+        "@dotcom-tool-kit/npm": "^4.0.2",
         "tslib": "^2.3.1"
       },
       "engines": {
@@ -31461,11 +31469,11 @@
     },
     "plugins/component": {
       "name": "@dotcom-tool-kit/component",
-      "version": "5.0.1",
+      "version": "5.0.3",
       "license": "ISC",
       "dependencies": {
-        "@dotcom-tool-kit/circleci-npm": "^6.0.1",
-        "@dotcom-tool-kit/npm": "^4.0.1"
+        "@dotcom-tool-kit/circleci-npm": "^6.0.3",
+        "@dotcom-tool-kit/npm": "^4.0.2"
       },
       "engines": {
         "node": "18.x || 20.x",
@@ -31477,17 +31485,17 @@
     },
     "plugins/cypress": {
       "name": "@dotcom-tool-kit/cypress",
-      "version": "5.0.1",
+      "version": "5.0.2",
       "license": "ISC",
       "dependencies": {
         "@dotcom-tool-kit/base": "^1.0.0",
-        "@dotcom-tool-kit/doppler": "^2.0.1",
+        "@dotcom-tool-kit/doppler": "^2.0.2",
         "@dotcom-tool-kit/logger": "^4.0.0",
-        "@dotcom-tool-kit/package-json-hook": "^5.0.1",
+        "@dotcom-tool-kit/package-json-hook": "^5.0.2",
         "@dotcom-tool-kit/state": "^4.0.0"
       },
       "devDependencies": {
-        "@dotcom-tool-kit/schemas": "^1.1.0"
+        "@dotcom-tool-kit/schemas": "^1.1.1"
       },
       "engines": {
         "node": "18.x || 20.x",
@@ -31499,7 +31507,7 @@
     },
     "plugins/eslint": {
       "name": "@dotcom-tool-kit/eslint",
-      "version": "4.0.1",
+      "version": "4.0.2",
       "license": "ISC",
       "dependencies": {
         "@dotcom-tool-kit/base": "^1.0.0",
@@ -31508,7 +31516,7 @@
         "tslib": "^2.3.1"
       },
       "devDependencies": {
-        "@dotcom-tool-kit/schemas": "^1.1.0",
+        "@dotcom-tool-kit/schemas": "^1.1.1",
         "@jest/globals": "^27.4.6",
         "@types/eslint": "^7.2.13",
         "@types/temp": "^0.9.4",
@@ -31724,12 +31732,12 @@
     },
     "plugins/frontend-app": {
       "name": "@dotcom-tool-kit/frontend-app",
-      "version": "4.0.1",
+      "version": "4.0.2",
       "license": "ISC",
       "dependencies": {
-        "@dotcom-tool-kit/backend-heroku-app": "^4.0.1",
-        "@dotcom-tool-kit/upload-assets-to-s3": "^4.0.1",
-        "@dotcom-tool-kit/webpack": "^4.0.1"
+        "@dotcom-tool-kit/backend-heroku-app": "^4.0.2",
+        "@dotcom-tool-kit/upload-assets-to-s3": "^4.0.2",
+        "@dotcom-tool-kit/webpack": "^4.0.2"
       },
       "engines": {
         "node": "18.x || 20.x",
@@ -31741,16 +31749,16 @@
     },
     "plugins/heroku": {
       "name": "@dotcom-tool-kit/heroku",
-      "version": "4.0.1",
+      "version": "4.0.2",
       "license": "ISC",
       "dependencies": {
         "@dotcom-tool-kit/base": "^1.0.0",
-        "@dotcom-tool-kit/doppler": "^2.0.1",
+        "@dotcom-tool-kit/doppler": "^2.0.2",
         "@dotcom-tool-kit/error": "^4.0.0",
         "@dotcom-tool-kit/logger": "^4.0.0",
-        "@dotcom-tool-kit/npm": "^4.0.1",
-        "@dotcom-tool-kit/options": "^4.0.1",
-        "@dotcom-tool-kit/package-json-hook": "^5.0.1",
+        "@dotcom-tool-kit/npm": "^4.0.2",
+        "@dotcom-tool-kit/options": "^4.0.2",
+        "@dotcom-tool-kit/package-json-hook": "^5.0.2",
         "@dotcom-tool-kit/state": "^4.0.0",
         "@dotcom-tool-kit/wait-for-ok": "^4.0.0",
         "@octokit/request": "^5.6.0",
@@ -31761,7 +31769,7 @@
         "tslib": "^2.3.1"
       },
       "devDependencies": {
-        "@dotcom-tool-kit/schemas": "^1.1.0",
+        "@dotcom-tool-kit/schemas": "^1.1.1",
         "@types/financial-times__package-json": "^1.9.0",
         "@types/p-retry": "^3.0.1",
         "winston": "^3.5.1"
@@ -31781,10 +31789,10 @@
     },
     "plugins/husky-npm": {
       "name": "@dotcom-tool-kit/husky-npm",
-      "version": "5.0.1",
+      "version": "5.0.2",
       "license": "ISC",
       "dependencies": {
-        "@dotcom-tool-kit/package-json-hook": "^5.0.1",
+        "@dotcom-tool-kit/package-json-hook": "^5.0.2",
         "tslib": "^2.3.1"
       },
       "engines": {
@@ -31803,7 +31811,7 @@
     },
     "plugins/jest": {
       "name": "@dotcom-tool-kit/jest",
-      "version": "4.0.1",
+      "version": "4.0.2",
       "license": "ISC",
       "dependencies": {
         "@dotcom-tool-kit/base": "^1.0.0",
@@ -31811,7 +31819,7 @@
         "tslib": "^2.3.1"
       },
       "devDependencies": {
-        "@dotcom-tool-kit/schemas": "^1.1.0",
+        "@dotcom-tool-kit/schemas": "^1.1.1",
         "winston": "^3.5.1"
       },
       "engines": {
@@ -31830,12 +31838,12 @@
     },
     "plugins/lint-staged": {
       "name": "@dotcom-tool-kit/lint-staged",
-      "version": "5.0.1",
+      "version": "5.0.2",
       "license": "ISC",
       "dependencies": {
         "@dotcom-tool-kit/base": "^1.0.0",
         "@dotcom-tool-kit/logger": "^4.0.0",
-        "@dotcom-tool-kit/package-json-hook": "^5.0.1",
+        "@dotcom-tool-kit/package-json-hook": "^5.0.2",
         "lint-staged": "^11.2.3",
         "tslib": "^2.3.1"
       },
@@ -31849,13 +31857,13 @@
     },
     "plugins/lint-staged-npm": {
       "name": "@dotcom-tool-kit/lint-staged-npm",
-      "version": "4.0.1",
+      "version": "4.0.2",
       "license": "ISC",
       "dependencies": {
-        "@dotcom-tool-kit/husky-npm": "^5.0.1",
-        "@dotcom-tool-kit/lint-staged": "^5.0.1",
-        "@dotcom-tool-kit/options": "^4.0.1",
-        "@dotcom-tool-kit/package-json-hook": "^5.0.1",
+        "@dotcom-tool-kit/husky-npm": "^5.0.2",
+        "@dotcom-tool-kit/lint-staged": "^5.0.2",
+        "@dotcom-tool-kit/options": "^4.0.2",
+        "@dotcom-tool-kit/package-json-hook": "^5.0.2",
         "tslib": "^2.3.1"
       },
       "engines": {
@@ -31928,7 +31936,7 @@
     },
     "plugins/mocha": {
       "name": "@dotcom-tool-kit/mocha",
-      "version": "4.0.1",
+      "version": "4.0.2",
       "license": "ISC",
       "dependencies": {
         "@dotcom-tool-kit/base": "^1.0.0",
@@ -31938,7 +31946,7 @@
         "tslib": "^2.3.1"
       },
       "devDependencies": {
-        "@dotcom-tool-kit/schemas": "^1.1.0",
+        "@dotcom-tool-kit/schemas": "^1.1.1",
         "@jest/globals": "^27.4.6",
         "@types/glob": "^7.1.3",
         "@types/mocha": "^8.2.2",
@@ -31963,7 +31971,7 @@
     },
     "plugins/n-test": {
       "name": "@dotcom-tool-kit/n-test",
-      "version": "4.0.1",
+      "version": "4.0.2",
       "license": "ISC",
       "dependencies": {
         "@dotcom-tool-kit/base": "^1.0.0",
@@ -31973,7 +31981,7 @@
         "tslib": "^2.3.1"
       },
       "devDependencies": {
-        "@dotcom-tool-kit/schemas": "^1.1.0",
+        "@dotcom-tool-kit/schemas": "^1.1.1",
         "@jest/globals": "^27.4.6",
         "@types/jest": "^27.4.0",
         "winston": "^3.5.1"
@@ -32085,11 +32093,11 @@
     },
     "plugins/next-router": {
       "name": "@dotcom-tool-kit/next-router",
-      "version": "4.0.1",
+      "version": "4.0.2",
       "license": "ISC",
       "dependencies": {
         "@dotcom-tool-kit/base": "^1.0.0",
-        "@dotcom-tool-kit/doppler": "^2.0.1",
+        "@dotcom-tool-kit/doppler": "^2.0.2",
         "@dotcom-tool-kit/error": "^4.0.0",
         "@dotcom-tool-kit/logger": "^4.0.0",
         "@dotcom-tool-kit/state": "^4.0.0",
@@ -32097,7 +32105,7 @@
         "tslib": "^2.3.1"
       },
       "devDependencies": {
-        "@dotcom-tool-kit/schemas": "^1.1.0"
+        "@dotcom-tool-kit/schemas": "^1.1.1"
       },
       "engines": {
         "node": "18.x || 20.x",
@@ -32219,11 +32227,11 @@
     },
     "plugins/node": {
       "name": "@dotcom-tool-kit/node",
-      "version": "4.0.1",
+      "version": "4.0.2",
       "license": "ISC",
       "dependencies": {
         "@dotcom-tool-kit/base": "^1.0.0",
-        "@dotcom-tool-kit/doppler": "^2.0.1",
+        "@dotcom-tool-kit/doppler": "^2.0.2",
         "@dotcom-tool-kit/error": "^4.0.0",
         "@dotcom-tool-kit/state": "^4.0.0",
         "get-port": "^5.1.1",
@@ -32231,7 +32239,7 @@
         "wait-port": "^0.2.9"
       },
       "devDependencies": {
-        "@dotcom-tool-kit/schemas": "^1.1.0"
+        "@dotcom-tool-kit/schemas": "^1.1.1"
       },
       "engines": {
         "node": "18.x || 20.x",
@@ -32248,18 +32256,18 @@
     },
     "plugins/nodemon": {
       "name": "@dotcom-tool-kit/nodemon",
-      "version": "4.0.1",
+      "version": "4.0.2",
       "license": "ISC",
       "dependencies": {
         "@dotcom-tool-kit/base": "^1.0.0",
-        "@dotcom-tool-kit/doppler": "^2.0.1",
+        "@dotcom-tool-kit/doppler": "^2.0.2",
         "@dotcom-tool-kit/error": "^4.0.0",
         "@dotcom-tool-kit/state": "^4.0.0",
         "get-port": "^5.1.1",
         "tslib": "^2.3.1"
       },
       "devDependencies": {
-        "@dotcom-tool-kit/schemas": "^1.1.0",
+        "@dotcom-tool-kit/schemas": "^1.1.1",
         "@types/nodemon": "^1.19.1"
       },
       "engines": {
@@ -32278,13 +32286,13 @@
     },
     "plugins/npm": {
       "name": "@dotcom-tool-kit/npm",
-      "version": "4.0.1",
+      "version": "4.0.2",
       "license": "ISC",
       "dependencies": {
         "@actions/exec": "^1.1.0",
         "@dotcom-tool-kit/base": "^1.0.0",
         "@dotcom-tool-kit/error": "^4.0.0",
-        "@dotcom-tool-kit/package-json-hook": "^5.0.1",
+        "@dotcom-tool-kit/package-json-hook": "^5.0.2",
         "@dotcom-tool-kit/state": "^4.0.0",
         "libnpmpack": "^3.1.0",
         "libnpmpublish": "^5.0.1",
@@ -32516,7 +32524,7 @@
     },
     "plugins/package-json-hook": {
       "name": "@dotcom-tool-kit/package-json-hook",
-      "version": "5.0.1",
+      "version": "5.0.2",
       "license": "ISC",
       "dependencies": {
         "@dotcom-tool-kit/base": "^1.0.0",
@@ -32527,7 +32535,7 @@
         "tslib": "^2.3.1"
       },
       "devDependencies": {
-        "@dotcom-tool-kit/schemas": "^1.1.0",
+        "@dotcom-tool-kit/schemas": "^1.1.1",
         "@jest/globals": "^27.4.6",
         "@types/lodash": "^4.14.185",
         "winston": "^3.5.1",
@@ -32546,15 +32554,16 @@
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
       "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
     },
+    "plugins/parallel": {},
     "plugins/prettier": {
       "name": "@dotcom-tool-kit/prettier",
-      "version": "4.0.1",
+      "version": "4.0.2",
       "license": "ISC",
       "dependencies": {
         "@dotcom-tool-kit/base": "^1.0.0",
         "@dotcom-tool-kit/error": "^4.0.0",
         "@dotcom-tool-kit/logger": "^4.0.0",
-        "@dotcom-tool-kit/package-json-hook": "^5.0.1",
+        "@dotcom-tool-kit/package-json-hook": "^5.0.2",
         "fast-glob": "^3.2.7",
         "hook-std": "^2.0.0",
         "prettier": "^2.2.1",
@@ -32604,20 +32613,20 @@
     },
     "plugins/serverless": {
       "name": "@dotcom-tool-kit/serverless",
-      "version": "3.0.1",
+      "version": "3.0.2",
       "license": "ISC",
       "dependencies": {
         "@dotcom-tool-kit/base": "^1.0.0",
-        "@dotcom-tool-kit/doppler": "^2.0.1",
+        "@dotcom-tool-kit/doppler": "^2.0.2",
         "@dotcom-tool-kit/error": "^4.0.0",
-        "@dotcom-tool-kit/options": "^4.0.1",
+        "@dotcom-tool-kit/options": "^4.0.2",
         "@dotcom-tool-kit/state": "^4.0.0",
         "get-port": "^5.1.1",
         "tslib": "^2.3.1",
         "wait-port": "^0.2.9"
       },
       "devDependencies": {
-        "@dotcom-tool-kit/schemas": "^1.1.0"
+        "@dotcom-tool-kit/schemas": "^1.1.1"
       },
       "engines": {
         "node": "18.x || 20.x",
@@ -32635,14 +32644,14 @@
     },
     "plugins/typescript": {
       "name": "@dotcom-tool-kit/typescript",
-      "version": "3.0.1",
+      "version": "3.0.2",
       "license": "ISC",
       "dependencies": {
         "@dotcom-tool-kit/base": "^1.0.0",
         "@dotcom-tool-kit/logger": "^4.0.0"
       },
       "devDependencies": {
-        "@dotcom-tool-kit/schemas": "^1.1.0",
+        "@dotcom-tool-kit/schemas": "^1.1.1",
         "@jest/globals": "^29.3.1",
         "typescript": "^4.9.4",
         "winston": "^3.8.2"
@@ -32857,7 +32866,7 @@
     },
     "plugins/upload-assets-to-s3": {
       "name": "@dotcom-tool-kit/upload-assets-to-s3",
-      "version": "4.0.1",
+      "version": "4.0.2",
       "license": "ISC",
       "dependencies": {
         "@aws-sdk/client-s3": "^3.256.0",
@@ -32870,7 +32879,7 @@
       },
       "devDependencies": {
         "@aws-sdk/types": "^3.13.1",
-        "@dotcom-tool-kit/schemas": "^1.1.0",
+        "@dotcom-tool-kit/schemas": "^1.1.1",
         "@jest/globals": "^27.4.6",
         "@types/glob": "^7.1.3",
         "@types/jest": "^27.4.0",
@@ -32892,7 +32901,7 @@
     },
     "plugins/webpack": {
       "name": "@dotcom-tool-kit/webpack",
-      "version": "4.0.1",
+      "version": "4.0.2",
       "license": "MIT",
       "dependencies": {
         "@dotcom-tool-kit/base": "^1.0.0",
@@ -32902,7 +32911,7 @@
         "webpack-cli": "^4.6.0"
       },
       "devDependencies": {
-        "@dotcom-tool-kit/schemas": "^1.1.0",
+        "@dotcom-tool-kit/schemas": "^1.1.1",
         "@jest/globals": "^27.4.6",
         "ts-node": "^10.0.0",
         "webpack": "^4.42.1",


### PR DESCRIPTION
noticed by @rowanmanning. in practice, most repos install a plugin that depends on `state`, which is why we haven't noticed this until now.

we should probably set up `eslint-plugin-import` to catch this!