### PR TITLE
Use correct Tool Kit workspace commands in CircleCI jobs

### DIFF
--- a/plugins/circleci-deploy/test/__snapshots__/circleci-deploy.test.ts.snap
+++ b/plugins/circleci-deploy/test/__snapshots__/circleci-deploy.test.ts.snap
@@ -14,10 +14,8 @@ jobs:
       - image: cimg/base:stable
     steps:
       - checkout
-      - persist_to_workspace:
-          root: .
-          paths:
-            - .
+      - tool-kit/persist-workspace:
+          path: .
 workflows:
   tool-kit:
     when:

--- a/plugins/circleci-npm/test/__snapshots__/circleci-npm.test.ts.snap
+++ b/plugins/circleci-npm/test/__snapshots__/circleci-npm.test.ts.snap
@@ -14,10 +14,8 @@ jobs:
       - image: cimg/base:stable
     steps:
       - checkout
-      - persist_to_workspace:
-          root: .
-          paths:
-            - .
+      - tool-kit/persist-workspace:
+          path: .
 workflows:
   tool-kit:
     when:

--- a/plugins/circleci/src/circleci-config.ts
+++ b/plugins/circleci/src/circleci-config.ts
@@ -480,17 +480,12 @@ const generateWorkflowJobs = (
 }
 
 const persistWorkspaceStep = {
-  persist_to_workspace: {
-    root: '.',
-    paths: ['.']
+  'tool-kit/persist-workspace': {
+    path: '.'
   }
 }
 
-const attachWorkspaceStep = {
-  'attach-workspace': {
-    at: '.'
-  }
-}
+const attachWorkspaceStep = 'tool-kit/attach-workspace'
 
 const generateJob = (job: CircleCiJob, nodeVersions: string[]): JobConfig => ({
   ...((job.splitIntoMatrix ?? true) && nodeVersions.length > 1

--- a/plugins/circleci/test/__snapshots__/circleci-config.test.ts.snap
+++ b/plugins/circleci/test/__snapshots__/circleci-config.test.ts.snap
@@ -14,10 +14,8 @@ jobs:
       - image: cimg/base:stable
     steps:
       - checkout
-      - persist_to_workspace:
-          root: .
-          paths:
-            - .
+      - tool-kit/persist-workspace:
+          path: .
 workflows:
   tool-kit:
     when:

--- a/plugins/circleci/test/circleci-config.test.ts
+++ b/plugins/circleci/test/circleci-config.test.ts
@@ -166,11 +166,7 @@ describe('CircleCI config hook', () => {
             "test-job": {
               "executor": "node",
               "steps": [
-                {
-                  "attach-workspace": {
-                    "at": ".",
-                  },
-                },
+                "tool-kit/attach-workspace",
                 {
                   "run": {
                     "command": "npx dotcom-tool-kit test:local",
@@ -178,11 +174,8 @@ describe('CircleCI config hook', () => {
                   },
                 },
                 {
-                  "persist_to_workspace": {
-                    "paths": [
-                      ".",
-                    ],
-                    "root": ".",
+                  "tool-kit/persist-workspace": {
+                    "path": ".",
                   },
                 },
               ],
@@ -244,11 +237,7 @@ describe('CircleCI config hook', () => {
             "test-job": {
               "executor": "node",
               "steps": [
-                {
-                  "attach-workspace": {
-                    "at": ".",
-                  },
-                },
+                "tool-kit/attach-workspace",
                 {
                   "run": {
                     "command": "npx dotcom-tool-kit test:local",
@@ -256,11 +245,8 @@ describe('CircleCI config hook', () => {
                   },
                 },
                 {
-                  "persist_to_workspace": {
-                    "paths": [
-                      ".",
-                    ],
-                    "root": ".",
+                  "tool-kit/persist-workspace": {
+                    "path": ".",
                   },
                 },
               ],


### PR DESCRIPTION
# Description

The persistence job step that is installed into custom jobs was calling CircleCI's `persist_to_workspace` command directly rather than the Tool Kit orb abstraction, and the attachment job step was doing the same except with the kebab casing of the Tool Kit command's name which meant it would create an invalid config file. Using the commands directly may have originally been intended as a step towards removing our use of the Tool Kit orb, but this is no longer a change that is currently planned.

This hasn't caused any problems as of yet as the attachment command is only installed for custom jobs which aren't particularly used currently.

# Checklist:

- [x] My branch has been rebased onto the latest commit on main (don't merge main into your branch)
- [x] My commit messages are [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/), for example: `feat(circleci): add support for nightly workflows`, `fix: set Heroku app name for staging apps too`
