### PR TITLE
fix: stop using chalk as a transitive dependency

### DIFF
--- a/lib/logger/package.json
+++ b/lib/logger/package.json
@@ -26,6 +26,7 @@
     "@apaleslimghost/boxen": "^5.1.3",
     "@dotcom-tool-kit/error": "^4.1.0",
     "ansi-regex": "^5.0.1",
+    "chalk": "^4.1.0",
     "triple-beam": "^1.3.0",
     "tslib": "^2.3.1",
     "winston": "^3.5.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1264,6 +1264,7 @@
         "@apaleslimghost/boxen": "^5.1.3",
         "@dotcom-tool-kit/error": "^4.1.0",
         "ansi-regex": "^5.0.1",
+        "chalk": "^4.1.0",
         "triple-beam": "^1.3.0",
         "tslib": "^2.3.1",
         "winston": "^3.5.1",


### PR DESCRIPTION
The logger module depends on `chalk` however it's not explicitly installed - it's installed by `@apaleslimghost/boxen`. This causes Tool Kit to wrongly depend on a more recent (and ESM only) version of Chalk if a project installs it.

The example I encountered: our project is installing `@commitlint/cli@19.6.1` which depends on `chalk@v5`. Tool Kit, on the other hand, seems to rely on `chalk@v4` transititvely - this version still supports CommonJS.

```
project@0.0.0
├─┬ @commitlint/cli@19.6.1
│ └─┬ @commitlint/format@19.5.0
│   └── chalk@5.4.1
└─┬ @dotcom-tool-kit/circleci@7.3.2
  └─┬ @dotcom-tool-kit/logger@4.1.0
    └─┬ @apaleslimghost/boxen@5.1.3
      └── chalk@4.1.2
```

`@dotcom-tool-kit/logger` imports `chalk` here:
https://github.com/Financial-Times/dotcom-tool-kit/blob/01031177495ac7c483bbcb23b4aa35a6842653d3/lib/logger/src/styles.ts#L1

It seems like, because it's not _explicitly_ a dependency we end up using v5. I get the following error when I run Tool Kit for my project:

```
/project/node_modules/@dotcom-tool-kit/logger/lib/styles.js:315
Error [ERR_REQUIRE_ESM]: require() of ES Module /project/node_modules/chalk/source/index.js from /project/node_modules/@dotcom-tool-kit/logger/lib/styles.js not supported.
Instead change the require of index.js in /project/node_modules/@dotcom-tool-kit/logger/lib/styles.js to a dynamic import() which is available in all CommonJS modules.
    at TracingChannel.traceSync (node:diagnostics_channel:315:14)
    at Object.<anonymous> (/project/node_modules/@dotcom-tool-kit/logger/lib/styles.js:5:41) {
  code: 'ERR_REQUIRE_ESM'
}
```

I'm hopeful that installing `chalk@v4` explicitly will resolve this.

# Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. 

# Checklist:

- [x] My branch has been rebased onto the latest commit on main (don't merge main into your branch)
- [x] My commit messages are [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/), for example: `feat(circleci): add support for nightly workflows`, `fix: set Heroku app name for staging apps too`
