### PR TITLE
Fix reference to old entry point field name in generate-docs script

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -48,15 +48,15 @@
     },
     "core/cli": {
       "name": "dotcom-tool-kit",
-      "version": "4.4.3",
+      "version": "4.5.0",
       "license": "MIT",
       "dependencies": {
-        "@dotcom-tool-kit/base": "^1.1.9",
-        "@dotcom-tool-kit/config": "^1.0.12",
-        "@dotcom-tool-kit/conflict": "^1.0.0",
+        "@dotcom-tool-kit/base": "^1.1.10",
+        "@dotcom-tool-kit/config": "^1.1.0",
+        "@dotcom-tool-kit/conflict": "^1.0.1",
         "@dotcom-tool-kit/error": "^4.1.0",
         "@dotcom-tool-kit/logger": "^4.1.1",
-        "@dotcom-tool-kit/plugin": "^1.0.0",
+        "@dotcom-tool-kit/plugin": "^1.1.0",
         "@dotcom-tool-kit/schemas": "^1.9.0",
         "@dotcom-tool-kit/state": "^4.3.1",
         "@dotcom-tool-kit/validated": "^1.0.2",
@@ -1133,18 +1133,18 @@
     },
     "lib/base": {
       "name": "@dotcom-tool-kit/base",
-      "version": "1.1.9",
+      "version": "1.1.10",
       "license": "ISC",
       "dependencies": {
-        "@dotcom-tool-kit/conflict": "^1.0.0",
+        "@dotcom-tool-kit/conflict": "^1.0.1",
         "@dotcom-tool-kit/logger": "^4.1.1",
         "@dotcom-tool-kit/validated": "^1.0.2",
         "semver": "^7.5.4",
         "winston": "^3.11.0"
       },
       "devDependencies": {
-        "@dotcom-tool-kit/config": "^1.0.12",
-        "@dotcom-tool-kit/plugin": "^1.0.0",
+        "@dotcom-tool-kit/config": "^1.1.0",
+        "@dotcom-tool-kit/plugin": "^1.1.0",
         "type-fest": "^4.29.1",
         "winston": "^3.11.0",
         "zod": "^3.22.4"
@@ -1233,25 +1233,25 @@
     },
     "lib/config": {
       "name": "@dotcom-tool-kit/config",
-      "version": "1.0.12",
+      "version": "1.1.0",
       "license": "ISC",
       "dependencies": {
-        "@dotcom-tool-kit/conflict": "^1.0.0",
-        "@dotcom-tool-kit/plugin": "^1.0.0",
+        "@dotcom-tool-kit/conflict": "^1.0.1",
+        "@dotcom-tool-kit/plugin": "^1.1.0",
         "@dotcom-tool-kit/validated": "^1.0.2"
       }
     },
     "lib/conflict": {
       "name": "@dotcom-tool-kit/conflict",
-      "version": "1.0.0",
+      "version": "1.0.1",
       "license": "ISC",
       "dependencies": {
-        "@dotcom-tool-kit/plugin": "^1.0.0"
+        "@dotcom-tool-kit/plugin": "^1.1.0"
       }
     },
     "lib/doppler": {
       "name": "@dotcom-tool-kit/doppler",
-      "version": "2.1.7",
+      "version": "2.2.0",
       "license": "ISC",
       "dependencies": {
         "@dotcom-tool-kit/error": "^4.1.0",
@@ -1350,7 +1350,7 @@
     },
     "lib/plugin": {
       "name": "@dotcom-tool-kit/plugin",
-      "version": "1.0.0",
+      "version": "1.1.0",
       "license": "ISC",
       "devDependencies": {}
     },
@@ -31714,11 +31714,11 @@
     },
     "plugins/aws": {
       "name": "@dotcom-tool-kit/aws",
-      "version": "0.1.2",
+      "version": "0.1.3",
       "license": "ISC",
       "dependencies": {
         "@aws-sdk/client-sts": "^3.738.0",
-        "@dotcom-tool-kit/base": "^1.1.9",
+        "@dotcom-tool-kit/base": "^1.1.10",
         "@dotcom-tool-kit/error": "^4.1.0",
         "@dotcom-tool-kit/state": "^4.3.1",
         "zod": "^3.24.1"
@@ -32196,10 +32196,10 @@
     },
     "plugins/babel": {
       "name": "@dotcom-tool-kit/babel",
-      "version": "4.2.7",
+      "version": "4.3.0",
       "license": "MIT",
       "dependencies": {
-        "@dotcom-tool-kit/base": "^1.1.9",
+        "@dotcom-tool-kit/base": "^1.1.10",
         "@dotcom-tool-kit/error": "^4.1.0",
         "@dotcom-tool-kit/logger": "^4.1.1",
         "fast-glob": "^3.2.11",
@@ -32242,13 +32242,13 @@
     },
     "plugins/backend-heroku-app": {
       "name": "@dotcom-tool-kit/backend-heroku-app",
-      "version": "4.1.9",
+      "version": "4.1.10",
       "license": "ISC",
       "dependencies": {
-        "@dotcom-tool-kit/circleci-deploy": "^4.1.9",
-        "@dotcom-tool-kit/heroku": "^4.1.9",
-        "@dotcom-tool-kit/node": "^4.2.9",
-        "@dotcom-tool-kit/npm": "^4.2.9"
+        "@dotcom-tool-kit/circleci-deploy": "^4.1.10",
+        "@dotcom-tool-kit/heroku": "^4.2.0",
+        "@dotcom-tool-kit/node": "^4.3.0",
+        "@dotcom-tool-kit/npm": "^4.2.10"
       },
       "engines": {
         "node": "18.x || 20.x || 22.x"
@@ -32259,13 +32259,13 @@
     },
     "plugins/backend-serverless-app": {
       "name": "@dotcom-tool-kit/backend-serverless-app",
-      "version": "4.1.9",
+      "version": "4.1.10",
       "license": "ISC",
       "dependencies": {
-        "@dotcom-tool-kit/circleci-deploy": "^4.1.9",
-        "@dotcom-tool-kit/node": "^4.2.9",
-        "@dotcom-tool-kit/npm": "^4.2.9",
-        "@dotcom-tool-kit/serverless": "^3.2.9"
+        "@dotcom-tool-kit/circleci-deploy": "^4.1.10",
+        "@dotcom-tool-kit/node": "^4.3.0",
+        "@dotcom-tool-kit/npm": "^4.2.10",
+        "@dotcom-tool-kit/serverless": "^3.3.0"
       },
       "engines": {
         "node": "18.x || 20.x || 22.x"
@@ -32276,11 +32276,11 @@
     },
     "plugins/circleci": {
       "name": "@dotcom-tool-kit/circleci",
-      "version": "7.4.3",
+      "version": "7.5.0",
       "license": "ISC",
       "dependencies": {
-        "@dotcom-tool-kit/base": "^1.1.9",
-        "@dotcom-tool-kit/conflict": "^1.0.0",
+        "@dotcom-tool-kit/base": "^1.1.10",
+        "@dotcom-tool-kit/conflict": "^1.0.1",
         "@dotcom-tool-kit/error": "^4.1.0",
         "@dotcom-tool-kit/logger": "^4.1.1",
         "@dotcom-tool-kit/state": "^4.3.1",
@@ -32292,7 +32292,7 @@
         "zod": "^3.22.4"
       },
       "devDependencies": {
-        "@dotcom-tool-kit/plugin": "^1.0.0",
+        "@dotcom-tool-kit/plugin": "^1.1.0",
         "@jest/globals": "^27.4.6",
         "@types/jest": "^27.4.0",
         "@types/js-yaml": "^4.0.3",
@@ -32309,10 +32309,10 @@
     },
     "plugins/circleci-deploy": {
       "name": "@dotcom-tool-kit/circleci-deploy",
-      "version": "4.1.9",
+      "version": "4.1.10",
       "license": "ISC",
       "dependencies": {
-        "@dotcom-tool-kit/circleci": "^7.4.3",
+        "@dotcom-tool-kit/circleci": "^7.5.0",
         "tslib": "^2.3.1"
       },
       "devDependencies": {
@@ -32350,11 +32350,11 @@
     },
     "plugins/circleci-npm": {
       "name": "@dotcom-tool-kit/circleci-npm",
-      "version": "6.1.9",
+      "version": "6.1.10",
       "license": "ISC",
       "dependencies": {
-        "@dotcom-tool-kit/circleci": "^7.4.3",
-        "@dotcom-tool-kit/npm": "^4.2.9",
+        "@dotcom-tool-kit/circleci": "^7.5.0",
+        "@dotcom-tool-kit/npm": "^4.2.10",
         "tslib": "^2.3.1"
       },
       "engines": {
@@ -32470,7 +32470,7 @@
     },
     "plugins/cloudsmith": {
       "name": "@dotcom-tool-kit/cloudsmith",
-      "version": "1.0.1",
+      "version": "1.1.0",
       "license": "ISC",
       "dependencies": {
         "tslib": "^2.8.1",
@@ -32492,10 +32492,10 @@
     },
     "plugins/commitlint": {
       "name": "@dotcom-tool-kit/commitlint",
-      "version": "1.2.7",
+      "version": "1.2.8",
       "license": "ISC",
       "dependencies": {
-        "@dotcom-tool-kit/base": "^1.1.9",
+        "@dotcom-tool-kit/base": "^1.1.10",
         "@dotcom-tool-kit/logger": "^4.1.1"
       },
       "engines": {
@@ -33205,11 +33205,11 @@
     },
     "plugins/component": {
       "name": "@dotcom-tool-kit/component",
-      "version": "5.1.9",
+      "version": "5.1.10",
       "license": "ISC",
       "dependencies": {
-        "@dotcom-tool-kit/circleci-npm": "^6.1.9",
-        "@dotcom-tool-kit/npm": "^4.2.9"
+        "@dotcom-tool-kit/circleci-npm": "^6.1.10",
+        "@dotcom-tool-kit/npm": "^4.2.10"
       },
       "engines": {
         "node": "18.x || 20.x || 22.x"
@@ -33220,13 +33220,13 @@
     },
     "plugins/cypress": {
       "name": "@dotcom-tool-kit/cypress",
-      "version": "5.2.9",
+      "version": "5.3.0",
       "license": "ISC",
       "dependencies": {
-        "@dotcom-tool-kit/base": "^1.1.9",
-        "@dotcom-tool-kit/doppler": "^2.1.7",
+        "@dotcom-tool-kit/base": "^1.1.10",
+        "@dotcom-tool-kit/doppler": "^2.2.0",
         "@dotcom-tool-kit/logger": "^4.1.1",
-        "@dotcom-tool-kit/package-json-hook": "^5.1.7",
+        "@dotcom-tool-kit/package-json-hook": "^5.2.0",
         "@dotcom-tool-kit/state": "^4.3.1",
         "zod": "^3.24.1"
       },
@@ -33239,10 +33239,10 @@
     },
     "plugins/docker": {
       "name": "@dotcom-tool-kit/docker",
-      "version": "0.3.2",
+      "version": "0.3.3",
       "license": "ISC",
       "dependencies": {
-        "@dotcom-tool-kit/base": "^1.1.9",
+        "@dotcom-tool-kit/base": "^1.1.10",
         "@dotcom-tool-kit/error": "^4.1.0",
         "@dotcom-tool-kit/logger": "^4.1.1",
         "@dotcom-tool-kit/state": "^4.3.1",
@@ -33267,10 +33267,10 @@
     },
     "plugins/eslint": {
       "name": "@dotcom-tool-kit/eslint",
-      "version": "4.2.7",
+      "version": "4.3.0",
       "license": "ISC",
       "dependencies": {
-        "@dotcom-tool-kit/base": "^1.1.9",
+        "@dotcom-tool-kit/base": "^1.1.10",
         "@dotcom-tool-kit/error": "^4.1.0",
         "@dotcom-tool-kit/logger": "^4.1.1",
         "tslib": "^2.3.1",
@@ -33491,12 +33491,12 @@
     },
     "plugins/frontend-app": {
       "name": "@dotcom-tool-kit/frontend-app",
-      "version": "4.1.9",
+      "version": "4.1.10",
       "license": "ISC",
       "dependencies": {
-        "@dotcom-tool-kit/backend-heroku-app": "^4.1.9",
-        "@dotcom-tool-kit/upload-assets-to-s3": "^4.2.7",
-        "@dotcom-tool-kit/webpack": "^4.2.7"
+        "@dotcom-tool-kit/backend-heroku-app": "^4.1.10",
+        "@dotcom-tool-kit/upload-assets-to-s3": "^4.3.0",
+        "@dotcom-tool-kit/webpack": "^4.3.0"
       },
       "engines": {
         "node": "18.x || 20.x || 22.x"
@@ -33507,10 +33507,10 @@
     },
     "plugins/hako": {
       "name": "@dotcom-tool-kit/hako",
-      "version": "0.1.1",
+      "version": "0.1.2",
       "license": "ISC",
       "dependencies": {
-        "@dotcom-tool-kit/base": "^1.1.9",
+        "@dotcom-tool-kit/base": "^1.1.10",
         "@dotcom-tool-kit/error": "^4.1.0",
         "@dotcom-tool-kit/logger": "^4.1.1",
         "@dotcom-tool-kit/state": "^4.3.1",
@@ -33532,15 +33532,15 @@
     },
     "plugins/heroku": {
       "name": "@dotcom-tool-kit/heroku",
-      "version": "4.1.9",
+      "version": "4.2.0",
       "license": "ISC",
       "dependencies": {
-        "@dotcom-tool-kit/base": "^1.1.9",
-        "@dotcom-tool-kit/doppler": "^2.1.7",
+        "@dotcom-tool-kit/base": "^1.1.10",
+        "@dotcom-tool-kit/doppler": "^2.2.0",
         "@dotcom-tool-kit/error": "^4.1.0",
         "@dotcom-tool-kit/logger": "^4.1.1",
-        "@dotcom-tool-kit/npm": "^4.2.9",
-        "@dotcom-tool-kit/package-json-hook": "^5.1.7",
+        "@dotcom-tool-kit/npm": "^4.2.10",
+        "@dotcom-tool-kit/package-json-hook": "^5.2.0",
         "@dotcom-tool-kit/state": "^4.3.1",
         "@dotcom-tool-kit/wait-for-ok": "^4.1.0",
         "@octokit/request": "^8.4.0",
@@ -33622,10 +33622,10 @@
     },
     "plugins/husky-npm": {
       "name": "@dotcom-tool-kit/husky-npm",
-      "version": "5.1.7",
+      "version": "5.1.8",
       "license": "ISC",
       "dependencies": {
-        "@dotcom-tool-kit/package-json-hook": "^5.1.7",
+        "@dotcom-tool-kit/package-json-hook": "^5.2.0",
         "tslib": "^2.3.1"
       },
       "engines": {
@@ -33643,10 +33643,10 @@
     },
     "plugins/jest": {
       "name": "@dotcom-tool-kit/jest",
-      "version": "4.2.7",
+      "version": "4.3.0",
       "license": "ISC",
       "dependencies": {
-        "@dotcom-tool-kit/base": "^1.1.9",
+        "@dotcom-tool-kit/base": "^1.1.10",
         "@dotcom-tool-kit/logger": "^4.1.1",
         "tslib": "^2.3.1",
         "zod": "^3.24.1"
@@ -33669,12 +33669,12 @@
     },
     "plugins/lint-staged": {
       "name": "@dotcom-tool-kit/lint-staged",
-      "version": "5.2.7",
+      "version": "5.2.8",
       "license": "ISC",
       "dependencies": {
-        "@dotcom-tool-kit/base": "^1.1.9",
+        "@dotcom-tool-kit/base": "^1.1.10",
         "@dotcom-tool-kit/logger": "^4.1.1",
-        "@dotcom-tool-kit/package-json-hook": "^5.1.7",
+        "@dotcom-tool-kit/package-json-hook": "^5.2.0",
         "lint-staged": "^11.2.3",
         "tslib": "^2.3.1"
       },
@@ -33687,12 +33687,12 @@
     },
     "plugins/lint-staged-npm": {
       "name": "@dotcom-tool-kit/lint-staged-npm",
-      "version": "4.1.7",
+      "version": "4.2.0",
       "license": "ISC",
       "dependencies": {
-        "@dotcom-tool-kit/husky-npm": "^5.1.7",
-        "@dotcom-tool-kit/lint-staged": "^5.2.7",
-        "@dotcom-tool-kit/package-json-hook": "^5.1.7",
+        "@dotcom-tool-kit/husky-npm": "^5.1.8",
+        "@dotcom-tool-kit/lint-staged": "^5.2.8",
+        "@dotcom-tool-kit/package-json-hook": "^5.2.0",
         "tslib": "^2.3.1",
         "zod": "^3.24.1"
       },
@@ -33765,10 +33765,10 @@
     },
     "plugins/mocha": {
       "name": "@dotcom-tool-kit/mocha",
-      "version": "4.3.3",
+      "version": "4.4.0",
       "license": "ISC",
       "dependencies": {
-        "@dotcom-tool-kit/base": "^1.1.9",
+        "@dotcom-tool-kit/base": "^1.1.10",
         "@dotcom-tool-kit/error": "^4.1.0",
         "@dotcom-tool-kit/logger": "^4.1.1",
         "glob": "^7.1.7",
@@ -33799,10 +33799,10 @@
     },
     "plugins/n-test": {
       "name": "@dotcom-tool-kit/n-test",
-      "version": "4.2.10",
+      "version": "4.3.0",
       "license": "ISC",
       "dependencies": {
-        "@dotcom-tool-kit/base": "^1.1.9",
+        "@dotcom-tool-kit/base": "^1.1.10",
         "@dotcom-tool-kit/error": "^4.1.0",
         "@dotcom-tool-kit/logger": "^4.1.1",
         "@dotcom-tool-kit/state": "^4.3.1",
@@ -33921,11 +33921,11 @@
     },
     "plugins/next-router": {
       "name": "@dotcom-tool-kit/next-router",
-      "version": "4.2.9",
+      "version": "4.3.0",
       "license": "ISC",
       "dependencies": {
-        "@dotcom-tool-kit/base": "^1.1.9",
-        "@dotcom-tool-kit/doppler": "^2.1.7",
+        "@dotcom-tool-kit/base": "^1.1.10",
+        "@dotcom-tool-kit/doppler": "^2.2.0",
         "@dotcom-tool-kit/error": "^4.1.0",
         "@dotcom-tool-kit/logger": "^4.1.1",
         "@dotcom-tool-kit/state": "^4.3.1",
@@ -34052,11 +34052,11 @@
     },
     "plugins/node": {
       "name": "@dotcom-tool-kit/node",
-      "version": "4.2.9",
+      "version": "4.3.0",
       "license": "ISC",
       "dependencies": {
-        "@dotcom-tool-kit/base": "^1.1.9",
-        "@dotcom-tool-kit/doppler": "^2.1.7",
+        "@dotcom-tool-kit/base": "^1.1.10",
+        "@dotcom-tool-kit/doppler": "^2.2.0",
         "@dotcom-tool-kit/error": "^4.1.0",
         "@dotcom-tool-kit/state": "^4.3.1",
         "get-port": "^5.1.1",
@@ -34078,11 +34078,11 @@
     },
     "plugins/nodemon": {
       "name": "@dotcom-tool-kit/nodemon",
-      "version": "4.1.9",
+      "version": "4.2.0",
       "license": "ISC",
       "dependencies": {
-        "@dotcom-tool-kit/base": "^1.1.9",
-        "@dotcom-tool-kit/doppler": "^2.1.7",
+        "@dotcom-tool-kit/base": "^1.1.10",
+        "@dotcom-tool-kit/doppler": "^2.2.0",
         "@dotcom-tool-kit/error": "^4.1.0",
         "@dotcom-tool-kit/state": "^4.3.1",
         "get-port": "^5.1.1",
@@ -34107,12 +34107,12 @@
     },
     "plugins/npm": {
       "name": "@dotcom-tool-kit/npm",
-      "version": "4.2.9",
+      "version": "4.2.10",
       "license": "ISC",
       "dependencies": {
-        "@dotcom-tool-kit/base": "^1.1.9",
+        "@dotcom-tool-kit/base": "^1.1.10",
         "@dotcom-tool-kit/error": "^4.1.0",
-        "@dotcom-tool-kit/package-json-hook": "^5.1.7",
+        "@dotcom-tool-kit/package-json-hook": "^5.2.0",
         "@dotcom-tool-kit/state": "^4.3.1",
         "libnpmpack": "^3.1.0",
         "libnpmpublish": "^5.0.1",
@@ -34343,12 +34343,12 @@
     },
     "plugins/package-json-hook": {
       "name": "@dotcom-tool-kit/package-json-hook",
-      "version": "5.1.7",
+      "version": "5.2.0",
       "license": "ISC",
       "dependencies": {
-        "@dotcom-tool-kit/base": "^1.1.9",
-        "@dotcom-tool-kit/conflict": "^1.0.0",
-        "@dotcom-tool-kit/plugin": "^1.0.0",
+        "@dotcom-tool-kit/base": "^1.1.10",
+        "@dotcom-tool-kit/conflict": "^1.0.1",
+        "@dotcom-tool-kit/plugin": "^1.1.0",
         "@financial-times/package-json": "^3.0.0",
         "lodash": "^4.17.21",
         "tslib": "^2.3.1",
@@ -34376,13 +34376,13 @@
     },
     "plugins/prettier": {
       "name": "@dotcom-tool-kit/prettier",
-      "version": "4.2.7",
+      "version": "4.3.0",
       "license": "ISC",
       "dependencies": {
-        "@dotcom-tool-kit/base": "^1.1.9",
+        "@dotcom-tool-kit/base": "^1.1.10",
         "@dotcom-tool-kit/error": "^4.1.0",
         "@dotcom-tool-kit/logger": "^4.1.1",
-        "@dotcom-tool-kit/package-json-hook": "^5.1.7",
+        "@dotcom-tool-kit/package-json-hook": "^5.2.0",
         "fast-glob": "^3.2.7",
         "hook-std": "^2.0.0",
         "prettier": "^2.2.1",
@@ -34432,11 +34432,11 @@
     },
     "plugins/serverless": {
       "name": "@dotcom-tool-kit/serverless",
-      "version": "3.2.9",
+      "version": "3.3.0",
       "license": "ISC",
       "dependencies": {
-        "@dotcom-tool-kit/base": "^1.1.9",
-        "@dotcom-tool-kit/doppler": "^2.1.7",
+        "@dotcom-tool-kit/base": "^1.1.10",
+        "@dotcom-tool-kit/doppler": "^2.2.0",
         "@dotcom-tool-kit/error": "^4.1.0",
         "@dotcom-tool-kit/logger": "^4.1.1",
         "@dotcom-tool-kit/state": "^4.3.1",
@@ -34460,10 +34460,10 @@
     },
     "plugins/typescript": {
       "name": "@dotcom-tool-kit/typescript",
-      "version": "3.2.7",
+      "version": "3.3.0",
       "license": "ISC",
       "dependencies": {
-        "@dotcom-tool-kit/base": "^1.1.9",
+        "@dotcom-tool-kit/base": "^1.1.10",
         "@dotcom-tool-kit/logger": "^4.1.1",
         "zod": "^3.24.1"
       },
@@ -34681,11 +34681,11 @@
     },
     "plugins/upload-assets-to-s3": {
       "name": "@dotcom-tool-kit/upload-assets-to-s3",
-      "version": "4.2.7",
+      "version": "4.3.0",
       "license": "ISC",
       "dependencies": {
         "@aws-sdk/client-s3": "^3.256.0",
-        "@dotcom-tool-kit/base": "^1.1.9",
+        "@dotcom-tool-kit/base": "^1.1.10",
         "@dotcom-tool-kit/error": "^4.1.0",
         "@dotcom-tool-kit/logger": "^4.1.1",
         "glob": "^7.1.6",
@@ -34715,10 +34715,10 @@
     },
     "plugins/webpack": {
       "name": "@dotcom-tool-kit/webpack",
-      "version": "4.2.7",
+      "version": "4.3.0",
       "license": "MIT",
       "dependencies": {
-        "@dotcom-tool-kit/base": "^1.1.9",
+        "@dotcom-tool-kit/base": "^1.1.10",
         "@dotcom-tool-kit/error": "^4.1.0",
         "@dotcom-tool-kit/logger": "^4.1.1",
         "tslib": "^2.3.1",

--- a/scripts/generate-docs.js
+++ b/scripts/generate-docs.js
@@ -49,9 +49,9 @@ async function formatPluginSchemas(plugin) {
         if (taskSchema.valid) {
           return valid([taskName, taskSchema.value])
         } else {
-          return (await importEntryPoint(Task, taskEntryPoint)).flatMap((task) => {
-            return task.entryPoint.description
-              ? valid([taskName, z.object({}).describe(task.entryPoint.description)])
+          return (await importEntryPoint(Task, taskEntryPoint)).flatMap(({ baseClass: TaskClass }) => {
+            return TaskClass.description
+              ? valid([taskName, z.object({}).describe(TaskClass.description)])
               : invalid(['no description'])
           })
         }


### PR DESCRIPTION
# Description

Based on a code review suggestion, I updated the name of the field returned from `importEntryPoint` from `entryPoint` to `baseClass` as the previous name was overloading a parameter name that served a different purpose. I checked for build errors to find places where the name needed to be updated, but of course the `generate-docs.js` script is written in JavaScript and not checked by TypeScript, so I missed that the change needed to be reflected in the script too. This is now fixed and won't block git hooks from passing.

# Checklist:

- [x] My branch has been rebased onto the latest commit on main (don't merge main into your branch)
- [x] My commit messages are [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/), for example: `feat(circleci): add support for nightly workflows`, `fix: set Heroku app name for staging apps too`
