### PR TITLE
docs: fix name of UploadAssetsToS3

### DIFF
--- a/plugins/upload-assets-to-s3/README.md
+++ b/plugins/upload-assets-to-s3/README.md
@@ -68,4 +68,4 @@ Then running `npm run build` will run the `UploadAssetsToS3` task on your review
 
 | Name | Description | Preconfigured Hook|
 |-|-|-|
-| `UploadAssetsTos3` | Uploads provided files to a given S3 bucket | `release:remote` |
+| `UploadAssetsToS3` | Uploads provided files to a given S3 bucket | `release:remote` |


### PR DESCRIPTION
# Description

Correct name of `UploadAssetsToS3` task (capital `S3`)

# Checklist:

- [x] My branch has been rebased onto the latest commit on main (don't merge main into your branch)
- [x] My commit messages are [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/), for example: `feat(circleci): add support for nightly workflows`, `fix: set Heroku app name for staging apps too`
