### PR TITLE
Fix spurious conflict errors

### DIFF
--- a/core/cli/src/plugin/reduce-installations.ts
+++ b/core/cli/src/plugin/reduce-installations.ts
@@ -95,7 +95,7 @@ export async function reducePluginHookInstallations(
         }
 
         const installation: HookInstallation = {
-          options: parsedOptions ?? configHookOptions,
+          options: parsedOptions?.data ?? configHookOptions,
           plugin,
           forHook: id,
           hookConstructor: hookClass


### PR DESCRIPTION
# Description

This wasn't caught by TypeScript because `options` effectively has an `any` type. It was causing weird conflict errors because the options were nested one level deeper, messing with the conflict detection logic. This makes me happy because it explains the weird testing behaviour I was trying to fix in c5ea614d4f0b4e074459a1f9cdead82edd63042d :) We still don't need to parse the options twice so that commit doesn't need to be reverted.

# Checklist:

- [x] My branch has been rebased onto the latest commit on main (don't merge main into your branch)
- [x] My commit messages are [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/), for example: `feat(circleci): add support for nightly workflows`, `fix: set Heroku app name for staging apps too`
