### PR TITLE
CPP-2322 fix circleci option defaults

### DIFF
--- a/lib/schemas/src/hooks/circleci.ts
+++ b/lib/schemas/src/hooks/circleci.ts
@@ -20,22 +20,16 @@ export const CircleCiJob = z
     command: z.string(),
     workspace: z
       .object({
-        persist: z.boolean().default(true),
-        attach: z.boolean().default(true)
+        persist: z.boolean().optional(),
+        attach: z.boolean().optional()
       })
-      .default({
-        persist: true,
-        attach: true
-      }),
+      .optional(),
     steps: z
       .object({
-        pre: z.array(CircleCiStep).default([]),
-        post: z.array(CircleCiStep).default([])
+        pre: z.array(CircleCiStep).optional(),
+        post: z.array(CircleCiStep).optional()
       })
-      .default({
-        pre: [],
-        post: []
-      }),
+      .optional(),
     custom: CircleCiCustom.optional()
   })
   .partial()
@@ -47,7 +41,7 @@ export const CircleCiWorkflowJob = z
     name: z.string(),
     requires: z.array(z.string()),
     splitIntoMatrix: z.boolean().optional(),
-    runOnRelease: z.boolean().default(true),
+    runOnRelease: z.boolean().optional(),
     custom: CircleCiCustom.optional()
   })
   .partial()

--- a/plugins/circleci-deploy/test/__snapshots__/circleci-deploy.test.ts.snap
+++ b/plugins/circleci-deploy/test/__snapshots__/circleci-deploy.test.ts.snap
@@ -1,0 +1,109 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`circleci-deploy config integration test should generate a .circleci/config.yml with the base config from circleci-deploy/.toolkitrc.yml 1`] = `
+"version: 2.1
+orbs:
+  tool-kit: financial-times/dotcom-tool-kit@5
+executors:
+  node:
+    docker:
+      - image: cimg/node:18.19-browsers
+jobs:
+  checkout:
+    docker:
+      - image: cimg/base:stable
+    steps:
+      - checkout
+      - persist_to_workspace:
+          root: .
+          paths:
+            - .
+workflows:
+  tool-kit:
+    when:
+      not:
+        equal:
+          - scheduled_pipeline
+          - << pipeline.trigger_source >>
+    jobs:
+      - checkout:
+          filters:
+            tags:
+              only: /^v\\d+\\.\\d+\\.\\d+(-.+)?/
+      - tool-kit/setup:
+          executor: node
+          requires:
+            - checkout
+          filters:
+            tags:
+              only: /^v\\d+\\.\\d+\\.\\d+(-.+)?/
+      - tool-kit/build:
+          executor: node
+          requires:
+            - tool-kit/setup
+      - tool-kit/test:
+          executor: node
+          requires:
+            - tool-kit/build
+      - tool-kit/deploy-review:
+          executor: node
+          requires:
+            - tool-kit/setup
+          filters:
+            branches:
+              ignore: main
+      - tool-kit/deploy-staging:
+          executor: node
+          requires:
+            - tool-kit/setup
+          filters:
+            branches:
+              only: main
+      - tool-kit/e2e-test-review:
+          executor: node
+          requires:
+            - tool-kit/deploy-review
+      - tool-kit/e2e-test-staging:
+          executor: node
+          requires:
+            - tool-kit/deploy-staging
+      - tool-kit/deploy-production:
+          executor: node
+          requires:
+            - tool-kit/test
+            - tool-kit/e2e-test-staging
+          filters:
+            branches:
+              only: main
+  nightly:
+    when:
+      and:
+        - equal:
+            - scheduled_pipeline
+            - << pipeline.trigger_source >>
+        - equal:
+            - nightly
+            - << pipeline.schedule.name >>
+    jobs:
+      - checkout
+      - tool-kit/setup:
+          executor: node
+          requires:
+            - checkout
+      - tool-kit/build:
+          executor: node
+          requires:
+            - tool-kit/setup
+      - tool-kit/test:
+          executor: node
+          requires:
+            - tool-kit/build
+      - tool-kit/deploy-review:
+          executor: node
+          requires:
+            - tool-kit/setup
+          filters:
+            branches:
+              ignore: main
+"
+`;

--- a/plugins/circleci-deploy/test/__snapshots__/circleci-deploy.test.ts.snap
+++ b/plugins/circleci-deploy/test/__snapshots__/circleci-deploy.test.ts.snap
@@ -41,10 +41,16 @@ workflows:
           executor: node
           requires:
             - tool-kit/setup
+          filters:
+            tags:
+              only: /^v\\d+\\.\\d+\\.\\d+(-.+)?/
       - tool-kit/test:
           executor: node
           requires:
             - tool-kit/build
+          filters:
+            tags:
+              only: /^v\\d+\\.\\d+\\.\\d+(-.+)?/
       - tool-kit/deploy-review:
           executor: node
           requires:

--- a/plugins/circleci-deploy/test/circleci-deploy.test.ts
+++ b/plugins/circleci-deploy/test/circleci-deploy.test.ts
@@ -1,0 +1,25 @@
+import * as YAML from 'yaml'
+import path from 'path'
+import CircleCi from '@dotcom-tool-kit/circleci/lib/circleci-config'
+import winston, { Logger } from 'winston'
+import { loadConfig } from 'dotcom-tool-kit/lib/config'
+import { loadHookInstallations } from 'dotcom-tool-kit/lib/install'
+
+const logger = winston as unknown as Logger
+
+describe('circleci-deploy', () => {
+  describe('config integration test', () => {
+    it('should generate a .circleci/config.yml with the base config from circleci-deploy/.toolkitrc.yml', async () => {
+      const config = await loadConfig(logger, { root: path.resolve(__dirname, '..') })
+      const hookInstallationsPromise = loadHookInstallations(logger, config).then((validated) =>
+        validated.unwrap('hooks were invalid')
+      )
+
+      await expect(hookInstallationsPromise).resolves.toEqual([expect.any(CircleCi)])
+
+      const installation = (await hookInstallationsPromise)[0]
+
+      expect(YAML.stringify(await installation.install())).toMatchSnapshot()
+    })
+  })
+})

--- a/plugins/circleci-npm/test/__snapshots__/circleci-npm.test.ts.snap
+++ b/plugins/circleci-npm/test/__snapshots__/circleci-npm.test.ts.snap
@@ -1,0 +1,80 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`circleci-npm config integration test should generate a .circleci/config.yml with the base config from circleci-npm/.toolkitrc.yml 1`] = `
+"version: 2.1
+orbs:
+  tool-kit: financial-times/dotcom-tool-kit@5
+executors:
+  node:
+    docker:
+      - image: cimg/node:18.19-browsers
+jobs:
+  checkout:
+    docker:
+      - image: cimg/base:stable
+    steps:
+      - checkout
+      - persist_to_workspace:
+          root: .
+          paths:
+            - .
+workflows:
+  tool-kit:
+    when:
+      not:
+        equal:
+          - scheduled_pipeline
+          - << pipeline.trigger_source >>
+    jobs:
+      - checkout:
+          filters:
+            tags:
+              only: /^v\\d+\\.\\d+\\.\\d+(-.+)?/
+      - tool-kit/setup:
+          executor: node
+          requires:
+            - checkout
+          filters:
+            tags:
+              only: /^v\\d+\\.\\d+\\.\\d+(-.+)?/
+      - tool-kit/build:
+          executor: node
+          requires:
+            - tool-kit/setup
+      - tool-kit/test:
+          executor: node
+          requires:
+            - tool-kit/build
+      - tool-kit/publish-tag:
+          executor: node
+          requires:
+            - tool-kit/test
+          context: npm-publish-token
+          filters:
+            branches:
+              ignore: /.*/
+  nightly:
+    when:
+      and:
+        - equal:
+            - scheduled_pipeline
+            - << pipeline.trigger_source >>
+        - equal:
+            - nightly
+            - << pipeline.schedule.name >>
+    jobs:
+      - checkout
+      - tool-kit/setup:
+          executor: node
+          requires:
+            - checkout
+      - tool-kit/build:
+          executor: node
+          requires:
+            - tool-kit/setup
+      - tool-kit/test:
+          executor: node
+          requires:
+            - tool-kit/build
+"
+`;

--- a/plugins/circleci-npm/test/__snapshots__/circleci-npm.test.ts.snap
+++ b/plugins/circleci-npm/test/__snapshots__/circleci-npm.test.ts.snap
@@ -41,18 +41,26 @@ workflows:
           executor: node
           requires:
             - tool-kit/setup
+          filters:
+            tags:
+              only: /^v\\d+\\.\\d+\\.\\d+(-.+)?/
       - tool-kit/test:
           executor: node
           requires:
             - tool-kit/build
+          filters:
+            tags:
+              only: /^v\\d+\\.\\d+\\.\\d+(-.+)?/
       - tool-kit/publish-tag:
           executor: node
           requires:
             - tool-kit/test
-          context: npm-publish-token
           filters:
+            tags:
+              only: /^v\\d+\\.\\d+\\.\\d+(-.+)?/
             branches:
               ignore: /.*/
+          context: npm-publish-token
   nightly:
     when:
       and:

--- a/plugins/circleci-npm/test/circleci-npm.test.ts
+++ b/plugins/circleci-npm/test/circleci-npm.test.ts
@@ -1,0 +1,25 @@
+import * as YAML from 'yaml'
+import path from 'path'
+import CircleCi from '@dotcom-tool-kit/circleci/lib/circleci-config'
+import winston, { Logger } from 'winston'
+import { loadConfig } from 'dotcom-tool-kit/lib/config'
+import { loadHookInstallations } from 'dotcom-tool-kit/lib/install'
+
+const logger = winston as unknown as Logger
+
+describe('circleci-npm', () => {
+  describe('config integration test', () => {
+    it('should generate a .circleci/config.yml with the base config from circleci-npm/.toolkitrc.yml', async () => {
+      const config = await loadConfig(logger, { root: path.resolve(__dirname, '..') })
+      const hookInstallationsPromise = loadHookInstallations(logger, config).then((validated) =>
+        validated.unwrap('hooks were invalid')
+      )
+
+      await expect(hookInstallationsPromise).resolves.toEqual([expect.any(CircleCi)])
+
+      const installation = (await hookInstallationsPromise)[0]
+
+      expect(YAML.stringify(await installation.install())).toMatchSnapshot()
+    })
+  })
+})

--- a/plugins/circleci/src/circleci-config.ts
+++ b/plugins/circleci/src/circleci-config.ts
@@ -396,7 +396,7 @@ const generateWorkflowJobs = (
             return `${requiredOrb}-${splitIntoMatrix ? '<< matrix.executor >>' : 'node'}`
           })
         },
-        workflow.runOnRelease && job.runOnRelease ? tagFilter(tagFilterRegex) : {},
+        workflow.runOnRelease && (job.runOnRelease ?? true) ? tagFilter(tagFilterRegex) : {},
         job.custom
       )
     }
@@ -418,7 +418,7 @@ const attachWorkspaceStep = {
 
 const generateJob = (job: CircleCiJob): JobConfig => ({
   steps: [
-    ...(job.workspace?.attach ? [attachWorkspaceStep] : []),
+    ...(job.workspace?.attach ?? true ? [attachWorkspaceStep] : []),
     ...(job.steps?.pre ?? []),
     {
       run: {
@@ -427,7 +427,7 @@ const generateJob = (job: CircleCiJob): JobConfig => ({
       }
     },
     ...(job.steps?.post ?? []),
-    ...(job.workspace?.persist ? [persistWorkspaceStep] : [])
+    ...(job.workspace?.persist ?? true ? [persistWorkspaceStep] : [])
   ],
   ...job.custom
 })

--- a/plugins/circleci/test/__snapshots__/circleci-config.test.ts.snap
+++ b/plugins/circleci/test/__snapshots__/circleci-config.test.ts.snap
@@ -1,0 +1,72 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`CircleCI config hook config integration test should generate a .circleci/config.yml with the base config from circleci/.toolkitrc.yml 1`] = `
+"version: 2.1
+orbs:
+  tool-kit: financial-times/dotcom-tool-kit@5
+executors:
+  node:
+    docker:
+      - image: cimg/node:18.19-browsers
+jobs:
+  checkout:
+    docker:
+      - image: cimg/base:stable
+    steps:
+      - checkout
+      - persist_to_workspace:
+          root: .
+          paths:
+            - .
+workflows:
+  tool-kit:
+    when:
+      not:
+        equal:
+          - scheduled_pipeline
+          - << pipeline.trigger_source >>
+    jobs:
+      - checkout:
+          filters:
+            tags:
+              only: /^v\\d+\\.\\d+\\.\\d+(-.+)?/
+      - tool-kit/setup:
+          executor: node
+          requires:
+            - checkout
+          filters:
+            tags:
+              only: /^v\\d+\\.\\d+\\.\\d+(-.+)?/
+      - tool-kit/build:
+          executor: node
+          requires:
+            - tool-kit/setup
+      - tool-kit/test:
+          executor: node
+          requires:
+            - tool-kit/build
+  nightly:
+    when:
+      and:
+        - equal:
+            - scheduled_pipeline
+            - << pipeline.trigger_source >>
+        - equal:
+            - nightly
+            - << pipeline.schedule.name >>
+    jobs:
+      - checkout
+      - tool-kit/setup:
+          executor: node
+          requires:
+            - checkout
+      - tool-kit/build:
+          executor: node
+          requires:
+            - tool-kit/setup
+      - tool-kit/test:
+          executor: node
+          requires:
+            - tool-kit/build
+"
+`;

--- a/plugins/circleci/test/__snapshots__/circleci-config.test.ts.snap
+++ b/plugins/circleci/test/__snapshots__/circleci-config.test.ts.snap
@@ -41,10 +41,16 @@ workflows:
           executor: node
           requires:
             - tool-kit/setup
+          filters:
+            tags:
+              only: /^v\\d+\\.\\d+\\.\\d+(-.+)?/
       - tool-kit/test:
           executor: node
           requires:
             - tool-kit/build
+          filters:
+            tags:
+              only: /^v\\d+\\.\\d+\\.\\d+(-.+)?/
   nightly:
     when:
       and:

--- a/plugins/circleci/test/circleci-config.test.ts
+++ b/plugins/circleci/test/circleci-config.test.ts
@@ -158,9 +158,22 @@ describe('CircleCI config hook', () => {
             "test-job": {
               "steps": [
                 {
+                  "attach-workspace": {
+                    "at": ".",
+                  },
+                },
+                {
                   "run": {
                     "command": "npx dotcom-tool-kit test:local",
                     "name": "test-job",
+                  },
+                },
+                {
+                  "persist_to_workspace": {
+                    "paths": [
+                      ".",
+                    ],
+                    "root": ".",
                   },
                 },
               ],
@@ -218,9 +231,22 @@ describe('CircleCI config hook', () => {
             "test-job": {
               "steps": [
                 {
+                  "attach-workspace": {
+                    "at": ".",
+                  },
+                },
+                {
                   "run": {
                     "command": "npx dotcom-tool-kit test:local",
                     "name": "test-job",
+                  },
+                },
+                {
+                  "persist_to_workspace": {
+                    "paths": [
+                      ".",
+                    ],
+                    "root": ".",
                   },
                 },
               ],

--- a/plugins/circleci/test/files/.toolkitrc.yml
+++ b/plugins/circleci/test/files/.toolkitrc.yml
@@ -1,0 +1,2 @@
+plugins:
+  - @dotcom-tool-kit/circleci


### PR DESCRIPTION
the `.partial()` on the hook option objects is overriding the `.default()` on their properties.
short of splitting the schema into an incoming options schema that's meant to be merged from
multiple sources, and an outgoing schema for the final hook options, this is the most
straightforward way of doing this.
