### PR TITLE
CPP-2313 Add proper support for custom jobs in CircleCI

### DIFF
--- a/core/cli/src/install.ts
+++ b/core/cli/src/install.ts
@@ -85,12 +85,15 @@ export const loadHookInstallations = async (
   })
 
   return installationsWithoutConflicts.map((installations) => {
-    return installations.map(
-      ({ hookConstructor, forHook, options }) => {
-        const hookPlugin = config.hooks[forHook].plugin
-        return new hookConstructor(logger, forHook, options, config.pluginOptions[hookPlugin.id as keyof PluginOptions]?.options)
-      }
-    )
+    return installations.map(({ hookConstructor, forHook, options }) => {
+      const hookPlugin = config.hooks[forHook].plugin
+      return new hookConstructor(
+        logger,
+        forHook,
+        options,
+        config.pluginOptions[hookPlugin.id as keyof PluginOptions]?.options
+      )
+    })
   })
 }
 
@@ -159,9 +162,7 @@ export default async function installHooks(logger: Logger): Promise<ValidConfig>
   }
 
   if (errors.length) {
-    const error = new ToolKitError('could not automatically install hooks:')
-    error.details = errors.map((error) => `- ${error.message}`).join('\n')
-    throw error
+    throw new AggregateError(errors, 'could not automatically install hooks')
   }
 
   await updateHashes(config)

--- a/lib/schemas/src/hooks/circleci.ts
+++ b/lib/schemas/src/hooks/circleci.ts
@@ -30,6 +30,7 @@ export const CircleCiJob = z
         post: z.array(CircleCiStep).optional()
       })
       .optional(),
+    splitIntoMatrix: z.boolean().optional(),
     custom: CircleCiCustom.optional()
   })
   .partial()

--- a/plugins/circleci/test/circleci-config.test.ts
+++ b/plugins/circleci/test/circleci-config.test.ts
@@ -26,6 +26,12 @@ const testWorkflowJob: CircleCiWorkflowJob = {
   splitIntoMatrix: false
 }
 
+const dependedWorkflowJob: CircleCiWorkflowJob = {
+  name: 'that-job',
+  requires: [],
+  splitIntoMatrix: false
+}
+
 const testPrefixedWorkflowJob: CircleCiWorkflowJob = {
   name: 'slack/approval-notification',
   requires: ['another/orb'],
@@ -45,7 +51,7 @@ const anotherTestWorkflowJob: CircleCiWorkflowJob = {
 }
 
 const configWithWorkflowJob: CircleCiOptions = {
-  workflows: [{ name: 'tool-kit', jobs: [testWorkflowJob] }],
+  workflows: [{ name: 'tool-kit', jobs: [dependedWorkflowJob, testWorkflowJob] }],
   disableBaseConfig: true
 }
 
@@ -131,6 +137,12 @@ describe('CircleCI config hook', () => {
             "tool-kit": {
               "jobs": [
                 {
+                  "tool-kit/that-job": {
+                    "executor": "node",
+                    "requires": [],
+                  },
+                },
+                {
                   "tool-kit/test-job": {
                     "executor": "node",
                     "requires": [
@@ -156,6 +168,7 @@ describe('CircleCI config hook', () => {
         {
           "jobs": {
             "test-job": {
+              "executor": "node",
               "steps": [
                 {
                   "attach-workspace": {
@@ -197,13 +210,11 @@ describe('CircleCI config hook', () => {
               "jobs": [
                 {
                   "another/orb": {
-                    "executor": "node",
                     "requires": [],
                   },
                 },
                 {
                   "slack/approval-notification": {
-                    "executor": "node",
                     "requires": [
                       "another/orb",
                     ],
@@ -235,6 +246,7 @@ describe('CircleCI config hook', () => {
         {
           "jobs": {
             "test-job": {
+              "executor": "node",
               "steps": [
                 {
                   "attach-workspace": {
@@ -262,8 +274,13 @@ describe('CircleCI config hook', () => {
             "tool-kit": {
               "jobs": [
                 {
-                  "test-job": {
+                  "tool-kit/that-job": {
                     "executor": "node",
+                    "requires": [],
+                  },
+                },
+                {
+                  "test-job": {
                     "requires": [
                       "tool-kit/that-job",
                     ],
@@ -306,7 +323,9 @@ describe('CircleCI config hook', () => {
           forHook: 'CircleCi',
           hookConstructor: CircleCi,
           options: {
-            workflows: [{ name: 'test-workflow', jobs: [testWorkflowJob], runOnRelease: true }]
+            workflows: [
+              { name: 'test-workflow', jobs: [dependedWorkflowJob, testWorkflowJob], runOnRelease: true }
+            ]
           }
         }
       ]
@@ -325,7 +344,9 @@ describe('CircleCI config hook', () => {
               }
             ],
             jobs: [testJob],
-            workflows: [{ name: 'test-workflow', jobs: [testWorkflowJob], runOnRelease: true }]
+            workflows: [
+              { name: 'test-workflow', jobs: [dependedWorkflowJob, testWorkflowJob], runOnRelease: true }
+            ]
           })
         }
       ])
@@ -350,7 +371,9 @@ describe('CircleCI config hook', () => {
           hookConstructor: CircleCi,
           options: {
             jobs: [testJob],
-            workflows: [{ name: 'test-workflow', jobs: [testWorkflowJob], runOnRelease: true }]
+            workflows: [
+              { name: 'test-workflow', jobs: [dependedWorkflowJob, testWorkflowJob], runOnRelease: true }
+            ]
           }
         }
       ]
@@ -363,7 +386,11 @@ describe('CircleCI config hook', () => {
           options: expect.objectContaining({
             jobs: [overriddenTestJob],
             workflows: [
-              { name: 'test-workflow', jobs: [testWorkflowJob, anotherTestWorkflowJob], runOnRelease: true }
+              {
+                name: 'test-workflow',
+                jobs: [dependedWorkflowJob, testWorkflowJob, anotherTestWorkflowJob],
+                runOnRelease: true
+              }
             ]
           })
         }

--- a/plugins/circleci/test/circleci-config.test.ts
+++ b/plugins/circleci/test/circleci-config.test.ts
@@ -50,7 +50,7 @@ const configWithWorkflowJob: CircleCiOptions = {
 }
 
 const configWithPrefixedWorkflowJob: CircleCiOptions = {
-  workflows: [{ name: 'tool-kit', jobs: [testPrefixedWorkflowJob] }],
+  workflows: [{ name: 'tool-kit', jobs: [{ name: 'another/orb', requires: [] }, testPrefixedWorkflowJob] }],
   disableBaseConfig: true
 }
 
@@ -195,6 +195,12 @@ describe('CircleCI config hook', () => {
           "workflows": {
             "tool-kit": {
               "jobs": [
+                {
+                  "another/orb": {
+                    "executor": "node",
+                    "requires": [],
+                  },
+                },
                 {
                   "slack/approval-notification": {
                     "executor": "node",

--- a/plugins/circleci/test/files/unmanaged/with-workflow-job/.circleci/config.yml
+++ b/plugins/circleci/test/files/unmanaged/with-workflow-job/.circleci/config.yml
@@ -1,6 +1,9 @@
 workflows:
   tool-kit:
     jobs:
+      - tool-kit/that-job:
+          requires: []
+          executor: node
       - tool-kit/test-job:
           requires:
             - tool-kit/that-job


### PR DESCRIPTION
# Description

Our initial 4.0 release of Tool Kit only contained minimal support for defining custom jobs in CircleCI. They didn't define the executor the job would run in, resulting in CircleCI validation errors unless they were added explicitly in a `custom` block, so even calling it 'minimal support' might be a stretch. This PR adds proper support for the execution property, as well as adding a `splitIntoMatrix` option to jobs which works the same as it does for workflow jobs. Efforts have also been made to refactor the code so that it's easier to follow.

This now allows us to generate a CircleCI config for next-preflight using Tool Kit config exclusively without manual intervention.

Closes #740, as this PR carries on from the changes made in that PR.

# Checklist:

- [x] My commit messages are [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/), for example: `feat(circleci): add support for nightly workflows`, `fix: set Heroku app name for staging apps too`
