### PR TITLE
feat: widen semver range for mocha

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -49,11 +49,11 @@
     },
     "core/cli": {
       "name": "dotcom-tool-kit",
-      "version": "4.3.6",
+      "version": "4.3.7",
       "license": "MIT",
       "dependencies": {
-        "@dotcom-tool-kit/base": "^1.1.5",
-        "@dotcom-tool-kit/config": "^1.0.8",
+        "@dotcom-tool-kit/base": "^1.1.6",
+        "@dotcom-tool-kit/config": "^1.0.9",
         "@dotcom-tool-kit/conflict": "^1.0.0",
         "@dotcom-tool-kit/error": "^4.1.0",
         "@dotcom-tool-kit/logger": "^4.1.1",
@@ -133,16 +133,16 @@
     },
     "core/create": {
       "name": "@dotcom-tool-kit/create",
-      "version": "4.2.6",
+      "version": "4.2.7",
       "license": "ISC",
       "dependencies": {
         "@aws-sdk/client-iam": "^3.282.0",
         "@aws-sdk/client-sts": "^3.282.0",
-        "@dotcom-tool-kit/doppler": "^2.1.3",
+        "@dotcom-tool-kit/doppler": "^2.1.4",
         "@dotcom-tool-kit/error": "^4.1.0",
         "@dotcom-tool-kit/logger": "^4.1.1",
         "@dotcom-tool-kit/plugin": "^1.0.0",
-        "@dotcom-tool-kit/schemas": "^1.6.1",
+        "@dotcom-tool-kit/schemas": "^1.6.2",
         "@octokit/rest": "^19.0.5",
         "@quarterto/parse-makefile-rules": "^1.1.0",
         "cli-highlight": "^2.1.11",
@@ -169,7 +169,7 @@
         "@types/node-fetch": "^2.6.2",
         "@types/pacote": "^11.1.3",
         "@types/prompts": "^2.0.14",
-        "dotcom-tool-kit": "^4.3.6",
+        "dotcom-tool-kit": "^4.3.7",
         "type-fest": "^3.13.1"
       },
       "engines": {
@@ -1100,7 +1100,7 @@
     },
     "lib/base": {
       "name": "@dotcom-tool-kit/base",
-      "version": "1.1.5",
+      "version": "1.1.6",
       "license": "ISC",
       "dependencies": {
         "@dotcom-tool-kit/conflict": "^1.0.0",
@@ -1110,7 +1110,7 @@
         "winston": "^3.11.0"
       },
       "devDependencies": {
-        "@dotcom-tool-kit/config": "^1.0.8",
+        "@dotcom-tool-kit/config": "^1.0.9",
         "@dotcom-tool-kit/plugin": "^1.0.0",
         "type-fest": "^4.29.1",
         "winston": "^3.11.0",
@@ -1200,12 +1200,12 @@
     },
     "lib/config": {
       "name": "@dotcom-tool-kit/config",
-      "version": "1.0.8",
+      "version": "1.0.9",
       "license": "ISC",
       "dependencies": {
         "@dotcom-tool-kit/conflict": "^1.0.0",
         "@dotcom-tool-kit/plugin": "^1.0.0",
-        "@dotcom-tool-kit/schemas": "^1.6.1",
+        "@dotcom-tool-kit/schemas": "^1.6.2",
         "@dotcom-tool-kit/validated": "^1.0.2"
       }
     },
@@ -1219,7 +1219,7 @@
     },
     "lib/doppler": {
       "name": "@dotcom-tool-kit/doppler",
-      "version": "2.1.3",
+      "version": "2.1.4",
       "license": "ISC",
       "dependencies": {
         "@dotcom-tool-kit/error": "^4.1.0",
@@ -1227,7 +1227,7 @@
         "tslib": "^2.3.1"
       },
       "devDependencies": {
-        "@dotcom-tool-kit/schemas": "^1.6.1",
+        "@dotcom-tool-kit/schemas": "^1.6.2",
         "spawk": "^1.8.1",
         "winston": "^3.5.1"
       },
@@ -1324,7 +1324,7 @@
     },
     "lib/schemas": {
       "name": "@dotcom-tool-kit/schemas",
-      "version": "1.6.1",
+      "version": "1.6.2",
       "license": "ISC",
       "dependencies": {
         "@dotcom-tool-kit/logger": "^4.1.1"
@@ -30491,10 +30491,10 @@
     },
     "plugins/babel": {
       "name": "@dotcom-tool-kit/babel",
-      "version": "4.2.3",
+      "version": "4.2.4",
       "license": "MIT",
       "dependencies": {
-        "@dotcom-tool-kit/base": "^1.1.5",
+        "@dotcom-tool-kit/base": "^1.1.6",
         "@dotcom-tool-kit/error": "^4.1.0",
         "@dotcom-tool-kit/logger": "^4.1.1",
         "fast-glob": "^3.2.11",
@@ -30502,7 +30502,7 @@
       },
       "devDependencies": {
         "@babel/preset-env": "^7.16.11",
-        "@dotcom-tool-kit/schemas": "^1.6.1",
+        "@dotcom-tool-kit/schemas": "^1.6.2",
         "@jest/globals": "^27.4.6",
         "winston": "^3.5.1"
       },
@@ -30537,13 +30537,13 @@
     },
     "plugins/backend-heroku-app": {
       "name": "@dotcom-tool-kit/backend-heroku-app",
-      "version": "4.1.3",
+      "version": "4.1.4",
       "license": "ISC",
       "dependencies": {
-        "@dotcom-tool-kit/circleci-deploy": "^4.1.3",
-        "@dotcom-tool-kit/heroku": "^4.1.3",
-        "@dotcom-tool-kit/node": "^4.2.3",
-        "@dotcom-tool-kit/npm": "^4.2.3"
+        "@dotcom-tool-kit/circleci-deploy": "^4.1.4",
+        "@dotcom-tool-kit/heroku": "^4.1.4",
+        "@dotcom-tool-kit/node": "^4.2.4",
+        "@dotcom-tool-kit/npm": "^4.2.4"
       },
       "engines": {
         "node": "18.x || 20.x || 22.x"
@@ -30554,13 +30554,13 @@
     },
     "plugins/backend-serverless-app": {
       "name": "@dotcom-tool-kit/backend-serverless-app",
-      "version": "4.1.3",
+      "version": "4.1.4",
       "license": "ISC",
       "dependencies": {
-        "@dotcom-tool-kit/circleci-deploy": "^4.1.3",
-        "@dotcom-tool-kit/node": "^4.2.3",
-        "@dotcom-tool-kit/npm": "^4.2.3",
-        "@dotcom-tool-kit/serverless": "^3.2.3"
+        "@dotcom-tool-kit/circleci-deploy": "^4.1.4",
+        "@dotcom-tool-kit/node": "^4.2.4",
+        "@dotcom-tool-kit/npm": "^4.2.4",
+        "@dotcom-tool-kit/serverless": "^3.2.4"
       },
       "engines": {
         "node": "18.x || 20.x || 22.x"
@@ -30571,10 +30571,10 @@
     },
     "plugins/circleci": {
       "name": "@dotcom-tool-kit/circleci",
-      "version": "7.3.3",
+      "version": "7.3.4",
       "license": "ISC",
       "dependencies": {
-        "@dotcom-tool-kit/base": "^1.1.5",
+        "@dotcom-tool-kit/base": "^1.1.6",
         "@dotcom-tool-kit/conflict": "^1.0.0",
         "@dotcom-tool-kit/error": "^4.1.0",
         "@dotcom-tool-kit/logger": "^4.1.1",
@@ -30587,7 +30587,7 @@
       },
       "devDependencies": {
         "@dotcom-tool-kit/plugin": "^1.0.0",
-        "@dotcom-tool-kit/schemas": "^1.6.1",
+        "@dotcom-tool-kit/schemas": "^1.6.2",
         "@jest/globals": "^27.4.6",
         "@types/jest": "^27.4.0",
         "@types/js-yaml": "^4.0.3",
@@ -30605,10 +30605,10 @@
     },
     "plugins/circleci-deploy": {
       "name": "@dotcom-tool-kit/circleci-deploy",
-      "version": "4.1.3",
+      "version": "4.1.4",
       "license": "ISC",
       "dependencies": {
-        "@dotcom-tool-kit/circleci": "^7.3.3",
+        "@dotcom-tool-kit/circleci": "^7.3.4",
         "tslib": "^2.3.1"
       },
       "devDependencies": {
@@ -30646,11 +30646,11 @@
     },
     "plugins/circleci-npm": {
       "name": "@dotcom-tool-kit/circleci-npm",
-      "version": "6.1.3",
+      "version": "6.1.4",
       "license": "ISC",
       "dependencies": {
-        "@dotcom-tool-kit/circleci": "^7.3.3",
-        "@dotcom-tool-kit/npm": "^4.2.3",
+        "@dotcom-tool-kit/circleci": "^7.3.4",
+        "@dotcom-tool-kit/npm": "^4.2.4",
         "tslib": "^2.3.1"
       },
       "engines": {
@@ -30778,10 +30778,10 @@
     },
     "plugins/commitlint": {
       "name": "@dotcom-tool-kit/commitlint",
-      "version": "1.2.3",
+      "version": "1.2.4",
       "license": "ISC",
       "dependencies": {
-        "@dotcom-tool-kit/base": "^1.1.5",
+        "@dotcom-tool-kit/base": "^1.1.6",
         "@dotcom-tool-kit/logger": "^4.1.1"
       },
       "engines": {
@@ -31491,11 +31491,11 @@
     },
     "plugins/component": {
       "name": "@dotcom-tool-kit/component",
-      "version": "5.1.3",
+      "version": "5.1.4",
       "license": "ISC",
       "dependencies": {
-        "@dotcom-tool-kit/circleci-npm": "^6.1.3",
-        "@dotcom-tool-kit/npm": "^4.2.3"
+        "@dotcom-tool-kit/circleci-npm": "^6.1.4",
+        "@dotcom-tool-kit/npm": "^4.2.4"
       },
       "engines": {
         "node": "18.x || 20.x || 22.x"
@@ -31506,17 +31506,17 @@
     },
     "plugins/cypress": {
       "name": "@dotcom-tool-kit/cypress",
-      "version": "5.2.3",
+      "version": "5.2.4",
       "license": "ISC",
       "dependencies": {
-        "@dotcom-tool-kit/base": "^1.1.5",
-        "@dotcom-tool-kit/doppler": "^2.1.3",
+        "@dotcom-tool-kit/base": "^1.1.6",
+        "@dotcom-tool-kit/doppler": "^2.1.4",
         "@dotcom-tool-kit/logger": "^4.1.1",
-        "@dotcom-tool-kit/package-json-hook": "^5.1.3",
+        "@dotcom-tool-kit/package-json-hook": "^5.1.4",
         "@dotcom-tool-kit/state": "^4.1.0"
       },
       "devDependencies": {
-        "@dotcom-tool-kit/schemas": "^1.6.1"
+        "@dotcom-tool-kit/schemas": "^1.6.2"
       },
       "engines": {
         "node": "18.x || 20.x || 22.x"
@@ -31527,17 +31527,17 @@
     },
     "plugins/docker": {
       "name": "@dotcom-tool-kit/docker",
-      "version": "0.2.1",
+      "version": "0.2.2",
       "license": "ISC",
       "dependencies": {
-        "@dotcom-tool-kit/base": "^1.1.5",
+        "@dotcom-tool-kit/base": "^1.1.6",
         "@dotcom-tool-kit/error": "^4.1.0",
         "@dotcom-tool-kit/logger": "^4.1.1",
         "@dotcom-tool-kit/state": "^4.1.0",
         "tslib": "^2.3.1"
       },
       "devDependencies": {
-        "@dotcom-tool-kit/schemas": "^1.6.1"
+        "@dotcom-tool-kit/schemas": "^1.6.2"
       },
       "engines": {
         "node": "18.x || 20.x || 22.x"
@@ -31557,16 +31557,16 @@
     },
     "plugins/eslint": {
       "name": "@dotcom-tool-kit/eslint",
-      "version": "4.2.3",
+      "version": "4.2.4",
       "license": "ISC",
       "dependencies": {
-        "@dotcom-tool-kit/base": "^1.1.5",
+        "@dotcom-tool-kit/base": "^1.1.6",
         "@dotcom-tool-kit/error": "^4.1.0",
         "@dotcom-tool-kit/logger": "^4.1.1",
         "tslib": "^2.3.1"
       },
       "devDependencies": {
-        "@dotcom-tool-kit/schemas": "^1.6.1",
+        "@dotcom-tool-kit/schemas": "^1.6.2",
         "@jest/globals": "^27.4.6",
         "@types/eslint": "^7.2.13",
         "@types/temp": "^0.9.4",
@@ -31781,12 +31781,12 @@
     },
     "plugins/frontend-app": {
       "name": "@dotcom-tool-kit/frontend-app",
-      "version": "4.1.3",
+      "version": "4.1.4",
       "license": "ISC",
       "dependencies": {
-        "@dotcom-tool-kit/backend-heroku-app": "^4.1.3",
-        "@dotcom-tool-kit/upload-assets-to-s3": "^4.2.3",
-        "@dotcom-tool-kit/webpack": "^4.2.3"
+        "@dotcom-tool-kit/backend-heroku-app": "^4.1.4",
+        "@dotcom-tool-kit/upload-assets-to-s3": "^4.2.4",
+        "@dotcom-tool-kit/webpack": "^4.2.4"
       },
       "engines": {
         "node": "18.x || 20.x || 22.x"
@@ -31797,15 +31797,15 @@
     },
     "plugins/heroku": {
       "name": "@dotcom-tool-kit/heroku",
-      "version": "4.1.3",
+      "version": "4.1.4",
       "license": "ISC",
       "dependencies": {
-        "@dotcom-tool-kit/base": "^1.1.5",
-        "@dotcom-tool-kit/doppler": "^2.1.3",
+        "@dotcom-tool-kit/base": "^1.1.6",
+        "@dotcom-tool-kit/doppler": "^2.1.4",
         "@dotcom-tool-kit/error": "^4.1.0",
         "@dotcom-tool-kit/logger": "^4.1.1",
-        "@dotcom-tool-kit/npm": "^4.2.3",
-        "@dotcom-tool-kit/package-json-hook": "^5.1.3",
+        "@dotcom-tool-kit/npm": "^4.2.4",
+        "@dotcom-tool-kit/package-json-hook": "^5.1.4",
         "@dotcom-tool-kit/state": "^4.1.0",
         "@dotcom-tool-kit/wait-for-ok": "^4.1.0",
         "@octokit/request": "^8.4.0",
@@ -31816,7 +31816,7 @@
         "tslib": "^2.3.1"
       },
       "devDependencies": {
-        "@dotcom-tool-kit/schemas": "^1.6.1",
+        "@dotcom-tool-kit/schemas": "^1.6.2",
         "@types/financial-times__package-json": "^1.9.0",
         "@types/p-retry": "^3.0.1",
         "winston": "^3.5.1"
@@ -31887,10 +31887,10 @@
     },
     "plugins/husky-npm": {
       "name": "@dotcom-tool-kit/husky-npm",
-      "version": "5.1.3",
+      "version": "5.1.4",
       "license": "ISC",
       "dependencies": {
-        "@dotcom-tool-kit/package-json-hook": "^5.1.3",
+        "@dotcom-tool-kit/package-json-hook": "^5.1.4",
         "tslib": "^2.3.1"
       },
       "engines": {
@@ -31908,15 +31908,15 @@
     },
     "plugins/jest": {
       "name": "@dotcom-tool-kit/jest",
-      "version": "4.2.3",
+      "version": "4.2.4",
       "license": "ISC",
       "dependencies": {
-        "@dotcom-tool-kit/base": "^1.1.5",
+        "@dotcom-tool-kit/base": "^1.1.6",
         "@dotcom-tool-kit/logger": "^4.1.1",
         "tslib": "^2.3.1"
       },
       "devDependencies": {
-        "@dotcom-tool-kit/schemas": "^1.6.1",
+        "@dotcom-tool-kit/schemas": "^1.6.2",
         "winston": "^3.5.1"
       },
       "engines": {
@@ -31934,12 +31934,12 @@
     },
     "plugins/lint-staged": {
       "name": "@dotcom-tool-kit/lint-staged",
-      "version": "5.2.3",
+      "version": "5.2.4",
       "license": "ISC",
       "dependencies": {
-        "@dotcom-tool-kit/base": "^1.1.5",
+        "@dotcom-tool-kit/base": "^1.1.6",
         "@dotcom-tool-kit/logger": "^4.1.1",
-        "@dotcom-tool-kit/package-json-hook": "^5.1.3",
+        "@dotcom-tool-kit/package-json-hook": "^5.1.4",
         "lint-staged": "^11.2.3",
         "tslib": "^2.3.1"
       },
@@ -31952,12 +31952,12 @@
     },
     "plugins/lint-staged-npm": {
       "name": "@dotcom-tool-kit/lint-staged-npm",
-      "version": "4.1.3",
+      "version": "4.1.4",
       "license": "ISC",
       "dependencies": {
-        "@dotcom-tool-kit/husky-npm": "^5.1.3",
-        "@dotcom-tool-kit/lint-staged": "^5.2.3",
-        "@dotcom-tool-kit/package-json-hook": "^5.1.3",
+        "@dotcom-tool-kit/husky-npm": "^5.1.4",
+        "@dotcom-tool-kit/lint-staged": "^5.2.4",
+        "@dotcom-tool-kit/package-json-hook": "^5.1.4",
         "tslib": "^2.3.1"
       },
       "engines": {
@@ -32029,17 +32029,17 @@
     },
     "plugins/mocha": {
       "name": "@dotcom-tool-kit/mocha",
-      "version": "4.2.3",
+      "version": "4.2.4",
       "license": "ISC",
       "dependencies": {
-        "@dotcom-tool-kit/base": "^1.1.5",
+        "@dotcom-tool-kit/base": "^1.1.6",
         "@dotcom-tool-kit/error": "^4.1.0",
         "@dotcom-tool-kit/logger": "^4.1.1",
         "glob": "^7.1.7",
         "tslib": "^2.3.1"
       },
       "devDependencies": {
-        "@dotcom-tool-kit/schemas": "^1.6.1",
+        "@dotcom-tool-kit/schemas": "^1.6.2",
         "@jest/globals": "^27.4.6",
         "@types/glob": "^7.1.3",
         "@types/mocha": "^8.2.2",
@@ -32050,7 +32050,7 @@
       },
       "peerDependencies": {
         "dotcom-tool-kit": "4.x",
-        "mocha": ">=6.x <=10.x"
+        "mocha": ">=6.x <=11.x"
       }
     },
     "plugins/mocha/node_modules/tslib": {
@@ -32063,10 +32063,10 @@
     },
     "plugins/n-test": {
       "name": "@dotcom-tool-kit/n-test",
-      "version": "4.2.4",
+      "version": "4.2.5",
       "license": "ISC",
       "dependencies": {
-        "@dotcom-tool-kit/base": "^1.1.5",
+        "@dotcom-tool-kit/base": "^1.1.6",
         "@dotcom-tool-kit/error": "^4.1.0",
         "@dotcom-tool-kit/logger": "^4.1.1",
         "@dotcom-tool-kit/state": "^4.1.0",
@@ -32074,7 +32074,7 @@
         "tslib": "^2.3.1"
       },
       "devDependencies": {
-        "@dotcom-tool-kit/schemas": "^1.6.1",
+        "@dotcom-tool-kit/schemas": "^1.6.2",
         "@jest/globals": "^27.4.6",
         "@types/jest": "^27.4.0",
         "winston": "^3.5.1"
@@ -32185,11 +32185,11 @@
     },
     "plugins/next-router": {
       "name": "@dotcom-tool-kit/next-router",
-      "version": "4.2.3",
+      "version": "4.2.4",
       "license": "ISC",
       "dependencies": {
-        "@dotcom-tool-kit/base": "^1.1.5",
-        "@dotcom-tool-kit/doppler": "^2.1.3",
+        "@dotcom-tool-kit/base": "^1.1.6",
+        "@dotcom-tool-kit/doppler": "^2.1.4",
         "@dotcom-tool-kit/error": "^4.1.0",
         "@dotcom-tool-kit/logger": "^4.1.1",
         "@dotcom-tool-kit/state": "^4.1.0",
@@ -32197,7 +32197,7 @@
         "tslib": "^2.3.1"
       },
       "devDependencies": {
-        "@dotcom-tool-kit/schemas": "^1.6.1"
+        "@dotcom-tool-kit/schemas": "^1.6.2"
       },
       "engines": {
         "node": "18.x || 20.x || 22.x"
@@ -32318,11 +32318,11 @@
     },
     "plugins/node": {
       "name": "@dotcom-tool-kit/node",
-      "version": "4.2.3",
+      "version": "4.2.4",
       "license": "ISC",
       "dependencies": {
-        "@dotcom-tool-kit/base": "^1.1.5",
-        "@dotcom-tool-kit/doppler": "^2.1.3",
+        "@dotcom-tool-kit/base": "^1.1.6",
+        "@dotcom-tool-kit/doppler": "^2.1.4",
         "@dotcom-tool-kit/error": "^4.1.0",
         "@dotcom-tool-kit/state": "^4.1.0",
         "get-port": "^5.1.1",
@@ -32330,7 +32330,7 @@
         "wait-port": "^0.2.9"
       },
       "devDependencies": {
-        "@dotcom-tool-kit/schemas": "^1.6.1"
+        "@dotcom-tool-kit/schemas": "^1.6.2"
       },
       "engines": {
         "node": "18.x || 20.x || 22.x"
@@ -32346,18 +32346,18 @@
     },
     "plugins/nodemon": {
       "name": "@dotcom-tool-kit/nodemon",
-      "version": "4.1.3",
+      "version": "4.1.4",
       "license": "ISC",
       "dependencies": {
-        "@dotcom-tool-kit/base": "^1.1.5",
-        "@dotcom-tool-kit/doppler": "^2.1.3",
+        "@dotcom-tool-kit/base": "^1.1.6",
+        "@dotcom-tool-kit/doppler": "^2.1.4",
         "@dotcom-tool-kit/error": "^4.1.0",
         "@dotcom-tool-kit/state": "^4.1.0",
         "get-port": "^5.1.1",
         "tslib": "^2.3.1"
       },
       "devDependencies": {
-        "@dotcom-tool-kit/schemas": "^1.6.1",
+        "@dotcom-tool-kit/schemas": "^1.6.2",
         "@types/nodemon": "^1.19.1"
       },
       "engines": {
@@ -32375,12 +32375,12 @@
     },
     "plugins/npm": {
       "name": "@dotcom-tool-kit/npm",
-      "version": "4.2.3",
+      "version": "4.2.4",
       "license": "ISC",
       "dependencies": {
-        "@dotcom-tool-kit/base": "^1.1.5",
+        "@dotcom-tool-kit/base": "^1.1.6",
         "@dotcom-tool-kit/error": "^4.1.0",
-        "@dotcom-tool-kit/package-json-hook": "^5.1.3",
+        "@dotcom-tool-kit/package-json-hook": "^5.1.4",
         "@dotcom-tool-kit/state": "^4.1.0",
         "libnpmpack": "^3.1.0",
         "libnpmpublish": "^5.0.1",
@@ -32611,10 +32611,10 @@
     },
     "plugins/package-json-hook": {
       "name": "@dotcom-tool-kit/package-json-hook",
-      "version": "5.1.3",
+      "version": "5.1.4",
       "license": "ISC",
       "dependencies": {
-        "@dotcom-tool-kit/base": "^1.1.5",
+        "@dotcom-tool-kit/base": "^1.1.6",
         "@dotcom-tool-kit/conflict": "^1.0.0",
         "@dotcom-tool-kit/plugin": "^1.0.0",
         "@financial-times/package-json": "^3.0.0",
@@ -32622,7 +32622,7 @@
         "tslib": "^2.3.1"
       },
       "devDependencies": {
-        "@dotcom-tool-kit/schemas": "^1.6.1",
+        "@dotcom-tool-kit/schemas": "^1.6.2",
         "@jest/globals": "^27.4.6",
         "@types/lodash": "^4.14.185",
         "winston": "^3.5.1",
@@ -32645,13 +32645,13 @@
     },
     "plugins/prettier": {
       "name": "@dotcom-tool-kit/prettier",
-      "version": "4.2.3",
+      "version": "4.2.4",
       "license": "ISC",
       "dependencies": {
-        "@dotcom-tool-kit/base": "^1.1.5",
+        "@dotcom-tool-kit/base": "^1.1.6",
         "@dotcom-tool-kit/error": "^4.1.0",
         "@dotcom-tool-kit/logger": "^4.1.1",
-        "@dotcom-tool-kit/package-json-hook": "^5.1.3",
+        "@dotcom-tool-kit/package-json-hook": "^5.1.4",
         "fast-glob": "^3.2.7",
         "hook-std": "^2.0.0",
         "prettier": "^2.2.1",
@@ -32700,11 +32700,11 @@
     },
     "plugins/serverless": {
       "name": "@dotcom-tool-kit/serverless",
-      "version": "3.2.3",
+      "version": "3.2.4",
       "license": "ISC",
       "dependencies": {
-        "@dotcom-tool-kit/base": "^1.1.5",
-        "@dotcom-tool-kit/doppler": "^2.1.3",
+        "@dotcom-tool-kit/base": "^1.1.6",
+        "@dotcom-tool-kit/doppler": "^2.1.4",
         "@dotcom-tool-kit/error": "^4.1.0",
         "@dotcom-tool-kit/state": "^4.1.0",
         "get-port": "^5.1.1",
@@ -32712,7 +32712,7 @@
         "wait-port": "^0.2.9"
       },
       "devDependencies": {
-        "@dotcom-tool-kit/schemas": "^1.6.1"
+        "@dotcom-tool-kit/schemas": "^1.6.2"
       },
       "engines": {
         "node": "18.x || 20.x || 22.x"
@@ -32729,14 +32729,14 @@
     },
     "plugins/typescript": {
       "name": "@dotcom-tool-kit/typescript",
-      "version": "3.2.3",
+      "version": "3.2.4",
       "license": "ISC",
       "dependencies": {
-        "@dotcom-tool-kit/base": "^1.1.5",
+        "@dotcom-tool-kit/base": "^1.1.6",
         "@dotcom-tool-kit/logger": "^4.1.1"
       },
       "devDependencies": {
-        "@dotcom-tool-kit/schemas": "^1.6.1",
+        "@dotcom-tool-kit/schemas": "^1.6.2",
         "@jest/globals": "^29.3.1",
         "typescript": "^4.9.4",
         "winston": "^3.8.2"
@@ -32950,11 +32950,11 @@
     },
     "plugins/upload-assets-to-s3": {
       "name": "@dotcom-tool-kit/upload-assets-to-s3",
-      "version": "4.2.3",
+      "version": "4.2.4",
       "license": "ISC",
       "dependencies": {
         "@aws-sdk/client-s3": "^3.256.0",
-        "@dotcom-tool-kit/base": "^1.1.5",
+        "@dotcom-tool-kit/base": "^1.1.6",
         "@dotcom-tool-kit/error": "^4.1.0",
         "@dotcom-tool-kit/logger": "^4.1.1",
         "glob": "^7.1.6",
@@ -32963,7 +32963,7 @@
       },
       "devDependencies": {
         "@aws-sdk/types": "^3.13.1",
-        "@dotcom-tool-kit/schemas": "^1.6.1",
+        "@dotcom-tool-kit/schemas": "^1.6.2",
         "@jest/globals": "^27.4.6",
         "@types/glob": "^7.1.3",
         "@types/jest": "^27.4.0",
@@ -32984,17 +32984,17 @@
     },
     "plugins/webpack": {
       "name": "@dotcom-tool-kit/webpack",
-      "version": "4.2.3",
+      "version": "4.2.4",
       "license": "MIT",
       "dependencies": {
-        "@dotcom-tool-kit/base": "^1.1.5",
+        "@dotcom-tool-kit/base": "^1.1.6",
         "@dotcom-tool-kit/error": "^4.1.0",
         "@dotcom-tool-kit/logger": "^4.1.1",
         "tslib": "^2.3.1",
         "webpack-cli": "^4.6.0"
       },
       "devDependencies": {
-        "@dotcom-tool-kit/schemas": "^1.6.1",
+        "@dotcom-tool-kit/schemas": "^1.6.2",
         "@jest/globals": "^27.4.6",
         "ts-node": "^10.0.0",
         "webpack": "^4.42.1",

--- a/plugins/mocha/package.json
+++ b/plugins/mocha/package.json
@@ -39,7 +39,7 @@
   },
   "peerDependencies": {
     "dotcom-tool-kit": "4.x",
-    "mocha": ">=6.x <=10.x"
+    "mocha": ">=6.x <=11.x"
   },
   "engines": {
     "node": "18.x || 20.x || 22.x"


### PR DESCRIPTION
# Description

mocha v11 has only one breaking change - dropping support for Node.js 14 and 16. We should widen the version range to allow our projects to use it.

# Checklist:

- [x] My branch has been rebased onto the latest commit on main (don't merge main into your branch)
- [x] My commit messages are [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/), for example: `feat(circleci): add support for nightly workflows`, `fix: set Heroku app name for staging apps too`
