### PR TITLE
feat(schemas): add validation warnings for plugin options that moved to task options

### DIFF
--- a/lib/schemas/src/moved-plugin-options.ts
+++ b/lib/schemas/src/moved-plugin-options.ts
@@ -1,0 +1,10 @@
+import { styles } from '@dotcom-tool-kit/logger'
+
+export const movedPluginOptions = <T extends Record<string, unknown>>(option: string, task: string, newName = option) => [
+	(options: T) => !(option in options),
+	{
+	  message: `the option ${styles.code(option)} has moved to ${styles.code(
+					  `options.tasks.${styles.task(task)}.${newName}`
+					)}`
+	}
+ ] as const

--- a/lib/schemas/src/plugins/heroku.ts
+++ b/lib/schemas/src/plugins/heroku.ts
@@ -1,3 +1,4 @@
+import { movedPluginOptions } from '../moved-plugin-options'
 import { PromptGenerators } from '../prompts'
 import { z } from 'zod'
 
@@ -8,6 +9,8 @@ export const HerokuSchema = z.object({
       "the ID of your app's Heroku pipeline. this can be found at https://dashboard.heroku.com/pipelines/[PIPELINE_ID]"
     )
 })
+.passthrough()
+.refine(...movedPluginOptions('scaling', 'HerokuProduction'))
 
 export type HerokuOptions = z.infer<typeof HerokuSchema>
 

--- a/lib/schemas/src/plugins/serverless.ts
+++ b/lib/schemas/src/plugins/serverless.ts
@@ -1,3 +1,4 @@
+import { movedPluginOptions } from '../moved-plugin-options'
 import { PromptGenerators } from '../prompts'
 import { z } from 'zod'
 
@@ -19,6 +20,9 @@ export const ServerlessSchema = z.object({
       'path to your serverless config file. If this is not provided, Serverless defaults to `./serverless.yml` but [other config fomats are accepted](https://www.serverless.com/framework/docs/providers/aws/guide/intro#alternative-configuration-format)'
     )
 })
+.passthrough()
+.refine(...movedPluginOptions('useVault', 'ServerlessRun', 'useDoppler'))
+.refine(...movedPluginOptions('ports', 'ServerlessRun'))
 
 export type ServerlessOptions = z.infer<typeof ServerlessSchema>
 


### PR DESCRIPTION
when migrating from v3, Tool Kit will happily accept these options, even though they're not present in the plugin schema (because it's not strict). this provides helpful error messages to instruct the user that these options need to be moved (which will make the migration guide easier to follow).