### PR TITLE
fix: log an extra newline after error details

### DIFF
--- a/core/cli/bin/run
+++ b/core/cli/bin/run
@@ -46,6 +46,7 @@ async function main() {
       rootLogger.error(error.message)
       rootLogger.error(styles.ruler() + '\n', { skipformat: true })
       rootLogger.error(error.details, { skipformat: true })
+      rootLogger.error('\n', { skipformat: true })
     } else {
       rootLogger.error(error.stack)
     }


### PR DESCRIPTION
winston seems to eat the last log line for some reason?
