### PR TITLE
Make sure to run all install hooks when options are set at the app root

### DIFF
--- a/core/cli/src/plugin/reduce-installations.ts
+++ b/core/cli/src/plugin/reduce-installations.ts
@@ -80,8 +80,8 @@ export async function reducePluginHookInstallations(
   if (plugin.rcFile.options.hooks.length === 0) {
     return valid(childInstallations)
   }
-  const unusedHookOptions = plugin.rcFile.options.hooks
-    .flatMap(Object.keys)
+  const pluginHookIds = plugin.rcFile.options.hooks.flatMap(Object.keys)
+  const unusedHookOptions = pluginHookIds
     .filter((hookId) => !(hookId in hookModules))
     .map((hookId) => styles.hook(hookId))
   if (unusedHookOptions.length > 0) {
@@ -115,6 +115,10 @@ export async function reducePluginHookInstallations(
       }
     )
   )
-
-  return reduceValidated(validatedInstallations).map((installations) => installations.flat())
+  return reduceValidated(validatedInstallations).map((installations) => [
+    ...installations.flat(),
+    ...childInstallations.filter(
+      (childInstallation) => !pluginHookIds.includes(extractForHook(childInstallation))
+    )
+  ])
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -48,7 +48,7 @@
     },
     "core/cli": {
       "name": "dotcom-tool-kit",
-      "version": "4.5.0",
+      "version": "4.6.0",
       "license": "MIT",
       "dependencies": {
         "@dotcom-tool-kit/base": "^1.1.10",
@@ -32705,10 +32705,10 @@
     },
     "plugins/backend-heroku-app": {
       "name": "@dotcom-tool-kit/backend-heroku-app",
-      "version": "4.1.10",
+      "version": "4.1.11",
       "license": "ISC",
       "dependencies": {
-        "@dotcom-tool-kit/circleci-deploy": "^4.1.10",
+        "@dotcom-tool-kit/circleci-deploy": "^4.1.11",
         "@dotcom-tool-kit/heroku": "^4.2.0",
         "@dotcom-tool-kit/node": "^4.3.0",
         "@dotcom-tool-kit/npm": "^4.2.10"
@@ -32722,10 +32722,10 @@
     },
     "plugins/backend-serverless-app": {
       "name": "@dotcom-tool-kit/backend-serverless-app",
-      "version": "4.1.10",
+      "version": "4.1.11",
       "license": "ISC",
       "dependencies": {
-        "@dotcom-tool-kit/circleci-deploy": "^4.1.10",
+        "@dotcom-tool-kit/circleci-deploy": "^4.1.11",
         "@dotcom-tool-kit/node": "^4.3.0",
         "@dotcom-tool-kit/npm": "^4.2.10",
         "@dotcom-tool-kit/serverless": "^3.3.0"
@@ -32739,7 +32739,7 @@
     },
     "plugins/circleci": {
       "name": "@dotcom-tool-kit/circleci",
-      "version": "7.5.0",
+      "version": "7.6.0",
       "license": "ISC",
       "dependencies": {
         "@dotcom-tool-kit/base": "^1.1.10",
@@ -32772,10 +32772,10 @@
     },
     "plugins/circleci-deploy": {
       "name": "@dotcom-tool-kit/circleci-deploy",
-      "version": "4.1.10",
+      "version": "4.1.11",
       "license": "ISC",
       "dependencies": {
-        "@dotcom-tool-kit/circleci": "^7.5.0",
+        "@dotcom-tool-kit/circleci": "^7.6.0",
         "tslib": "^2.3.1"
       },
       "devDependencies": {
@@ -32813,10 +32813,10 @@
     },
     "plugins/circleci-npm": {
       "name": "@dotcom-tool-kit/circleci-npm",
-      "version": "6.1.10",
+      "version": "6.1.11",
       "license": "ISC",
       "dependencies": {
-        "@dotcom-tool-kit/circleci": "^7.5.0",
+        "@dotcom-tool-kit/circleci": "^7.6.0",
         "@dotcom-tool-kit/npm": "^4.2.10",
         "tslib": "^2.3.1"
       },
@@ -33668,10 +33668,10 @@
     },
     "plugins/component": {
       "name": "@dotcom-tool-kit/component",
-      "version": "5.1.10",
+      "version": "5.1.11",
       "license": "ISC",
       "dependencies": {
-        "@dotcom-tool-kit/circleci-npm": "^6.1.10",
+        "@dotcom-tool-kit/circleci-npm": "^6.1.11",
         "@dotcom-tool-kit/npm": "^4.2.10"
       },
       "engines": {
@@ -33683,15 +33683,15 @@
     },
     "plugins/containerised-app": {
       "name": "@dotcom-tool-kit/containerised-app",
-      "version": "0.1.1",
+      "version": "0.1.4",
       "license": "ISC",
       "dependencies": {
         "@dotcom-tool-kit/aws": "^0.1.2",
-        "@dotcom-tool-kit/circleci-deploy": "^4.1.10",
+        "@dotcom-tool-kit/circleci-deploy": "^4.1.11",
         "@dotcom-tool-kit/cloudsmith": "^1.0.1",
         "@dotcom-tool-kit/docker": "^0.3.2",
         "@dotcom-tool-kit/doppler": "^2.1.7",
-        "@dotcom-tool-kit/hako": "^0.1.3",
+        "@dotcom-tool-kit/hako": "^0.1.4",
         "@dotcom-tool-kit/node": "^4.2.9",
         "zod": "^3.24.1"
       },
@@ -33704,10 +33704,10 @@
     },
     "plugins/containerised-app-with-assets": {
       "name": "@dotcom-tool-kit/containerised-app-with-assets",
-      "version": "0.1.1",
+      "version": "0.1.4",
       "license": "ISC",
       "dependencies": {
-        "@dotcom-tool-kit/containerised-app": "^0.1.1",
+        "@dotcom-tool-kit/containerised-app": "^0.1.4",
         "@dotcom-tool-kit/upload-assets-to-s3": "^4.2.7",
         "@dotcom-tool-kit/webpack": "^4.2.7",
         "zod": "^3.24.1"
@@ -33992,10 +33992,10 @@
     },
     "plugins/frontend-app": {
       "name": "@dotcom-tool-kit/frontend-app",
-      "version": "4.1.10",
+      "version": "4.1.11",
       "license": "ISC",
       "dependencies": {
-        "@dotcom-tool-kit/backend-heroku-app": "^4.1.10",
+        "@dotcom-tool-kit/backend-heroku-app": "^4.1.11",
         "@dotcom-tool-kit/upload-assets-to-s3": "^4.3.0",
         "@dotcom-tool-kit/webpack": "^4.3.0"
       },
@@ -34008,7 +34008,7 @@
     },
     "plugins/hako": {
       "name": "@dotcom-tool-kit/hako",
-      "version": "0.1.3",
+      "version": "0.1.4",
       "license": "ISC",
       "dependencies": {
         "@dotcom-tool-kit/base": "^1.1.10",

--- a/plugins/circleci-npm/test/circleci-npm.test.ts
+++ b/plugins/circleci-npm/test/circleci-npm.test.ts
@@ -15,7 +15,7 @@ describe('circleci-npm', () => {
         validated.unwrap('hooks were invalid')
       )
 
-      await expect(hookInstallationsPromise).resolves.toEqual([expect.any(CircleCi)])
+      await expect(hookInstallationsPromise).resolves.toEqual(expect.arrayContaining([expect.any(CircleCi)]))
 
       const installation = (await hookInstallationsPromise)[0]
 


### PR DESCRIPTION
# Description

There was a bug where if any hook's options were overridden at the top level plugin (i.e., the `.toolkitrc.yml` at a project's root) then only that hook would run, regardless of whether hooks were defined in transitive plugins. This was because the code path taken when there were hook options in a plugin was different and would only return hooks with options defined.

This isn't usually an issue as none of the plugins typically responsible for defining hook options would be parents of plugins that defined other hooks, so hooks were never discarded and were merged as siblings by further plugin parents. This becomes a more obvious issue if a user was to define top-level hook options, as by definition the app root has no parent plugins and therefore no siblings either.

# Checklist:

- [x] My branch has been rebased onto the latest commit on main (don't merge main into your branch)
- [x] My commit messages are [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/), for example: `feat(circleci): add support for nightly workflows`, `fix: set Heroku app name for staging apps too`
