### PR TITLE
CPP-2067 Gracefully handle hook installation errors

### DIFF
--- a/core/cli/src/install.ts
+++ b/core/cli/src/install.ts
@@ -86,11 +86,9 @@ export const loadHookInstallations = async (
   })
 
   return installationsWithoutConflicts.map((installations) => {
-    return installations.map(({ hookConstructor, forHook, options }) => {
-      const schema = HookSchemas[forHook as keyof HookOptions]
-      const parsedOptions = schema ? schema.parse(options) : {}
-      return new hookConstructor(logger, forHook, parsedOptions)
-    })
+    return installations.map(
+      ({ hookConstructor, forHook, options }) => new hookConstructor(logger, forHook, options)
+    )
   })
 }
 

--- a/core/cli/src/install.ts
+++ b/core/cli/src/install.ts
@@ -55,11 +55,13 @@ export const loadHookInstallations = async (
   config: ValidConfig
 ): Promise<Validated<Hook<z.ZodType, unknown>[]>> => {
   const hookClassResults = await loadHookEntrypoints(logger, config)
-  const installationResults = await hookClassResults
-    .map((hookClasses) =>
-      reducePluginHookInstallations(logger, config, hookClasses, config.plugins['app root'])
-    )
-    .awaitValue()
+  const installationResults = (
+    await hookClassResults
+      .map((hookClasses) =>
+        reducePluginHookInstallations(logger, config, hookClasses, config.plugins['app root'])
+      )
+      .awaitValue()
+  ).flatMap((installation) => installation)
 
   const installationsWithoutConflicts = installationResults.flatMap((installations) => {
     const conflicts = findConflicts(installations)

--- a/core/cli/src/messages.ts
+++ b/core/cli/src/messages.ts
@@ -145,6 +145,24 @@ ${
 }.
 `
 
+export const formatUnusedHookOptions = (
+  unusedOptions: string[],
+  definedHooks: string[]
+): string => `Options are defined in your Tool Kit configuration for hooks that don't exist:
+
+${unusedOptions.map((optionName) => `- ${s.hook(optionName)}`).join('\n')}
+
+They could be misspelt, or defined by a Tool Kit plugin that isn't installed in this app.
+
+${
+  definedHooks.length > 0
+    ? `Hooks that are defined and can have options set are: ${definedHooks
+        .map((hook) => s.hook(hook))
+        .join(', ')}`
+    : `You don't have currently any plugins installed that provide hooks. You'll need to install some plugins before options can be set.`
+}.
+`
+
 export const formatUninstalledHooks = (
   uninstalledHooks: Hook<z.ZodTypeAny, unknown>[]
 ): string => `These hooks aren't installed into your app:

--- a/core/cli/test/index.test.ts
+++ b/core/cli/test/index.test.ts
@@ -16,9 +16,7 @@ const logger = winston as unknown as Logger
 jest.setTimeout(20000)
 
 describe('cli', () => {
-  // TODO:KB:202301121 we only return conflicts for hooks that are defined.
-  // currently there are no hooks lol
-  it.skip('should indicate when there are conflicts', async () => {
+  it('should indicate when there are conflicts', async () => {
     const config = createConfig()
 
     const plugin = await loadPlugin('app root', config, logger, {
@@ -34,7 +32,7 @@ describe('cli', () => {
     resolvePluginOptions((plugin as Valid<Plugin>).value, validPluginConfig)
     resolvePlugin((plugin as Valid<Plugin>).value, validPluginConfig, logger)
 
-    expect(() => validateConfig(validPluginConfig, logger)).toThrow(ToolKitError)
+    expect(() => validateConfig(validPluginConfig)).toThrow(ToolKitError)
     expect(validPluginConfig).toHaveProperty('commandTasks.build:ci.conflicting')
     expect(validPluginConfig).toHaveProperty('commandTasks.build:remote.conflicting')
     expect(validPluginConfig).toHaveProperty('commandTasks.build:local.conflicting')
@@ -56,7 +54,7 @@ describe('cli', () => {
     resolvePluginOptions((plugin as Valid<Plugin>).value, validPluginConfig)
     resolvePlugin((plugin as Valid<Plugin>).value, validPluginConfig, logger)
 
-    expect(() => validateConfig(validPluginConfig, logger)).toThrow(ToolKitError)
+    expect(() => validateConfig(validPluginConfig)).toThrow(ToolKitError)
     expect(config).toHaveProperty('commandTasks.build:ci.conflicting')
     expect(config).toHaveProperty('commandTasks.build:remote.conflicting')
     expect(config).toHaveProperty('commandTasks.build:local.conflicting')
@@ -79,7 +77,7 @@ describe('cli', () => {
     resolvePlugin((plugin as Valid<Plugin>).value, validPluginConfig, logger)
 
     try {
-      const validConfig = validateConfig(validPluginConfig, logger)
+      const validConfig = validateConfig(validPluginConfig)
       expect(validConfig).not.toHaveProperty('hooks.build:local.conflicting')
     } catch (e) {
       if (e instanceof ToolKitError) {
@@ -107,7 +105,7 @@ describe('cli', () => {
     resolvePlugin((plugin as Valid<Plugin>).value, validPluginConfig, logger)
 
     try {
-      const validConfig = validateConfig(validPluginConfig, logger)
+      const validConfig = validateConfig(validPluginConfig)
 
       expect(validConfig).not.toHaveProperty('commandTasks.build:local.conflicting')
       expect(validConfig.commandTasks['build:local'].tasks.map((task) => task.task)).toEqual([
@@ -138,7 +136,7 @@ describe('cli', () => {
 
     resolvePlugin((plugin as Valid<Plugin>).value, validPluginConfig, logger)
 
-    const validConfig = validateConfig(validPluginConfig, logger)
+    const validConfig = validateConfig(validPluginConfig)
     const hooks = await loadHookInstallations(logger, validConfig)
     expect(hooks.valid).toBe(true)
   })


### PR DESCRIPTION
# Description

We were previously throwing when we encountered an unknown hook option or an invalid hook option. This resulted in a cryptic stacktrace without much for the user to use to fix the issue. Instead, let's wrap the function in a `Validated` and use properly formatted error messages to handle these errors. 

# Checklist:

- [x] My branch has been rebased onto the latest commit on main (don't merge main into your branch)
- [x] My commit messages are [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/), for example: `feat(circleci): add support for nightly workflows`, `fix: set Heroku app name for staging apps too`
