### PR TITLE
Add monorepo plugin to release-please config

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -43,6 +43,7 @@
     "plugins/lint-staged": {},
     "plugins/lint-staged-npm": {},
     "plugins/mocha": {},
+    "plugins/monorepo": {},
     "plugins/n-test": {},
     "plugins/next-router": {},
     "plugins/node": {},


### PR DESCRIPTION
# Description

This will allow release-please to release the plugin. 

# Checklist:

- [x] My branch has been rebased onto the latest commit on main (don't merge main into your branch)
- [x] My commit messages are [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/), for example: `feat(circleci): add support for nightly workflows`, `fix: set Heroku app name for staging apps too`
