### PR TITLE
feat!: move docker auth to a new task

### DIFF
--- a/plugins/docker/.toolkitrc.yml
+++ b/plugins/docker/.toolkitrc.yml
@@ -1,4 +1,5 @@
 tasks:
+  DockerAuthCloudsmith: './lib/tasks/auth-cloudsmith'
   DockerBuild: './lib/tasks/build'
   DockerPush: './lib/tasks/push'
 

--- a/plugins/docker/src/tasks/auth-cloudsmith.ts
+++ b/plugins/docker/src/tasks/auth-cloudsmith.ts
@@ -1,0 +1,37 @@
+import { hookFork, waitOnExit } from '@dotcom-tool-kit/logger'
+import { spawn } from 'node:child_process'
+import { Task } from '@dotcom-tool-kit/base'
+import { ToolKitError } from '@dotcom-tool-kit/error'
+
+export default class DockerAuthCloudsmith extends Task {
+  async run() {
+    try {
+      const auth = {
+        username: process.env.CLOUDSMITH_SERVICE_ACCOUNT,
+        password: process.env.CLOUDSMITH_OIDC_TOKEN,
+        registry: 'docker.packages.ft.com'
+      }
+
+      if (!auth.username || !auth.password) {
+        throw new Error(
+          'No CloudSmith service account found. Install @dotcom-tool-kit/cloudsmith and use the serviceAccount option'
+        )
+      }
+
+      const child = spawn('docker', ['login', '--username', auth.username, '--password-stdin', auth.registry])
+      child.stdin.setDefaultEncoding('utf-8')
+      child.stdin.write(auth.password)
+      child.stdin.end()
+      hookFork(this.logger, 'docker-login', child)
+      await waitOnExit('docker-login', child)
+    } catch (err) {
+      if (err instanceof Error) {
+        const error = new ToolKitError('docker auth with cloudsmith failed to run')
+        error.details = err.message
+        throw error
+      } else {
+        throw err
+      }
+    }
+  }
+}


### PR DESCRIPTION
# Description

We hit an annoying roadblock here. Because all the auth is done as part of the `DockerPush` task, we aren't authenticated when we try to pull a built image as part of the production deploy.

I think it's sensible to pull the auth out of the `DockerPush` task. Unfortunately this is a breaking change, but that's why we went with an `0.1.0` release originally.

# Checklist:

- [x] My branch has been rebased onto the latest commit on main (don't merge main into your branch)
- [x] My commit messages are [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/), for example: `feat(circleci): add support for nightly workflows`, `fix: set Heroku app name for staging apps too`
