### PR TITLE
fix: stop adding CWD to the n-test config path

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -49,11 +49,11 @@
     },
     "core/cli": {
       "name": "dotcom-tool-kit",
-      "version": "4.3.0",
+      "version": "4.3.2",
       "license": "MIT",
       "dependencies": {
-        "@dotcom-tool-kit/base": "^1.1.2",
-        "@dotcom-tool-kit/config": "^1.0.5",
+        "@dotcom-tool-kit/base": "^1.1.3",
+        "@dotcom-tool-kit/config": "^1.0.6",
         "@dotcom-tool-kit/conflict": "^1.0.0",
         "@dotcom-tool-kit/error": "^4.1.0",
         "@dotcom-tool-kit/logger": "^4.1.0",
@@ -133,16 +133,16 @@
     },
     "core/create": {
       "name": "@dotcom-tool-kit/create",
-      "version": "4.2.0",
+      "version": "4.2.2",
       "license": "ISC",
       "dependencies": {
         "@aws-sdk/client-iam": "^3.282.0",
         "@aws-sdk/client-sts": "^3.282.0",
-        "@dotcom-tool-kit/doppler": "^2.1.0",
+        "@dotcom-tool-kit/doppler": "^2.1.1",
         "@dotcom-tool-kit/error": "^4.1.0",
         "@dotcom-tool-kit/logger": "^4.1.0",
         "@dotcom-tool-kit/plugin": "^1.0.0",
-        "@dotcom-tool-kit/schemas": "^1.4.0",
+        "@dotcom-tool-kit/schemas": "^1.5.0",
         "@octokit/rest": "^19.0.5",
         "@quarterto/parse-makefile-rules": "^1.1.0",
         "cli-highlight": "^2.1.11",
@@ -169,7 +169,7 @@
         "@types/node-fetch": "^2.6.2",
         "@types/pacote": "^11.1.3",
         "@types/prompts": "^2.0.14",
-        "dotcom-tool-kit": "^4.3.0",
+        "dotcom-tool-kit": "^4.3.2",
         "type-fest": "^3.13.1"
       },
       "engines": {
@@ -1100,7 +1100,7 @@
     },
     "lib/base": {
       "name": "@dotcom-tool-kit/base",
-      "version": "1.1.2",
+      "version": "1.1.3",
       "license": "ISC",
       "dependencies": {
         "@dotcom-tool-kit/conflict": "^1.0.0",
@@ -1109,7 +1109,7 @@
         "winston": "^3.11.0"
       },
       "devDependencies": {
-        "@dotcom-tool-kit/config": "^1.0.5",
+        "@dotcom-tool-kit/config": "^1.0.6",
         "@dotcom-tool-kit/logger": "^4.1.0",
         "@dotcom-tool-kit/plugin": "^1.0.0",
         "type-fest": "^4.29.1",
@@ -1200,12 +1200,12 @@
     },
     "lib/config": {
       "name": "@dotcom-tool-kit/config",
-      "version": "1.0.5",
+      "version": "1.0.6",
       "license": "ISC",
       "dependencies": {
         "@dotcom-tool-kit/conflict": "^1.0.0",
         "@dotcom-tool-kit/plugin": "^1.0.0",
-        "@dotcom-tool-kit/schemas": "^1.4.0",
+        "@dotcom-tool-kit/schemas": "^1.5.0",
         "@dotcom-tool-kit/validated": "^1.0.2"
       }
     },
@@ -1219,7 +1219,7 @@
     },
     "lib/doppler": {
       "name": "@dotcom-tool-kit/doppler",
-      "version": "2.1.0",
+      "version": "2.1.1",
       "license": "ISC",
       "dependencies": {
         "@dotcom-tool-kit/error": "^4.1.0",
@@ -1227,7 +1227,7 @@
         "tslib": "^2.3.1"
       },
       "devDependencies": {
-        "@dotcom-tool-kit/schemas": "^1.4.0",
+        "@dotcom-tool-kit/schemas": "^1.5.0",
         "spawk": "^1.8.1",
         "winston": "^3.5.1"
       },
@@ -1323,7 +1323,7 @@
     },
     "lib/schemas": {
       "name": "@dotcom-tool-kit/schemas",
-      "version": "1.4.0",
+      "version": "1.5.0",
       "license": "ISC",
       "dependencies": {
         "@dotcom-tool-kit/logger": "^4.1.0"
@@ -30490,10 +30490,10 @@
     },
     "plugins/babel": {
       "name": "@dotcom-tool-kit/babel",
-      "version": "4.2.0",
+      "version": "4.2.1",
       "license": "MIT",
       "dependencies": {
-        "@dotcom-tool-kit/base": "^1.1.2",
+        "@dotcom-tool-kit/base": "^1.1.3",
         "@dotcom-tool-kit/error": "^4.1.0",
         "@dotcom-tool-kit/logger": "^4.1.0",
         "fast-glob": "^3.2.11",
@@ -30501,7 +30501,7 @@
       },
       "devDependencies": {
         "@babel/preset-env": "^7.16.11",
-        "@dotcom-tool-kit/schemas": "^1.4.0",
+        "@dotcom-tool-kit/schemas": "^1.5.0",
         "@jest/globals": "^27.4.6",
         "winston": "^3.5.1"
       },
@@ -30536,13 +30536,13 @@
     },
     "plugins/backend-heroku-app": {
       "name": "@dotcom-tool-kit/backend-heroku-app",
-      "version": "4.1.0",
+      "version": "4.1.1",
       "license": "ISC",
       "dependencies": {
-        "@dotcom-tool-kit/circleci-deploy": "^4.1.0",
-        "@dotcom-tool-kit/heroku": "^4.1.0",
-        "@dotcom-tool-kit/node": "^4.2.0",
-        "@dotcom-tool-kit/npm": "^4.2.0"
+        "@dotcom-tool-kit/circleci-deploy": "^4.1.1",
+        "@dotcom-tool-kit/heroku": "^4.1.1",
+        "@dotcom-tool-kit/node": "^4.2.1",
+        "@dotcom-tool-kit/npm": "^4.2.1"
       },
       "engines": {
         "node": "18.x || 20.x || 22.x"
@@ -30553,13 +30553,13 @@
     },
     "plugins/backend-serverless-app": {
       "name": "@dotcom-tool-kit/backend-serverless-app",
-      "version": "4.1.0",
+      "version": "4.1.1",
       "license": "ISC",
       "dependencies": {
-        "@dotcom-tool-kit/circleci-deploy": "^4.1.0",
-        "@dotcom-tool-kit/node": "^4.2.0",
-        "@dotcom-tool-kit/npm": "^4.2.0",
-        "@dotcom-tool-kit/serverless": "^3.2.0"
+        "@dotcom-tool-kit/circleci-deploy": "^4.1.1",
+        "@dotcom-tool-kit/node": "^4.2.1",
+        "@dotcom-tool-kit/npm": "^4.2.1",
+        "@dotcom-tool-kit/serverless": "^3.2.1"
       },
       "engines": {
         "node": "18.x || 20.x || 22.x"
@@ -30570,10 +30570,10 @@
     },
     "plugins/circleci": {
       "name": "@dotcom-tool-kit/circleci",
-      "version": "7.3.0",
+      "version": "7.3.1",
       "license": "ISC",
       "dependencies": {
-        "@dotcom-tool-kit/base": "^1.1.2",
+        "@dotcom-tool-kit/base": "^1.1.3",
         "@dotcom-tool-kit/conflict": "^1.0.0",
         "@dotcom-tool-kit/error": "^4.1.0",
         "@dotcom-tool-kit/logger": "^4.1.0",
@@ -30586,7 +30586,7 @@
       },
       "devDependencies": {
         "@dotcom-tool-kit/plugin": "^1.0.0",
-        "@dotcom-tool-kit/schemas": "^1.4.0",
+        "@dotcom-tool-kit/schemas": "^1.5.0",
         "@jest/globals": "^27.4.6",
         "@types/jest": "^27.4.0",
         "@types/js-yaml": "^4.0.3",
@@ -30604,10 +30604,10 @@
     },
     "plugins/circleci-deploy": {
       "name": "@dotcom-tool-kit/circleci-deploy",
-      "version": "4.1.0",
+      "version": "4.1.1",
       "license": "ISC",
       "dependencies": {
-        "@dotcom-tool-kit/circleci": "^7.3.0",
+        "@dotcom-tool-kit/circleci": "^7.3.1",
         "tslib": "^2.3.1"
       },
       "devDependencies": {
@@ -30645,11 +30645,11 @@
     },
     "plugins/circleci-npm": {
       "name": "@dotcom-tool-kit/circleci-npm",
-      "version": "6.1.0",
+      "version": "6.1.1",
       "license": "ISC",
       "dependencies": {
-        "@dotcom-tool-kit/circleci": "^7.3.0",
-        "@dotcom-tool-kit/npm": "^4.2.0",
+        "@dotcom-tool-kit/circleci": "^7.3.1",
+        "@dotcom-tool-kit/npm": "^4.2.1",
         "tslib": "^2.3.1"
       },
       "engines": {
@@ -30765,7 +30765,7 @@
     },
     "plugins/cloudsmith": {
       "name": "@dotcom-tool-kit/cloudsmith",
-      "version": "1.0.0",
+      "version": "1.0.1",
       "license": "ISC",
       "engines": {
         "node": "18.x || 20.x",
@@ -30777,10 +30777,10 @@
     },
     "plugins/commitlint": {
       "name": "@dotcom-tool-kit/commitlint",
-      "version": "1.2.0",
+      "version": "1.2.1",
       "license": "ISC",
       "dependencies": {
-        "@dotcom-tool-kit/base": "^1.1.2",
+        "@dotcom-tool-kit/base": "^1.1.3",
         "@dotcom-tool-kit/logger": "^4.1.0"
       },
       "engines": {
@@ -31490,11 +31490,11 @@
     },
     "plugins/component": {
       "name": "@dotcom-tool-kit/component",
-      "version": "5.1.0",
+      "version": "5.1.1",
       "license": "ISC",
       "dependencies": {
-        "@dotcom-tool-kit/circleci-npm": "^6.1.0",
-        "@dotcom-tool-kit/npm": "^4.2.0"
+        "@dotcom-tool-kit/circleci-npm": "^6.1.1",
+        "@dotcom-tool-kit/npm": "^4.2.1"
       },
       "engines": {
         "node": "18.x || 20.x || 22.x"
@@ -31505,17 +31505,17 @@
     },
     "plugins/cypress": {
       "name": "@dotcom-tool-kit/cypress",
-      "version": "5.2.0",
+      "version": "5.2.1",
       "license": "ISC",
       "dependencies": {
-        "@dotcom-tool-kit/base": "^1.1.2",
-        "@dotcom-tool-kit/doppler": "^2.1.0",
+        "@dotcom-tool-kit/base": "^1.1.3",
+        "@dotcom-tool-kit/doppler": "^2.1.1",
         "@dotcom-tool-kit/logger": "^4.1.0",
-        "@dotcom-tool-kit/package-json-hook": "^5.1.0",
+        "@dotcom-tool-kit/package-json-hook": "^5.1.1",
         "@dotcom-tool-kit/state": "^4.1.0"
       },
       "devDependencies": {
-        "@dotcom-tool-kit/schemas": "^1.4.0"
+        "@dotcom-tool-kit/schemas": "^1.5.0"
       },
       "engines": {
         "node": "18.x || 20.x || 22.x"
@@ -31526,20 +31526,19 @@
     },
     "plugins/docker": {
       "name": "@dotcom-tool-kit/docker",
-      "version": "0.0.0",
+      "version": "0.1.0",
       "license": "ISC",
       "dependencies": {
-        "@dotcom-tool-kit/base": "^1.1.2",
+        "@dotcom-tool-kit/base": "^1.1.3",
         "@dotcom-tool-kit/error": "^4.1.0",
         "@dotcom-tool-kit/logger": "^4.1.0",
         "tslib": "^2.3.1"
       },
       "devDependencies": {
-        "@dotcom-tool-kit/schemas": "^1.4.0"
+        "@dotcom-tool-kit/schemas": "^1.5.0"
       },
       "engines": {
-        "node": "18.x || 20.x",
-        "npm": "7.x || 8.x || 9.x || 10.x"
+        "node": "18.x || 20.x || 22.x"
       },
       "peerDependencies": {
         "dotcom-tool-kit": "4.x"
@@ -31556,16 +31555,16 @@
     },
     "plugins/eslint": {
       "name": "@dotcom-tool-kit/eslint",
-      "version": "4.2.0",
+      "version": "4.2.1",
       "license": "ISC",
       "dependencies": {
-        "@dotcom-tool-kit/base": "^1.1.2",
+        "@dotcom-tool-kit/base": "^1.1.3",
         "@dotcom-tool-kit/error": "^4.1.0",
         "@dotcom-tool-kit/logger": "^4.1.0",
         "tslib": "^2.3.1"
       },
       "devDependencies": {
-        "@dotcom-tool-kit/schemas": "^1.4.0",
+        "@dotcom-tool-kit/schemas": "^1.5.0",
         "@jest/globals": "^27.4.6",
         "@types/eslint": "^7.2.13",
         "@types/temp": "^0.9.4",
@@ -31780,12 +31779,12 @@
     },
     "plugins/frontend-app": {
       "name": "@dotcom-tool-kit/frontend-app",
-      "version": "4.1.0",
+      "version": "4.1.1",
       "license": "ISC",
       "dependencies": {
-        "@dotcom-tool-kit/backend-heroku-app": "^4.1.0",
-        "@dotcom-tool-kit/upload-assets-to-s3": "^4.2.0",
-        "@dotcom-tool-kit/webpack": "^4.2.0"
+        "@dotcom-tool-kit/backend-heroku-app": "^4.1.1",
+        "@dotcom-tool-kit/upload-assets-to-s3": "^4.2.1",
+        "@dotcom-tool-kit/webpack": "^4.2.1"
       },
       "engines": {
         "node": "18.x || 20.x || 22.x"
@@ -31796,15 +31795,15 @@
     },
     "plugins/heroku": {
       "name": "@dotcom-tool-kit/heroku",
-      "version": "4.1.0",
+      "version": "4.1.1",
       "license": "ISC",
       "dependencies": {
-        "@dotcom-tool-kit/base": "^1.1.2",
-        "@dotcom-tool-kit/doppler": "^2.1.0",
+        "@dotcom-tool-kit/base": "^1.1.3",
+        "@dotcom-tool-kit/doppler": "^2.1.1",
         "@dotcom-tool-kit/error": "^4.1.0",
         "@dotcom-tool-kit/logger": "^4.1.0",
-        "@dotcom-tool-kit/npm": "^4.2.0",
-        "@dotcom-tool-kit/package-json-hook": "^5.1.0",
+        "@dotcom-tool-kit/npm": "^4.2.1",
+        "@dotcom-tool-kit/package-json-hook": "^5.1.1",
         "@dotcom-tool-kit/state": "^4.1.0",
         "@dotcom-tool-kit/wait-for-ok": "^4.1.0",
         "@octokit/request": "^8.4.0",
@@ -31815,7 +31814,7 @@
         "tslib": "^2.3.1"
       },
       "devDependencies": {
-        "@dotcom-tool-kit/schemas": "^1.4.0",
+        "@dotcom-tool-kit/schemas": "^1.5.0",
         "@types/financial-times__package-json": "^1.9.0",
         "@types/p-retry": "^3.0.1",
         "winston": "^3.5.1"
@@ -31886,10 +31885,10 @@
     },
     "plugins/husky-npm": {
       "name": "@dotcom-tool-kit/husky-npm",
-      "version": "5.1.0",
+      "version": "5.1.1",
       "license": "ISC",
       "dependencies": {
-        "@dotcom-tool-kit/package-json-hook": "^5.1.0",
+        "@dotcom-tool-kit/package-json-hook": "^5.1.1",
         "tslib": "^2.3.1"
       },
       "engines": {
@@ -31907,15 +31906,15 @@
     },
     "plugins/jest": {
       "name": "@dotcom-tool-kit/jest",
-      "version": "4.2.0",
+      "version": "4.2.1",
       "license": "ISC",
       "dependencies": {
-        "@dotcom-tool-kit/base": "^1.1.2",
+        "@dotcom-tool-kit/base": "^1.1.3",
         "@dotcom-tool-kit/logger": "^4.1.0",
         "tslib": "^2.3.1"
       },
       "devDependencies": {
-        "@dotcom-tool-kit/schemas": "^1.4.0",
+        "@dotcom-tool-kit/schemas": "^1.5.0",
         "winston": "^3.5.1"
       },
       "engines": {
@@ -31933,12 +31932,12 @@
     },
     "plugins/lint-staged": {
       "name": "@dotcom-tool-kit/lint-staged",
-      "version": "5.2.0",
+      "version": "5.2.1",
       "license": "ISC",
       "dependencies": {
-        "@dotcom-tool-kit/base": "^1.1.2",
+        "@dotcom-tool-kit/base": "^1.1.3",
         "@dotcom-tool-kit/logger": "^4.1.0",
-        "@dotcom-tool-kit/package-json-hook": "^5.1.0",
+        "@dotcom-tool-kit/package-json-hook": "^5.1.1",
         "lint-staged": "^11.2.3",
         "tslib": "^2.3.1"
       },
@@ -31951,12 +31950,12 @@
     },
     "plugins/lint-staged-npm": {
       "name": "@dotcom-tool-kit/lint-staged-npm",
-      "version": "4.1.0",
+      "version": "4.1.1",
       "license": "ISC",
       "dependencies": {
-        "@dotcom-tool-kit/husky-npm": "^5.1.0",
-        "@dotcom-tool-kit/lint-staged": "^5.2.0",
-        "@dotcom-tool-kit/package-json-hook": "^5.1.0",
+        "@dotcom-tool-kit/husky-npm": "^5.1.1",
+        "@dotcom-tool-kit/lint-staged": "^5.2.1",
+        "@dotcom-tool-kit/package-json-hook": "^5.1.1",
         "tslib": "^2.3.1"
       },
       "engines": {
@@ -32028,17 +32027,17 @@
     },
     "plugins/mocha": {
       "name": "@dotcom-tool-kit/mocha",
-      "version": "4.2.0",
+      "version": "4.2.1",
       "license": "ISC",
       "dependencies": {
-        "@dotcom-tool-kit/base": "^1.1.2",
+        "@dotcom-tool-kit/base": "^1.1.3",
         "@dotcom-tool-kit/error": "^4.1.0",
         "@dotcom-tool-kit/logger": "^4.1.0",
         "glob": "^7.1.7",
         "tslib": "^2.3.1"
       },
       "devDependencies": {
-        "@dotcom-tool-kit/schemas": "^1.4.0",
+        "@dotcom-tool-kit/schemas": "^1.5.0",
         "@jest/globals": "^27.4.6",
         "@types/glob": "^7.1.3",
         "@types/mocha": "^8.2.2",
@@ -32062,17 +32061,18 @@
     },
     "plugins/n-test": {
       "name": "@dotcom-tool-kit/n-test",
-      "version": "4.2.0",
+      "version": "4.2.1",
       "license": "ISC",
       "dependencies": {
-        "@dotcom-tool-kit/base": "^1.1.2",
+        "@dotcom-tool-kit/base": "^1.1.3",
+        "@dotcom-tool-kit/error": "^4.1.0",
         "@dotcom-tool-kit/logger": "^4.1.0",
         "@dotcom-tool-kit/state": "^4.1.0",
         "@financial-times/n-test": "^6.1.0-beta.1",
         "tslib": "^2.3.1"
       },
       "devDependencies": {
-        "@dotcom-tool-kit/schemas": "^1.4.0",
+        "@dotcom-tool-kit/schemas": "^1.5.0",
         "@jest/globals": "^27.4.6",
         "@types/jest": "^27.4.0",
         "winston": "^3.5.1"
@@ -32183,11 +32183,11 @@
     },
     "plugins/next-router": {
       "name": "@dotcom-tool-kit/next-router",
-      "version": "4.2.0",
+      "version": "4.2.1",
       "license": "ISC",
       "dependencies": {
-        "@dotcom-tool-kit/base": "^1.1.2",
-        "@dotcom-tool-kit/doppler": "^2.1.0",
+        "@dotcom-tool-kit/base": "^1.1.3",
+        "@dotcom-tool-kit/doppler": "^2.1.1",
         "@dotcom-tool-kit/error": "^4.1.0",
         "@dotcom-tool-kit/logger": "^4.1.0",
         "@dotcom-tool-kit/state": "^4.1.0",
@@ -32195,7 +32195,7 @@
         "tslib": "^2.3.1"
       },
       "devDependencies": {
-        "@dotcom-tool-kit/schemas": "^1.4.0"
+        "@dotcom-tool-kit/schemas": "^1.5.0"
       },
       "engines": {
         "node": "18.x || 20.x || 22.x"
@@ -32316,11 +32316,11 @@
     },
     "plugins/node": {
       "name": "@dotcom-tool-kit/node",
-      "version": "4.2.0",
+      "version": "4.2.1",
       "license": "ISC",
       "dependencies": {
-        "@dotcom-tool-kit/base": "^1.1.2",
-        "@dotcom-tool-kit/doppler": "^2.1.0",
+        "@dotcom-tool-kit/base": "^1.1.3",
+        "@dotcom-tool-kit/doppler": "^2.1.1",
         "@dotcom-tool-kit/error": "^4.1.0",
         "@dotcom-tool-kit/state": "^4.1.0",
         "get-port": "^5.1.1",
@@ -32328,7 +32328,7 @@
         "wait-port": "^0.2.9"
       },
       "devDependencies": {
-        "@dotcom-tool-kit/schemas": "^1.4.0"
+        "@dotcom-tool-kit/schemas": "^1.5.0"
       },
       "engines": {
         "node": "18.x || 20.x || 22.x"
@@ -32344,18 +32344,18 @@
     },
     "plugins/nodemon": {
       "name": "@dotcom-tool-kit/nodemon",
-      "version": "4.1.0",
+      "version": "4.1.1",
       "license": "ISC",
       "dependencies": {
-        "@dotcom-tool-kit/base": "^1.1.2",
-        "@dotcom-tool-kit/doppler": "^2.1.0",
+        "@dotcom-tool-kit/base": "^1.1.3",
+        "@dotcom-tool-kit/doppler": "^2.1.1",
         "@dotcom-tool-kit/error": "^4.1.0",
         "@dotcom-tool-kit/state": "^4.1.0",
         "get-port": "^5.1.1",
         "tslib": "^2.3.1"
       },
       "devDependencies": {
-        "@dotcom-tool-kit/schemas": "^1.4.0",
+        "@dotcom-tool-kit/schemas": "^1.5.0",
         "@types/nodemon": "^1.19.1"
       },
       "engines": {
@@ -32373,12 +32373,12 @@
     },
     "plugins/npm": {
       "name": "@dotcom-tool-kit/npm",
-      "version": "4.2.0",
+      "version": "4.2.1",
       "license": "ISC",
       "dependencies": {
-        "@dotcom-tool-kit/base": "^1.1.2",
+        "@dotcom-tool-kit/base": "^1.1.3",
         "@dotcom-tool-kit/error": "^4.1.0",
-        "@dotcom-tool-kit/package-json-hook": "^5.1.0",
+        "@dotcom-tool-kit/package-json-hook": "^5.1.1",
         "@dotcom-tool-kit/state": "^4.1.0",
         "libnpmpack": "^3.1.0",
         "libnpmpublish": "^5.0.1",
@@ -32609,10 +32609,10 @@
     },
     "plugins/package-json-hook": {
       "name": "@dotcom-tool-kit/package-json-hook",
-      "version": "5.1.0",
+      "version": "5.1.1",
       "license": "ISC",
       "dependencies": {
-        "@dotcom-tool-kit/base": "^1.1.2",
+        "@dotcom-tool-kit/base": "^1.1.3",
         "@dotcom-tool-kit/conflict": "^1.0.0",
         "@dotcom-tool-kit/plugin": "^1.0.0",
         "@financial-times/package-json": "^3.0.0",
@@ -32620,7 +32620,7 @@
         "tslib": "^2.3.1"
       },
       "devDependencies": {
-        "@dotcom-tool-kit/schemas": "^1.4.0",
+        "@dotcom-tool-kit/schemas": "^1.5.0",
         "@jest/globals": "^27.4.6",
         "@types/lodash": "^4.14.185",
         "winston": "^3.5.1",
@@ -32643,13 +32643,13 @@
     },
     "plugins/prettier": {
       "name": "@dotcom-tool-kit/prettier",
-      "version": "4.2.0",
+      "version": "4.2.1",
       "license": "ISC",
       "dependencies": {
-        "@dotcom-tool-kit/base": "^1.1.2",
+        "@dotcom-tool-kit/base": "^1.1.3",
         "@dotcom-tool-kit/error": "^4.1.0",
         "@dotcom-tool-kit/logger": "^4.1.0",
-        "@dotcom-tool-kit/package-json-hook": "^5.1.0",
+        "@dotcom-tool-kit/package-json-hook": "^5.1.1",
         "fast-glob": "^3.2.7",
         "hook-std": "^2.0.0",
         "prettier": "^2.2.1",
@@ -32698,11 +32698,11 @@
     },
     "plugins/serverless": {
       "name": "@dotcom-tool-kit/serverless",
-      "version": "3.2.0",
+      "version": "3.2.1",
       "license": "ISC",
       "dependencies": {
-        "@dotcom-tool-kit/base": "^1.1.2",
-        "@dotcom-tool-kit/doppler": "^2.1.0",
+        "@dotcom-tool-kit/base": "^1.1.3",
+        "@dotcom-tool-kit/doppler": "^2.1.1",
         "@dotcom-tool-kit/error": "^4.1.0",
         "@dotcom-tool-kit/state": "^4.1.0",
         "get-port": "^5.1.1",
@@ -32710,7 +32710,7 @@
         "wait-port": "^0.2.9"
       },
       "devDependencies": {
-        "@dotcom-tool-kit/schemas": "^1.4.0"
+        "@dotcom-tool-kit/schemas": "^1.5.0"
       },
       "engines": {
         "node": "18.x || 20.x || 22.x"
@@ -32727,14 +32727,14 @@
     },
     "plugins/typescript": {
       "name": "@dotcom-tool-kit/typescript",
-      "version": "3.2.0",
+      "version": "3.2.1",
       "license": "ISC",
       "dependencies": {
-        "@dotcom-tool-kit/base": "^1.1.2",
+        "@dotcom-tool-kit/base": "^1.1.3",
         "@dotcom-tool-kit/logger": "^4.1.0"
       },
       "devDependencies": {
-        "@dotcom-tool-kit/schemas": "^1.4.0",
+        "@dotcom-tool-kit/schemas": "^1.5.0",
         "@jest/globals": "^29.3.1",
         "typescript": "^4.9.4",
         "winston": "^3.8.2"
@@ -32948,11 +32948,11 @@
     },
     "plugins/upload-assets-to-s3": {
       "name": "@dotcom-tool-kit/upload-assets-to-s3",
-      "version": "4.2.0",
+      "version": "4.2.1",
       "license": "ISC",
       "dependencies": {
         "@aws-sdk/client-s3": "^3.256.0",
-        "@dotcom-tool-kit/base": "^1.1.2",
+        "@dotcom-tool-kit/base": "^1.1.3",
         "@dotcom-tool-kit/error": "^4.1.0",
         "@dotcom-tool-kit/logger": "^4.1.0",
         "glob": "^7.1.6",
@@ -32961,7 +32961,7 @@
       },
       "devDependencies": {
         "@aws-sdk/types": "^3.13.1",
-        "@dotcom-tool-kit/schemas": "^1.4.0",
+        "@dotcom-tool-kit/schemas": "^1.5.0",
         "@jest/globals": "^27.4.6",
         "@types/glob": "^7.1.3",
         "@types/jest": "^27.4.0",
@@ -32982,17 +32982,17 @@
     },
     "plugins/webpack": {
       "name": "@dotcom-tool-kit/webpack",
-      "version": "4.2.0",
+      "version": "4.2.1",
       "license": "MIT",
       "dependencies": {
-        "@dotcom-tool-kit/base": "^1.1.2",
+        "@dotcom-tool-kit/base": "^1.1.3",
         "@dotcom-tool-kit/error": "^4.1.0",
         "@dotcom-tool-kit/logger": "^4.1.0",
         "tslib": "^2.3.1",
         "webpack-cli": "^4.6.0"
       },
       "devDependencies": {
-        "@dotcom-tool-kit/schemas": "^1.4.0",
+        "@dotcom-tool-kit/schemas": "^1.5.0",
         "@jest/globals": "^27.4.6",
         "ts-node": "^10.0.0",
         "webpack": "^4.42.1",

--- a/plugins/n-test/package.json
+++ b/plugins/n-test/package.json
@@ -12,6 +12,7 @@
   "dependencies": {
     "@dotcom-tool-kit/base": "^1.1.3",
     "@dotcom-tool-kit/logger": "^4.1.0",
+    "@dotcom-tool-kit/error": "^4.1.0",
     "@dotcom-tool-kit/state": "^4.1.0",
     "@financial-times/n-test": "^6.1.0-beta.1",
     "tslib": "^2.3.1"

--- a/plugins/n-test/src/tasks/n-test.ts
+++ b/plugins/n-test/src/tasks/n-test.ts
@@ -3,10 +3,10 @@ import { Task, TaskRunContext } from '@dotcom-tool-kit/base'
 import { SmokeTestSchema } from '@dotcom-tool-kit/schemas/lib/tasks/n-test'
 import { SmokeTest } from '@financial-times/n-test'
 import { readState } from '@dotcom-tool-kit/state'
-import path from 'path'
+import { ToolKitError } from '@dotcom-tool-kit/error'
 
 export default class NTest extends Task<{ task: typeof SmokeTestSchema }> {
-  async run({cwd}: TaskRunContext): Promise<void> {
+  async run({ cwd }: TaskRunContext): Promise<void> {
     const appState = readState('review') ?? readState('staging')
 
     // if we've built a review or staging app, test against that, not the app in the config
@@ -18,7 +18,12 @@ export default class NTest extends Task<{ task: typeof SmokeTestSchema }> {
         this.options.host = this.options.host.slice(0, -1)
       }
     }
-    this.options.config = path.join(cwd, this.options.config ?? 'test/smoke.js')
+
+    if (cwd !== process.cwd()) {
+      const error = new ToolKitError('the NTest task must be run from the current working directory')
+      error.details = `n-test prepends the config file path with the current working directory so it's not possible to resolve the config path properly if you're running this task from elsewhere`
+      throw error
+    }
 
     const smokeTest = new SmokeTest(this.options)
     this.logger.info(

--- a/plugins/n-test/test/tasks/n-test.test.ts
+++ b/plugins/n-test/test/tasks/n-test.test.ts
@@ -22,7 +22,7 @@ describe('n-test', () => {
       }
     )
 
-    await task.run({ command: 'e2e-test:staging', cwd: '' })
+    await task.run({ command: 'e2e-test:staging', cwd: process.cwd() })
   })
 
   it('should fail when there are errors', async () => {
@@ -39,7 +39,7 @@ describe('n-test', () => {
 
     expect.assertions(1)
     try {
-      await task.run({ command: 'e2e-test:staging', cwd: '' })
+      await task.run({ command: 'e2e-test:staging', cwd: process.cwd() })
     } catch (err) {
       expect(err).toBeTruthy()
     }
@@ -58,7 +58,7 @@ describe('n-test', () => {
     )
 
     try {
-      await task.run({ command: 'e2e-test:staging', cwd: '' })
+      await task.run({ command: 'e2e-test:staging', cwd: process.cwd() })
     } catch {}
 
     expect(task.options.host).toEqual(appUrl)

--- a/plugins/n-test/tsconfig.json
+++ b/plugins/n-test/tsconfig.json
@@ -7,6 +7,9 @@
   },
   "references": [
     {
+      "path": "../../lib/error"
+    },
+    {
       "path": "../../lib/state"
     },
     {


### PR DESCRIPTION
# Description

This line, which appeared in c070cc2, breaks test running. This is because n-test already prepends `process.cwd()` so it doubles up. This results in something like:

```
/Users/me/code/project/Users/me/code/project/test/smoke.js
```

@apaleslimghost suggested replacing it with an error if you're not running n-test from the current working directory. I copied it loosely from 81ebda7 where we're doing the same for the nodemon plugin.

I didn't want to make a change to n-test to get a quick fix rolled out, however that's probably the better long-term solution: n-test should use `path.resolve()` instead of `path.join()`, however that might break someone else's usage if they have a workaround in place 🤷

# Checklist:

- [x] My branch has been rebased onto the latest commit on main (don't merge main into your branch)
- [x] My commit messages are [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/), for example: `feat(circleci): add support for nightly workflows`, `fix: set Heroku app name for staging apps too`
