### PR TITLE
feat!: adopt standard labels for container images

### DIFF
--- a/plugins/docker/src/image-info.ts
+++ b/plugins/docker/src/image-info.ts
@@ -6,56 +6,34 @@ export function buildImageName({ registry, name }: { registry: string; name: str
   return joinPath(registry, name)
 }
 
-// See https://docs.docker.com/reference/cli/docker/image/tag/#description
-// We're just doing some basic sanitization now to avoid git tags causing issues.
-// If the tag isn't valid then Docker will error so it's not high risk
-function sanitizeDockerTag(tag: string): string {
-  return tag.replace(/[^a-z0-9\._-]+/gi, '')
+interface ImageLabels {
+  'org.opencontainers.image.created': string
+  'org.opencontainers.image.vendor': string
+  'org.opencontainers.image.source': string | undefined
+  'org.opencontainers.image.revision': string | undefined
+  'org.opencontainers.image.version': string | undefined
+  'com.ft.system.code': string
+  'com.ft.build.url': string | undefined
+  'com.ft.source.branch': string | undefined
 }
 
-interface ImageTags {
-  deploy: string
-  gitCommit?: string
-  gitTag?: string
-  gitBranch?: string
-}
-
-function generateImageTags(ciState: CIState | null): ImageTags {
-  const tags: ImageTags = {
-    deploy: getDeployTag(ciState)
+export function generateImageLabels(systemCode: string): ImageLabels {
+  return {
+    'org.opencontainers.image.created': new Date().toISOString(),
+    'org.opencontainers.image.vendor': 'The Financial Times Ltd',
+    'org.opencontainers.image.source': process.env.CIRCLE_REPOSITORY_URL,
+    'org.opencontainers.image.revision': process.env.CIRCLE_SHA1
+      ? process.env.CIRCLE_SHA1.slice(0, 7)
+      : undefined,
+    'org.opencontainers.image.version': process.env.CIRCLE_TAG,
+    'com.ft.system.code': systemCode,
+    'com.ft.build.url': process.env.CIRCLE_BUILD_URL,
+    'com.ft.source.branch': process.env.CIRCLE_BRANCH
   }
-
-  if (ciState?.version) {
-    tags.gitCommit = `git-${ciState.version.slice(0, 7)}`
-  }
-
-  if (ciState?.tag) {
-    tags.gitTag = `release-${ciState.tag}`
-  }
-
-  if (ciState?.branch) {
-    tags.gitBranch = `branch-${ciState.branch}`
-  }
-
-  return tags
 }
 
 export function getDeployTag(ciState: CIState | null): string {
   return ciState?.buildNumber
     ? `ci-${ciState.buildNumber}`
     : `local-${process.env.USER || 'unknown'}-${randomInt(1000, 9999)}`
-}
-
-export function getImageTagsFromEnvironment({
-  ciState,
-  registry,
-  name
-}: {
-  ciState: CIState | null
-  registry: string
-  name: string
-}): string[] {
-  const imageName = buildImageName({ registry, name })
-  const tags = Object.values(generateImageTags(ciState))
-  return tags.map((tag) => `${imageName}:${sanitizeDockerTag(tag)}`)
 }

--- a/plugins/docker/src/image-info.ts
+++ b/plugins/docker/src/image-info.ts
@@ -20,7 +20,7 @@ interface ImageLabels {
 export function generateImageLabels(systemCode: string): ImageLabels {
   return {
     'org.opencontainers.image.created': new Date().toISOString(),
-    'org.opencontainers.image.vendor': 'The Financial Times Ltd',
+    'org.opencontainers.image.vendor': 'Financial Times',
     'org.opencontainers.image.source': process.env.CIRCLE_REPOSITORY_URL,
     'org.opencontainers.image.revision': process.env.CIRCLE_SHA1
       ? process.env.CIRCLE_SHA1.slice(0, 7)


### PR DESCRIPTION
# Description

This removes a lot of the tags we've been adding to images, reducing it down to only the tag we use for deployment. It replaces many of these tags with the labels outlined in the [Standard Labels for FT Container Images proposal](https://docs.google.com/document/d/1USDbK4ptBe4VRW_3Ujv0RCgrD9JOhMHT1JjImQGvmRQ/edit).

# Checklist:

- [x] My branch has been rebased onto the latest commit on main (don't merge main into your branch)
- [x] My commit messages are [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/), for example: `feat(circleci): add support for nightly workflows`, `fix: set Heroku app name for staging apps too`
