### PR TITLE
Don't prepend Tool Kit orb namespace prefix to approval jobs in a CircleCI workflow

### DIFF
--- a/plugins/circleci/src/circleci-config.ts
+++ b/plugins/circleci/src/circleci-config.ts
@@ -355,27 +355,38 @@ const mergeInstallationResults = (
   return results
 }
 
-const toolKitOrbPrefix = (job: string, generatedJobs: CircleCIStatePartial['jobs']) => {
-  if (job.includes('/') || (generatedJobs && job in generatedJobs)) {
-    return job
-  }
-
-  return `tool-kit/${job}`
-}
-
 const generateWorkflowJobs = (
   workflow: CircleCiWorkflow,
   nodeVersions: string[],
   tagFilterRegex: string,
   generatedJobs: CircleCIStatePartial['jobs']
 ): WorkflowJob[] | undefined => {
+  // HACK:20250106:IM We were previously implicityly prepending a tool-kit/
+  // prefix to workflow job names, as it was assumed that they all were
+  // referencing jobs from the Tool Kit orb. However, many custom plugins
+  // define custom jobs which need to be referenced too. To avoid a breaking
+  // change where we require the tool-kit/ prefix to be explicit, let's try an
+  // infer whether to prepend the prefix or not.
+  const jobsShouldBeBare = (workflow.jobs ?? []).reduce((acc, job) => {
+    const shouldBeBare =
+      // custom jobs won't want the tool-kit/ prefix
+      (generatedJobs && job.name in generatedJobs) ||
+      // approval jobs don't need to be declared as a custom job before using
+      job.custom?.type === 'approval' ||
+      // a slash implies an orb job so we don't want to add another prefix
+      job.name.includes('/')
+    acc.set(job.name, shouldBeBare)
+    return acc
+  }, new Map<string, boolean>())
+  const toolKitOrbPrefix = (job: string) => (jobsShouldBeBare.get(job) ? job : `tool-kit/${job}`)
+
   const runsOnMultipleNodeVersions = nodeVersions.length > 1
   return workflow.jobs?.map((job) => {
     const splitIntoMatrix = runsOnMultipleNodeVersions && (job.splitIntoMatrix ?? true)
     return {
-      [toolKitOrbPrefix(job.name, generatedJobs)]: merge(
+      [toolKitOrbPrefix(job.name)]: merge(
         splitIntoMatrix
-          ? matrixBoilerplate(toolKitOrbPrefix(job.name, generatedJobs), nodeVersions)
+          ? matrixBoilerplate(toolKitOrbPrefix(job.name), nodeVersions)
           : {
               executor: 'node'
             },
@@ -384,7 +395,9 @@ const generateWorkflowJobs = (
             if (required === 'checkout') {
               return required
             }
-            const requiredOrb = toolKitOrbPrefix(required, generatedJobs)
+            // HACK:20250106:IM allow plugins to require orb jobs using the
+            // tool-kit/ prefix as that's what we want to move towards anyway
+            const requiredOrb = toolKitOrbPrefix(required.replace(/^tool-kit\//, ''))
             // only need to include a suffix for the required job if it splits
             // into a matrix for Node versions
             const splitRequiredIntoMatrix =

--- a/plugins/circleci/test/circleci-config.test.ts
+++ b/plugins/circleci/test/circleci-config.test.ts
@@ -48,7 +48,7 @@ const configWithWorkflowJob: CircleCiOptions = {
 }
 
 const configWithPrefixedWorkflowJob: CircleCiOptions = {
-  workflows: [{ name: 'tool-kit', jobs: [testPrefixedWorkflowJob] }],
+  workflows: [{ name: 'tool-kit', jobs: [{ name: 'another/orb', requires: [] }, testPrefixedWorkflowJob] }],
   disableBaseConfig: true
 }
 
@@ -180,6 +180,12 @@ describe('CircleCI config hook', () => {
           "workflows": {
             "tool-kit": {
               "jobs": [
+                {
+                  "another/orb": {
+                    "executor": "node",
+                    "requires": [],
+                  },
+                },
                 {
                   "slack/approval-notification": {
                     "executor": "node",


### PR DESCRIPTION
# Description

Our previous logic for guessing whether to prepend our Tool Kit orb namespace to a workflow job didn't account for approval jobs, which don't need to be declared in a `jobs` stanza ahead of time.

Also add some comments justifying why we're inferring whether to prepend the Tool Kit namespace as the logic is getting increasingly complicated. 

# Checklist:

- [x] My branch has been rebased onto the latest commit on main (don't merge main into your branch)
- [x] My commit messages are [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/), for example: `feat(circleci): add support for nightly workflows`, `fix: set Heroku app name for staging apps too`
