### PR TITLE
backstage: remove check-engine preinstall script

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,8 +9,7 @@
     "clean-up-packages": "./scripts/clean-up-packages.sh",
     "build": "tsc --build --verbose tsconfig.json",
     "watch": "tsc --build --watch --verbose tsconfig.json",
-    "test": "jest --silent --runInBand",
-    "preinstall": "[ \"$INIT_CWD\" != \"$PWD\" ] || npm_config_yes=true npx check-engine"
+    "test": "jest --silent --runInBand"
   },
   "lint-staged": {
     "**/*.{ts,js,json}": "prettier --write",


### PR DESCRIPTION
# Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. 

# Checklist:

- [ ] My branch has been rebased onto the latest commit on main (don't merge main into your branch)
- [ ] My commit messages are [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/), for example: `feat(circleci): add support for nightly workflows`, `fix: set Heroku app name for staging apps too`
