### PR TITLE
preserve relative paths in resolveRoot to fix custom plugin loading

### DIFF
--- a/core/cli/src/plugin/require-resolve.ts
+++ b/core/cli/src/plugin/require-resolve.ts
@@ -1,0 +1,1 @@
+export const resolve = require.resolve

--- a/core/cli/src/plugin/resolve-root.ts
+++ b/core/cli/src/plugin/resolve-root.ts
@@ -1,5 +1,7 @@
 import path from "path"
 import { resolve } from "./require-resolve"
+import { ToolKitError } from "@dotcom-tool-kit/error"
+import { styles } from "@dotcom-tool-kit/logger"
 
 export function resolveRoot(id: string, root: string): string {
   const isRelative = id.startsWith('./')
@@ -7,7 +9,18 @@ export function resolveRoot(id: string, root: string): string {
   // entrypoints now that we're intending their tasks/hooks to be loaded via
   // entrypoints defined in config
   const pluginPath = path.join(id, '.toolkitrc.yml')
-  const resolvedPath = resolve(isRelative ? './' + pluginPath :  pluginPath, { paths: [root] })
 
-  return path.dirname(resolvedPath)
+  try {
+    const resolvedPath = resolve(isRelative ? './' + pluginPath :  pluginPath, { paths: [root] })
+
+    return path.dirname(resolvedPath)
+  } catch(error) {
+    if(error instanceof Error && 'code' in error && error.code === 'MODULE_NOT_FOUND') {
+      const error = new ToolKitError(`Couldn't resolve plugin ${styles.plugin(id)} from directory ${styles.filepath(root)}`)
+      error.details = `If this is a built-in Tool Kit plugin, check it's installed as a dependency. If it's a custom plugin, check it has a ${styles.filepath('.toolkitrc.yml')}, and that the path is the correct relative path to the plugin from the ${styles.filepath('.toolkitrc.yml')} it's being included from.`
+      throw error
+    }
+
+    throw error
+  }
 }

--- a/core/cli/src/plugin/resolve-root.ts
+++ b/core/cli/src/plugin/resolve-root.ts
@@ -2,11 +2,12 @@ import path from "path"
 import { resolve } from "./require-resolve"
 
 export function resolveRoot(id: string, root: string): string {
+  const isRelative = id.startsWith('./')
   // resolve the .toolkitrc.yml of a plugin as many plugins don't have valid
   // entrypoints now that we're intending their tasks/hooks to be loaded via
   // entrypoints defined in config
   const pluginPath = path.join(id, '.toolkitrc.yml')
-  const resolvedPath = resolve(pluginPath, { paths: [root] })
+  const resolvedPath = resolve(isRelative ? './' + pluginPath :  pluginPath, { paths: [root] })
 
   return path.dirname(resolvedPath)
 }

--- a/core/cli/src/plugin/resolve-root.ts
+++ b/core/cli/src/plugin/resolve-root.ts
@@ -1,10 +1,12 @@
 import path from "path"
+import { resolve } from "./require-resolve"
 
 export function resolveRoot(id: string, root: string): string {
   // resolve the .toolkitrc.yml of a plugin as many plugins don't have valid
   // entrypoints now that we're intending their tasks/hooks to be loaded via
   // entrypoints defined in config
   const pluginPath = path.join(id, '.toolkitrc.yml')
-  const resolvedPath = require.resolve(pluginPath, { paths: [root] })
+  const resolvedPath = resolve(pluginPath, { paths: [root] })
+
   return path.dirname(resolvedPath)
 }

--- a/core/cli/test/resolve-root.test.ts
+++ b/core/cli/test/resolve-root.test.ts
@@ -1,6 +1,35 @@
 import path from 'path'
 import { resolveRoot } from '../src/plugin/resolve-root'
 
+// HACK:KB:20241126 Jest's require.resolve implementation works differently from Node's
+// when provided the `paths` option, in a way that let our tests pass but didn't work in
+// Node. there's no way to use Node's actual implementation of require.resolve in Jest,
+// so we need to call Node as a subprocess and have it run require.resolve for us.
+// https://github.com/jestjs/jest/issues/9502
+jest.mock('../src/plugin/require-resolve', () => {
+  const { spawnSync } = jest.requireActual('child_process')
+
+  return {
+    resolve: (id: string, options?: { paths?: string[] }) => {
+      const result = spawnSync(
+        'node',
+        ['-e', `process.stdout.write(require.resolve(${JSON.stringify(id)}${options ? ', ' + JSON.stringify(options) : ''}))`],
+        {cwd: __dirname}
+      )
+
+      if(result.error) {
+        throw result.error
+      }
+
+      if(result.status) {
+        throw new Error(result.stderr.toString())
+      }
+
+      return result.stdout.toString('utf8')
+    }
+  }
+})
+
 describe('plugin loading', () => {
   describe('resolveRoot', () => {
     it('should resolve a plugin specified as a node_module', () => {

--- a/core/cli/test/resolve-root.test.ts
+++ b/core/cli/test/resolve-root.test.ts
@@ -71,24 +71,43 @@ describe('plugin loading', () => {
     it(`should fail to resolve a node_module plugin that doesn't exist`, () => {
       expect(() => {
         resolveRoot('@dotcom-tool-kit/this-plugin-does-not-exist', '.')
-      }).toThrowErrorMatchingInlineSnapshot(
-        `"Couldn't resolve plugin [36m@dotcom-tool-kit/this-plugin-does-not-exist[39m from directory [3m.[23m"`
+      }).toThrow(
+        expect.objectContaining({
+          message: expect.stringMatching(
+            /Couldn't resolve plugin.+@dotcom-tool-kit\/this-plugin-does-not-exist/
+          ),
+          details: expect.stringMatching(
+            /If this is a built-in Tool Kit plugin, check it's installed as a dependency./
+          )
+        })
       )
     })
 
     it(`should fail to resolve a relative path that doesn't exist`, () => {
       expect(() => {
         resolveRoot('./files/this-file-does-not-exist', '.')
-      }).toThrowErrorMatchingInlineSnapshot(
-        `"Couldn't resolve plugin [36m./files/this-file-does-not-exist[39m from directory [3m.[23m"`
+      }).toThrow(
+        expect.objectContaining({
+          message: expect.stringMatching(/Couldn't resolve plugin.+.\/files\/this-file-does-not-exist/),
+          details: expect.stringMatching(
+            /If this is a built-in Tool Kit plugin, check it's installed as a dependency./
+          )
+        })
       )
     })
 
     it(`should fail to resolve a parent relative path that doesn't exist`, () => {
       expect(() => {
         resolveRoot('../test/files/this-file-does-not-exist', '.')
-      }).toThrowErrorMatchingInlineSnapshot(
-        `"Couldn't resolve plugin [36m../test/files/this-file-does-not-exist[39m from directory [3m.[23m"`
+      }).toThrow(
+        expect.objectContaining({
+          message: expect.stringMatching(
+            /Couldn't resolve plugin.+..\/test\/files\/this-file-does-not-exist/
+          ),
+          details: expect.stringMatching(
+            /If this is a built-in Tool Kit plugin, check it's installed as a dependency./
+          )
+        })
       )
     })
   })

--- a/core/cli/test/resolve-root.test.ts
+++ b/core/cli/test/resolve-root.test.ts
@@ -70,25 +70,25 @@ describe('plugin loading', () => {
 
     it(`should fail to resolve a node_module plugin that doesn't exist`, () => {
       expect(() => {
-        resolveRoot('@dotcom-tool-kit/this-plugin-does-not-exist', process.cwd())
+        resolveRoot('@dotcom-tool-kit/this-plugin-does-not-exist', '.')
       }).toThrowErrorMatchingInlineSnapshot(
-        `"Cannot find module '@dotcom-tool-kit/this-plugin-does-not-exist/.toolkitrc.yml'"`
+        `"Couldn't resolve plugin [36m@dotcom-tool-kit/this-plugin-does-not-exist[39m from directory [3m.[23m"`
       )
     })
 
     it(`should fail to resolve a relative path that doesn't exist`, () => {
       expect(() => {
-        resolveRoot('./files/this-file-does-not-exist', __dirname)
+        resolveRoot('./files/this-file-does-not-exist', '.')
       }).toThrowErrorMatchingInlineSnapshot(
-        `"Cannot find module './files/this-file-does-not-exist/.toolkitrc.yml'"`
+        `"Couldn't resolve plugin [36m./files/this-file-does-not-exist[39m from directory [3m.[23m"`
       )
     })
 
     it(`should fail to resolve a parent relative path that doesn't exist`, () => {
       expect(() => {
-        resolveRoot('../test/files/this-file-does-not-exist', __dirname)
+        resolveRoot('../test/files/this-file-does-not-exist', '.')
       }).toThrowErrorMatchingInlineSnapshot(
-        `"Cannot find module '../test/files/this-file-does-not-exist/.toolkitrc.yml'"`
+        `"Couldn't resolve plugin [36m../test/files/this-file-does-not-exist[39m from directory [3m.[23m"`
       )
     })
   })


### PR DESCRIPTION
and do some cursed things to work around Jest's different behaviour for `require.resolve` in the tests