### PR TITLE
backstage: fully remove ansi-colors

### DIFF
--- a/lib/logger/package.json
+++ b/lib/logger/package.json
@@ -25,7 +25,6 @@
   "dependencies": {
     "@apaleslimghost/boxen": "^5.1.3",
     "@dotcom-tool-kit/error": "^4.0.0",
-    "ansi-colors": "^4.1.1",
     "ansi-regex": "^5.0.1",
     "triple-beam": "^1.3.0",
     "tslib": "^2.3.1",

--- a/lib/logger/src/styles.ts
+++ b/lib/logger/src/styles.ts
@@ -3,7 +3,7 @@ import stripAnsi from 'strip-ansi'
 import boxen from '@apaleslimghost/boxen'
 
 // consistent styling use cases for terminal colours
-// don't use ansi-colors directly, define a style please
+// don't use chalk directly, define a style please
 export const styles = {
   hook: colours.yellow,
   command: colours.magenta,

--- a/package-lock.json
+++ b/package-lock.json
@@ -1265,7 +1265,6 @@
       "dependencies": {
         "@apaleslimghost/boxen": "^5.1.3",
         "@dotcom-tool-kit/error": "^4.0.0",
-        "ansi-colors": "^4.1.1",
         "ansi-regex": "^5.0.1",
         "triple-beam": "^1.3.0",
         "tslib": "^2.3.1",


### PR DESCRIPTION
we switched from `ansi-colors` to `chalk` in #627 (idk why!) but didn't remove it as a dependency