### PR TITLE
backstage: ensure the cloudsmith plugin publishes

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -30,6 +30,7 @@
     "plugins/circleci": {},
     "plugins/circleci-deploy": {},
     "plugins/circleci-npm": {},
+    "plugins/cloudsmith": {},
     "plugins/commitlint": {},
     "plugins/component": {},
     "plugins/cypress": {},


### PR DESCRIPTION
# Description

We forgot to add the new plugin to the Release Please config so it didn't get published.

# Checklist:

- [x] My branch has been rebased onto the latest commit on main (don't merge main into your branch)
- [x] My commit messages are [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/), for example: `feat(circleci): add support for nightly workflows`, `fix: set Heroku app name for staging apps too`
