### PR TITLE
Widen dependency range for serverless-offline peer dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -48,10 +48,10 @@
     },
     "core/cli": {
       "name": "dotcom-tool-kit",
-      "version": "4.6.0",
+      "version": "4.7.0",
       "license": "MIT",
       "dependencies": {
-        "@dotcom-tool-kit/base": "^1.1.10",
+        "@dotcom-tool-kit/base": "^1.2.0",
         "@dotcom-tool-kit/config": "^1.1.0",
         "@dotcom-tool-kit/conflict": "^1.0.1",
         "@dotcom-tool-kit/error": "^4.1.0",
@@ -1133,7 +1133,7 @@
     },
     "lib/base": {
       "name": "@dotcom-tool-kit/base",
-      "version": "1.1.10",
+      "version": "1.2.0",
       "license": "ISC",
       "dependencies": {
         "@dotcom-tool-kit/conflict": "^1.0.1",
@@ -32177,11 +32177,11 @@
     },
     "plugins/aws": {
       "name": "@dotcom-tool-kit/aws",
-      "version": "0.1.3",
+      "version": "0.1.4",
       "license": "ISC",
       "dependencies": {
         "@aws-sdk/client-sts": "^3.738.0",
-        "@dotcom-tool-kit/base": "^1.1.10",
+        "@dotcom-tool-kit/base": "^1.2.0",
         "@dotcom-tool-kit/error": "^4.1.0",
         "@dotcom-tool-kit/state": "^4.3.1",
         "zod": "^3.24.1"
@@ -32659,10 +32659,10 @@
     },
     "plugins/babel": {
       "name": "@dotcom-tool-kit/babel",
-      "version": "4.3.0",
+      "version": "4.3.1",
       "license": "MIT",
       "dependencies": {
-        "@dotcom-tool-kit/base": "^1.1.10",
+        "@dotcom-tool-kit/base": "^1.2.0",
         "@dotcom-tool-kit/error": "^4.1.0",
         "@dotcom-tool-kit/logger": "^4.1.1",
         "fast-glob": "^3.2.11",
@@ -32705,13 +32705,13 @@
     },
     "plugins/backend-heroku-app": {
       "name": "@dotcom-tool-kit/backend-heroku-app",
-      "version": "4.1.11",
+      "version": "4.1.12",
       "license": "ISC",
       "dependencies": {
-        "@dotcom-tool-kit/circleci-deploy": "^4.1.11",
-        "@dotcom-tool-kit/heroku": "^4.2.0",
-        "@dotcom-tool-kit/node": "^4.3.0",
-        "@dotcom-tool-kit/npm": "^4.2.10"
+        "@dotcom-tool-kit/circleci-deploy": "^4.1.12",
+        "@dotcom-tool-kit/heroku": "^4.2.1",
+        "@dotcom-tool-kit/node": "^4.3.1",
+        "@dotcom-tool-kit/npm": "^4.2.11"
       },
       "engines": {
         "node": "18.x || 20.x || 22.x"
@@ -32722,13 +32722,13 @@
     },
     "plugins/backend-serverless-app": {
       "name": "@dotcom-tool-kit/backend-serverless-app",
-      "version": "4.1.11",
+      "version": "4.1.12",
       "license": "ISC",
       "dependencies": {
-        "@dotcom-tool-kit/circleci-deploy": "^4.1.11",
-        "@dotcom-tool-kit/node": "^4.3.0",
-        "@dotcom-tool-kit/npm": "^4.2.10",
-        "@dotcom-tool-kit/serverless": "^3.3.0"
+        "@dotcom-tool-kit/circleci-deploy": "^4.1.12",
+        "@dotcom-tool-kit/node": "^4.3.1",
+        "@dotcom-tool-kit/npm": "^4.2.11",
+        "@dotcom-tool-kit/serverless": "^3.3.1"
       },
       "engines": {
         "node": "18.x || 20.x || 22.x"
@@ -32739,10 +32739,10 @@
     },
     "plugins/circleci": {
       "name": "@dotcom-tool-kit/circleci",
-      "version": "7.6.0",
+      "version": "7.6.1",
       "license": "ISC",
       "dependencies": {
-        "@dotcom-tool-kit/base": "^1.1.10",
+        "@dotcom-tool-kit/base": "^1.2.0",
         "@dotcom-tool-kit/conflict": "^1.0.1",
         "@dotcom-tool-kit/error": "^4.1.0",
         "@dotcom-tool-kit/logger": "^4.1.1",
@@ -32772,10 +32772,10 @@
     },
     "plugins/circleci-deploy": {
       "name": "@dotcom-tool-kit/circleci-deploy",
-      "version": "4.1.11",
+      "version": "4.1.12",
       "license": "ISC",
       "dependencies": {
-        "@dotcom-tool-kit/circleci": "^7.6.0",
+        "@dotcom-tool-kit/circleci": "^7.6.1",
         "tslib": "^2.3.1"
       },
       "devDependencies": {
@@ -32813,11 +32813,11 @@
     },
     "plugins/circleci-npm": {
       "name": "@dotcom-tool-kit/circleci-npm",
-      "version": "6.1.11",
+      "version": "6.1.12",
       "license": "ISC",
       "dependencies": {
-        "@dotcom-tool-kit/circleci": "^7.6.0",
-        "@dotcom-tool-kit/npm": "^4.2.10",
+        "@dotcom-tool-kit/circleci": "^7.6.1",
+        "@dotcom-tool-kit/npm": "^4.2.11",
         "tslib": "^2.3.1"
       },
       "engines": {
@@ -32955,10 +32955,10 @@
     },
     "plugins/commitlint": {
       "name": "@dotcom-tool-kit/commitlint",
-      "version": "1.2.8",
+      "version": "1.2.9",
       "license": "ISC",
       "dependencies": {
-        "@dotcom-tool-kit/base": "^1.1.10",
+        "@dotcom-tool-kit/base": "^1.2.0",
         "@dotcom-tool-kit/logger": "^4.1.1"
       },
       "engines": {
@@ -33668,11 +33668,11 @@
     },
     "plugins/component": {
       "name": "@dotcom-tool-kit/component",
-      "version": "5.1.11",
+      "version": "5.1.12",
       "license": "ISC",
       "dependencies": {
-        "@dotcom-tool-kit/circleci-npm": "^6.1.11",
-        "@dotcom-tool-kit/npm": "^4.2.10"
+        "@dotcom-tool-kit/circleci-npm": "^6.1.12",
+        "@dotcom-tool-kit/npm": "^4.2.11"
       },
       "engines": {
         "node": "18.x || 20.x || 22.x"
@@ -33683,16 +33683,16 @@
     },
     "plugins/containerised-app": {
       "name": "@dotcom-tool-kit/containerised-app",
-      "version": "0.1.4",
+      "version": "0.1.6",
       "license": "ISC",
       "dependencies": {
-        "@dotcom-tool-kit/aws": "^0.1.2",
-        "@dotcom-tool-kit/circleci-deploy": "^4.1.11",
+        "@dotcom-tool-kit/aws": "^0.1.4",
+        "@dotcom-tool-kit/circleci-deploy": "^4.1.12",
         "@dotcom-tool-kit/cloudsmith": "^1.0.1",
-        "@dotcom-tool-kit/docker": "^0.3.2",
+        "@dotcom-tool-kit/docker": "^0.4.0",
         "@dotcom-tool-kit/doppler": "^2.1.7",
-        "@dotcom-tool-kit/hako": "^0.1.4",
-        "@dotcom-tool-kit/node": "^4.2.9",
+        "@dotcom-tool-kit/hako": "^0.1.6",
+        "@dotcom-tool-kit/node": "^4.3.1",
         "zod": "^3.24.1"
       },
       "engines": {
@@ -33704,12 +33704,12 @@
     },
     "plugins/containerised-app-with-assets": {
       "name": "@dotcom-tool-kit/containerised-app-with-assets",
-      "version": "0.1.4",
+      "version": "0.1.6",
       "license": "ISC",
       "dependencies": {
-        "@dotcom-tool-kit/containerised-app": "^0.1.4",
-        "@dotcom-tool-kit/upload-assets-to-s3": "^4.2.7",
-        "@dotcom-tool-kit/webpack": "^4.2.7",
+        "@dotcom-tool-kit/containerised-app": "^0.1.6",
+        "@dotcom-tool-kit/upload-assets-to-s3": "^4.3.1",
+        "@dotcom-tool-kit/webpack": "^4.3.1",
         "zod": "^3.24.1"
       },
       "engines": {
@@ -33721,13 +33721,13 @@
     },
     "plugins/cypress": {
       "name": "@dotcom-tool-kit/cypress",
-      "version": "5.3.0",
+      "version": "5.3.1",
       "license": "ISC",
       "dependencies": {
-        "@dotcom-tool-kit/base": "^1.1.10",
+        "@dotcom-tool-kit/base": "^1.2.0",
         "@dotcom-tool-kit/doppler": "^2.2.0",
         "@dotcom-tool-kit/logger": "^4.1.1",
-        "@dotcom-tool-kit/package-json-hook": "^5.2.0",
+        "@dotcom-tool-kit/package-json-hook": "^5.2.1",
         "@dotcom-tool-kit/state": "^4.3.1",
         "zod": "^3.24.1"
       },
@@ -33740,10 +33740,10 @@
     },
     "plugins/docker": {
       "name": "@dotcom-tool-kit/docker",
-      "version": "0.3.3",
+      "version": "0.4.0",
       "license": "ISC",
       "dependencies": {
-        "@dotcom-tool-kit/base": "^1.1.10",
+        "@dotcom-tool-kit/base": "^1.2.0",
         "@dotcom-tool-kit/error": "^4.1.0",
         "@dotcom-tool-kit/logger": "^4.1.1",
         "@dotcom-tool-kit/state": "^4.3.1",
@@ -33768,10 +33768,10 @@
     },
     "plugins/eslint": {
       "name": "@dotcom-tool-kit/eslint",
-      "version": "4.3.0",
+      "version": "4.3.1",
       "license": "ISC",
       "dependencies": {
-        "@dotcom-tool-kit/base": "^1.1.10",
+        "@dotcom-tool-kit/base": "^1.2.0",
         "@dotcom-tool-kit/error": "^4.1.0",
         "@dotcom-tool-kit/logger": "^4.1.1",
         "tslib": "^2.3.1",
@@ -33992,12 +33992,12 @@
     },
     "plugins/frontend-app": {
       "name": "@dotcom-tool-kit/frontend-app",
-      "version": "4.1.11",
+      "version": "4.1.12",
       "license": "ISC",
       "dependencies": {
-        "@dotcom-tool-kit/backend-heroku-app": "^4.1.11",
-        "@dotcom-tool-kit/upload-assets-to-s3": "^4.3.0",
-        "@dotcom-tool-kit/webpack": "^4.3.0"
+        "@dotcom-tool-kit/backend-heroku-app": "^4.1.12",
+        "@dotcom-tool-kit/upload-assets-to-s3": "^4.3.1",
+        "@dotcom-tool-kit/webpack": "^4.3.1"
       },
       "engines": {
         "node": "18.x || 20.x || 22.x"
@@ -34008,10 +34008,10 @@
     },
     "plugins/hako": {
       "name": "@dotcom-tool-kit/hako",
-      "version": "0.1.4",
+      "version": "0.1.6",
       "license": "ISC",
       "dependencies": {
-        "@dotcom-tool-kit/base": "^1.1.10",
+        "@dotcom-tool-kit/base": "^1.2.0",
         "@dotcom-tool-kit/error": "^4.1.0",
         "@dotcom-tool-kit/logger": "^4.1.1",
         "@dotcom-tool-kit/state": "^4.3.1",
@@ -34033,15 +34033,15 @@
     },
     "plugins/heroku": {
       "name": "@dotcom-tool-kit/heroku",
-      "version": "4.2.0",
+      "version": "4.2.1",
       "license": "ISC",
       "dependencies": {
-        "@dotcom-tool-kit/base": "^1.1.10",
+        "@dotcom-tool-kit/base": "^1.2.0",
         "@dotcom-tool-kit/doppler": "^2.2.0",
         "@dotcom-tool-kit/error": "^4.1.0",
         "@dotcom-tool-kit/logger": "^4.1.1",
-        "@dotcom-tool-kit/npm": "^4.2.10",
-        "@dotcom-tool-kit/package-json-hook": "^5.2.0",
+        "@dotcom-tool-kit/npm": "^4.2.11",
+        "@dotcom-tool-kit/package-json-hook": "^5.2.1",
         "@dotcom-tool-kit/state": "^4.3.1",
         "@dotcom-tool-kit/wait-for-ok": "^4.1.0",
         "@octokit/request": "^8.4.0",
@@ -34123,10 +34123,10 @@
     },
     "plugins/husky-npm": {
       "name": "@dotcom-tool-kit/husky-npm",
-      "version": "5.1.8",
+      "version": "5.1.9",
       "license": "ISC",
       "dependencies": {
-        "@dotcom-tool-kit/package-json-hook": "^5.2.0",
+        "@dotcom-tool-kit/package-json-hook": "^5.2.1",
         "tslib": "^2.3.1"
       },
       "engines": {
@@ -34144,10 +34144,10 @@
     },
     "plugins/jest": {
       "name": "@dotcom-tool-kit/jest",
-      "version": "4.3.0",
+      "version": "4.3.1",
       "license": "ISC",
       "dependencies": {
-        "@dotcom-tool-kit/base": "^1.1.10",
+        "@dotcom-tool-kit/base": "^1.2.0",
         "@dotcom-tool-kit/logger": "^4.1.1",
         "tslib": "^2.3.1",
         "zod": "^3.24.1"
@@ -34170,12 +34170,12 @@
     },
     "plugins/lint-staged": {
       "name": "@dotcom-tool-kit/lint-staged",
-      "version": "5.2.8",
+      "version": "5.2.9",
       "license": "ISC",
       "dependencies": {
-        "@dotcom-tool-kit/base": "^1.1.10",
+        "@dotcom-tool-kit/base": "^1.2.0",
         "@dotcom-tool-kit/logger": "^4.1.1",
-        "@dotcom-tool-kit/package-json-hook": "^5.2.0",
+        "@dotcom-tool-kit/package-json-hook": "^5.2.1",
         "lint-staged": "^11.2.3",
         "tslib": "^2.3.1"
       },
@@ -34188,12 +34188,12 @@
     },
     "plugins/lint-staged-npm": {
       "name": "@dotcom-tool-kit/lint-staged-npm",
-      "version": "4.2.0",
+      "version": "4.2.1",
       "license": "ISC",
       "dependencies": {
-        "@dotcom-tool-kit/husky-npm": "^5.1.8",
-        "@dotcom-tool-kit/lint-staged": "^5.2.8",
-        "@dotcom-tool-kit/package-json-hook": "^5.2.0",
+        "@dotcom-tool-kit/husky-npm": "^5.1.9",
+        "@dotcom-tool-kit/lint-staged": "^5.2.9",
+        "@dotcom-tool-kit/package-json-hook": "^5.2.1",
         "tslib": "^2.3.1",
         "zod": "^3.24.1"
       },
@@ -34266,10 +34266,10 @@
     },
     "plugins/mocha": {
       "name": "@dotcom-tool-kit/mocha",
-      "version": "4.4.0",
+      "version": "4.4.1",
       "license": "ISC",
       "dependencies": {
-        "@dotcom-tool-kit/base": "^1.1.10",
+        "@dotcom-tool-kit/base": "^1.2.0",
         "@dotcom-tool-kit/error": "^4.1.0",
         "@dotcom-tool-kit/logger": "^4.1.1",
         "glob": "^7.1.7",
@@ -34300,7 +34300,7 @@
       "version": "0.1.0",
       "license": "ISC",
       "dependencies": {
-        "@dotcom-tool-kit/base": "^1.1.10",
+        "@dotcom-tool-kit/base": "^1.2.0",
         "@dotcom-tool-kit/logger": "^4.0.0",
         "@npmcli/map-workspaces": "^3.0.6",
         "minimatch": "^10.0.1",
@@ -34347,10 +34347,10 @@
     },
     "plugins/n-test": {
       "name": "@dotcom-tool-kit/n-test",
-      "version": "4.3.0",
+      "version": "4.3.1",
       "license": "ISC",
       "dependencies": {
-        "@dotcom-tool-kit/base": "^1.1.10",
+        "@dotcom-tool-kit/base": "^1.2.0",
         "@dotcom-tool-kit/error": "^4.1.0",
         "@dotcom-tool-kit/logger": "^4.1.1",
         "@dotcom-tool-kit/state": "^4.3.1",
@@ -34469,10 +34469,10 @@
     },
     "plugins/next-router": {
       "name": "@dotcom-tool-kit/next-router",
-      "version": "4.3.0",
+      "version": "4.3.1",
       "license": "ISC",
       "dependencies": {
-        "@dotcom-tool-kit/base": "^1.1.10",
+        "@dotcom-tool-kit/base": "^1.2.0",
         "@dotcom-tool-kit/doppler": "^2.2.0",
         "@dotcom-tool-kit/error": "^4.1.0",
         "@dotcom-tool-kit/logger": "^4.1.1",
@@ -34600,10 +34600,10 @@
     },
     "plugins/node": {
       "name": "@dotcom-tool-kit/node",
-      "version": "4.3.0",
+      "version": "4.3.1",
       "license": "ISC",
       "dependencies": {
-        "@dotcom-tool-kit/base": "^1.1.10",
+        "@dotcom-tool-kit/base": "^1.2.0",
         "@dotcom-tool-kit/doppler": "^2.2.0",
         "@dotcom-tool-kit/error": "^4.1.0",
         "@dotcom-tool-kit/state": "^4.3.1",
@@ -34626,10 +34626,10 @@
     },
     "plugins/nodemon": {
       "name": "@dotcom-tool-kit/nodemon",
-      "version": "4.2.0",
+      "version": "4.2.1",
       "license": "ISC",
       "dependencies": {
-        "@dotcom-tool-kit/base": "^1.1.10",
+        "@dotcom-tool-kit/base": "^1.2.0",
         "@dotcom-tool-kit/doppler": "^2.2.0",
         "@dotcom-tool-kit/error": "^4.1.0",
         "@dotcom-tool-kit/state": "^4.3.1",
@@ -34655,12 +34655,12 @@
     },
     "plugins/npm": {
       "name": "@dotcom-tool-kit/npm",
-      "version": "4.2.10",
+      "version": "4.2.11",
       "license": "ISC",
       "dependencies": {
-        "@dotcom-tool-kit/base": "^1.1.10",
+        "@dotcom-tool-kit/base": "^1.2.0",
         "@dotcom-tool-kit/error": "^4.1.0",
-        "@dotcom-tool-kit/package-json-hook": "^5.2.0",
+        "@dotcom-tool-kit/package-json-hook": "^5.2.1",
         "@dotcom-tool-kit/state": "^4.3.1",
         "libnpmpack": "^3.1.0",
         "libnpmpublish": "^5.0.1",
@@ -34891,10 +34891,10 @@
     },
     "plugins/package-json-hook": {
       "name": "@dotcom-tool-kit/package-json-hook",
-      "version": "5.2.0",
+      "version": "5.2.1",
       "license": "ISC",
       "dependencies": {
-        "@dotcom-tool-kit/base": "^1.1.10",
+        "@dotcom-tool-kit/base": "^1.2.0",
         "@dotcom-tool-kit/conflict": "^1.0.1",
         "@dotcom-tool-kit/plugin": "^1.1.0",
         "@financial-times/package-json": "^3.0.0",
@@ -34924,13 +34924,13 @@
     },
     "plugins/prettier": {
       "name": "@dotcom-tool-kit/prettier",
-      "version": "4.3.0",
+      "version": "4.3.1",
       "license": "ISC",
       "dependencies": {
-        "@dotcom-tool-kit/base": "^1.1.10",
+        "@dotcom-tool-kit/base": "^1.2.0",
         "@dotcom-tool-kit/error": "^4.1.0",
         "@dotcom-tool-kit/logger": "^4.1.1",
-        "@dotcom-tool-kit/package-json-hook": "^5.2.0",
+        "@dotcom-tool-kit/package-json-hook": "^5.2.1",
         "fast-glob": "^3.2.7",
         "hook-std": "^2.0.0",
         "prettier": "^2.2.1",
@@ -34980,10 +34980,10 @@
     },
     "plugins/serverless": {
       "name": "@dotcom-tool-kit/serverless",
-      "version": "3.3.0",
+      "version": "3.3.1",
       "license": "ISC",
       "dependencies": {
-        "@dotcom-tool-kit/base": "^1.1.10",
+        "@dotcom-tool-kit/base": "^1.2.0",
         "@dotcom-tool-kit/doppler": "^2.2.0",
         "@dotcom-tool-kit/error": "^4.1.0",
         "@dotcom-tool-kit/logger": "^4.1.1",
@@ -34998,7 +34998,7 @@
       },
       "peerDependencies": {
         "dotcom-tool-kit": "4.x",
-        "serverless-offline": "^12.0.4"
+        "serverless-offline": "12.x || 13.x"
       }
     },
     "plugins/serverless/node_modules/tslib": {
@@ -35008,10 +35008,10 @@
     },
     "plugins/typescript": {
       "name": "@dotcom-tool-kit/typescript",
-      "version": "3.3.0",
+      "version": "3.3.1",
       "license": "ISC",
       "dependencies": {
-        "@dotcom-tool-kit/base": "^1.1.10",
+        "@dotcom-tool-kit/base": "^1.2.0",
         "@dotcom-tool-kit/logger": "^4.1.1",
         "zod": "^3.24.1"
       },
@@ -35229,11 +35229,11 @@
     },
     "plugins/upload-assets-to-s3": {
       "name": "@dotcom-tool-kit/upload-assets-to-s3",
-      "version": "4.3.0",
+      "version": "4.3.1",
       "license": "ISC",
       "dependencies": {
         "@aws-sdk/client-s3": "^3.256.0",
-        "@dotcom-tool-kit/base": "^1.1.10",
+        "@dotcom-tool-kit/base": "^1.2.0",
         "@dotcom-tool-kit/error": "^4.1.0",
         "@dotcom-tool-kit/logger": "^4.1.1",
         "glob": "^7.1.6",
@@ -35263,10 +35263,10 @@
     },
     "plugins/webpack": {
       "name": "@dotcom-tool-kit/webpack",
-      "version": "4.3.0",
+      "version": "4.3.1",
       "license": "MIT",
       "dependencies": {
-        "@dotcom-tool-kit/base": "^1.1.10",
+        "@dotcom-tool-kit/base": "^1.2.0",
         "@dotcom-tool-kit/error": "^4.1.0",
         "@dotcom-tool-kit/logger": "^4.1.1",
         "tslib": "^2.3.1",

--- a/plugins/serverless/package.json
+++ b/plugins/serverless/package.json
@@ -22,7 +22,7 @@
   ],
   "peerDependencies": {
     "dotcom-tool-kit": "4.x",
-    "serverless-offline": "^12.0.4"
+    "serverless-offline": "12.x || 13.x"
   },
   "dependencies": {
     "@dotcom-tool-kit/base": "^1.2.0",


### PR DESCRIPTION
# Description

The range now includes v13. This [version](https://github.com/dherault/serverless-offline/releases/tag/v13.0.0) drops support for Node 16 (which we've also dropped support for) and no longer will try to install `node-fetch` if fetch is not present.

This is important for us as it uses a top-level await to import `node-fetch` which causes issues when running with Node 22. Serverless will typically try to require a module then fall back to an ESM import if that fails, but with Node 22 `require`'ing a module that has any top level awaits will cause an exception to be thrown instead.

Adding v13 to the range of permissible versions will allow consumers to update their version of `serverless-offline` in order to avoid this issue as part of a Node 22 migration. Note that the later v14 is not included in the range as that requires Serverless v4 which we do not support.

# Checklist:

- [x] My branch has been rebased onto the latest commit on main (don't merge main into your branch)
- [x] My commit messages are [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/), for example: `feat(circleci): add support for nightly workflows`, `fix: set Heroku app name for staging apps too`
