### PR TITLE
fix: add the requires property to CI jobs

### DIFF
--- a/plugins/cloudsmith/.toolkitrc.yml
+++ b/plugins/cloudsmith/.toolkitrc.yml
@@ -10,16 +10,19 @@ options:
           - name: 'tool-kit'
             jobs:
               - name: 'deploy-review'
+                requires: []
                 custom:
                   cloudsmith-org: financial-times
                   !toolkit/if-defined '@dotcom-tool-kit/cloudsmith.serviceAccount':
                     cloudsmith-service-account: !toolkit/option '@dotcom-tool-kit/cloudsmith.serviceAccount'
               - name: 'deploy-staging'
+                requires: []
                 custom:
                   cloudsmith-org: financial-times
                   !toolkit/if-defined '@dotcom-tool-kit/cloudsmith.serviceAccount':
                     cloudsmith-service-account: !toolkit/option '@dotcom-tool-kit/cloudsmith.serviceAccount'
               - name: 'deploy-production'
+                requires: []
                 custom:
                   cloudsmith-org: financial-times
                   !toolkit/if-defined '@dotcom-tool-kit/cloudsmith.serviceAccount':
@@ -27,6 +30,7 @@ options:
           - name: 'nightly'
             jobs:
               - name: 'deploy-review'
+                requires: []
                 custom:
                   cloudsmith-org: financial-times
                   !toolkit/if-defined '@dotcom-tool-kit/cloudsmith.serviceAccount':


### PR DESCRIPTION
# Description

This option is validated and we're required to set it to an array. Setting it to an empty array doesn't override the existing `requires` - the array gets merged together.

[See schema here](https://github.com/Financial-Times/dotcom-tool-kit/blob/de09e954ea4c73d866d3522ad84c4117c3f51ae8/lib/schemas/src/hooks/circleci.ts#L48). I didn't want to make this optional just in case that breaks something else.

# Checklist:

- [x] My branch has been rebased onto the latest commit on main (don't merge main into your branch)
- [x] My commit messages are [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/), for example: `feat(circleci): add support for nightly workflows`, `fix: set Heroku app name for staging apps too`
