### PR TITLE
Automatically use latest patch version of cloudsmith-oidc orb in our own orb

### DIFF
--- a/orb/src/@orb.yml
+++ b/orb/src/@orb.yml
@@ -6,13 +6,13 @@ description: >
 
 # This information will be displayed in the orb registry and is not mandatory.
 display:
-  home_url: "https://www.ft.com"
-  source_url: "https://www.github.com/financial-times/dotcom-tool-kit"
+  home_url: 'https://www.ft.com'
+  source_url: 'https://www.github.com/financial-times/dotcom-tool-kit'
 
 # If your orb requires other orbs, you can import them like this. Otherwise remove the "orbs" stanza.
 orbs:
   node: circleci/node@5.0.2
   change-api: financial-times/change-api@1.0.9
-  cloudsmith-oidc: ft-circleci-orbs/cloudsmith-oidc@1.0.0
+  cloudsmith-oidc: ft-circleci-orbs/cloudsmith-oidc@1.0
   aws-cli: circleci/aws-cli@3.1.4
   serverless-framework: circleci/serverless-framework@2.0.2


### PR DESCRIPTION
# Description

Code Management just pushed out a hotfix for the orb to account for an API change with Cloudsmith. Let's not specify the patch version when specifying their orb so that CircleCI will always use the latest patch (of the pinned minor version.)

Code Management [suggested](https://financialtimes.enterprise.slack.com/archives/C02ST9MNV0S/p1738008489052549) to do this themselves so we can assume they'll respect semver guidelines. 

# Checklist:

- [x] My branch has been rebased onto the latest commit on main (don't merge main into your branch)
- [x] My commit messages are [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/), for example: `feat(circleci): add support for nightly workflows`, `fix: set Heroku app name for staging apps too`
