### PR TITLE
fix: use a new "docker" state for pushed images

### DIFF
--- a/lib/state/src/index.ts
+++ b/lib/state/src/index.ts
@@ -24,8 +24,11 @@ export interface CIState {
   version: string
   tag: string
   buildNumber: string
-  pushedImages: DockerImage[]
   awsCredentials: AwsCredentials
+}
+
+export interface DockerState {
+  pushedImages: DockerImage[]
 }
 
 export interface ReviewState {
@@ -52,6 +55,7 @@ interface LocalState {
 
 export interface State {
   ci: CIState
+  docker: DockerState
   review: ReviewState
   staging: StagingState
   production: ProductionState

--- a/plugins/docker/src/tasks/push.ts
+++ b/plugins/docker/src/tasks/push.ts
@@ -36,6 +36,6 @@ export default class DockerPush extends Task<{
       }
     }
 
-    writeState('ci', { pushedImages })
+    writeState('docker', { pushedImages })
   }
 }

--- a/plugins/hako/src/tasks/deploy.ts
+++ b/plugins/hako/src/tasks/deploy.ts
@@ -15,9 +15,8 @@ export default class HakoDeploy extends Task<{ task: typeof HakoDeploySchema }> 
   async run() {
     this.logger.info('Deploying to Hako')
     try {
-      const ciState = readState('ci')
-      const awsCredentials = ciState?.awsCredentials || {}
-      const pushedImages = ciState?.pushedImages || []
+      const awsCredentials = readState('ci')?.awsCredentials || {}
+      const pushedImages = readState('docker')?.pushedImages || []
       const deployEnvironments = this.options.environments
 
       if (!awsCredentials.accessKeyId || !awsCredentials.secretAccessKey || !awsCredentials.sessionToken) {

--- a/plugins/hako/src/tasks/deploy.ts
+++ b/plugins/hako/src/tasks/deploy.ts
@@ -15,8 +15,8 @@ export default class HakoDeploy extends Task<{ task: typeof HakoDeploySchema }> 
   async run() {
     this.logger.info('Deploying to Hako')
     try {
-      const awsCredentials = readState('ci')?.awsCredentials || {}
-      const pushedImages = readState('docker')?.pushedImages || []
+      const awsCredentials = readState('ci')?.awsCredentials ?? {}
+      const pushedImages = readState('docker')?.pushedImages ?? []
       const deployEnvironments = this.options.environments
 
       if (!awsCredentials.accessKeyId || !awsCredentials.secretAccessKey || !awsCredentials.sessionToken) {


### PR DESCRIPTION
# Description

We were seeing some issues with using "ci" state because it's written to in multiple jobs - we can't rely on docker images being available when we reach deploy-prod.

# Checklist:

- [x] My branch has been rebased onto the latest commit on main (don't merge main into your branch)
- [x] My commit messages are [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/), for example: `feat(circleci): add support for nightly workflows`, `fix: set Heroku app name for staging apps too`
