### PR TITLE
Make sure to load plugins with CJS require instead of ESM import

### DIFF
--- a/core/cli/src/plugin/entry-point.ts
+++ b/core/cli/src/plugin/entry-point.ts
@@ -26,7 +26,7 @@ export async function importEntryPoint<T extends { name: string } & Omit<typeof 
 
   let pluginModule: unknown
   try {
-    pluginModule = await import(resolvedPath)
+    pluginModule = require(resolvedPath)
   } catch (e) {
     const err = e as Error
     return invalid([


### PR DESCRIPTION
# Description

We [recently bumped](https://github.com/Financial-Times/dotcom-tool-kit/pull/733) our tsconfig base to a newer version that switched the [`module`](https://www.typescriptlang.org/tsconfig/#module) setting from `commonjs` to `node16`. In most cases this had no effect on the generated code, as CommonJS code would still be emitted for files that aren't specified to be ESM modules. However, the setting also changes dynamic imports within CJS code to be preserved when emitted instead of being transpiled to a (wrapped) call to `require`.

Let's explicitly use `require` instead of a dynamic import when loading entrypoints to avoid CJS/ESM incompatibilities. I believe we had [previously](https://github.com/Financial-Times/dotcom-tool-kit/pull/241) opted for a dynamic import in order to get plugins loaded asynchronously, however this was a misunderstanding as the synchronous require call was still being emitted. I've kept the function as async still as I expect we'll want to restore the dynamic import at some point in the future when we support ESM.

Tested with next-preflight (which I'm currently in the process of upgrading to the latest Tool Kit.)

# Checklist:

- [x] My branch has been rebased onto the latest commit on main (don't merge main into your branch)
- [x] My commit messages are [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/), for example: `feat(circleci): add support for nightly workflows`, `fix: set Heroku app name for staging apps too`
