### PR TITLE
Store pushed Docker images in state

### DIFF
--- a/lib/state/src/index.ts
+++ b/lib/state/src/index.ts
@@ -6,12 +6,19 @@ const stateDir = target ? path.join(target, '.toolkitstate') : '.toolkitstate'
 
 type InstallState = Record<string, string>
 
-interface CIState {
+interface DockerImage {
+  fullyQualifiedName: string
+  name: string
+  tag: string
+}
+
+export interface CIState {
   repo: string
   branch: string
   version: string
   tag: string
   buildNumber: string
+  pushedImages: DockerImage[]
 }
 
 export interface ReviewState {

--- a/plugins/docker/src/tasks/build.ts
+++ b/plugins/docker/src/tasks/build.ts
@@ -1,6 +1,7 @@
 import { buildImageName, getImageTagsFromEnvironment } from '../image-info'
 import { DockerSchema } from '@dotcom-tool-kit/schemas/lib/plugins/docker'
 import { hookFork, waitOnExit } from '@dotcom-tool-kit/logger'
+import { readState } from '@dotcom-tool-kit/state'
 import { spawn } from 'node:child_process'
 import { Task } from '@dotcom-tool-kit/base'
 import { ToolKitError } from '@dotcom-tool-kit/error'
@@ -12,7 +13,13 @@ export default class DockerBuild extends Task<{
     // Iterate over different image types like web, worker, etc
     for (const [imageIdentifier, imageOptions] of Object.entries(this.pluginOptions.images)) {
       const imageName = buildImageName(imageOptions)
-      const imageTags = [imageName, ...getImageTagsFromEnvironment(imageOptions)]
+      const imageTags = [
+        imageName,
+        ...getImageTagsFromEnvironment({
+          ciState: readState('ci'),
+          ...imageOptions
+        })
+      ]
       this.logger.info(`Building image "${imageIdentifier}": with tags ${imageTags.join(', ')}`)
       try {
         // We need to create a builder so that we're not limited to


### PR DESCRIPTION
We will need the built image names and tags in order to deploy via Hako. This involved a bit of refactoring of the tag generation so that we weren't duplicating stuff. We're using the CI build number for deploys for now but this can change with no issue later if we change our minds.