### PR TITLE
Fix broken CircleCI status badge in project readme

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -2,7 +2,7 @@
    <img alt="FT.com Tool Kit" src="etc/logo.svg" width="300">
 </h1>
 
-[![CircleCI](https://dl.circleci.com/status-badge/img/gh/Financial-Times/dotcom-tool-kit/tree/main.svg?style=svg)](https://dl.circleci.com/status-badge/redirect/gh/Financial-Times/dotcom-tool-kit/tree/main)
+[![CircleCI](https://dl.circleci.com/status-badge/img/gh/Financial-Times/dotcom-tool-kit/tree/main.svg?style=svg&circle-token=CCIPRJ_HM19rNZuXH3Bt8gVMH2zCx_1c1f8cb1579d9709be93c842bdc5d53314e7308f)](https://dl.circleci.com/status-badge/redirect/gh/Financial-Times/dotcom-tool-kit/tree/main)
 
 Tool Kit is modern developer tooling for FT.com repositories. It's fully modular, allowing repos that need different tooling to install separate plugins that work consistently together.
 


### PR DESCRIPTION
# Description

It seems an API token is required as even though the GitHub repository is public, the CircleCI project is private. CircleCI can automatically generate this token with the limited status scope and it is now saved in the project settings. 

GitHub did initially block this push as it detected a CircleCI token (good!) but I allowed it because the token can only be used to access the build status of the project which is already public information.

# Checklist:

- [x] My branch has been rebased onto the latest commit on main (don't merge main into your branch)
- [x] My commit messages are [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/), for example: `feat(circleci): add support for nightly workflows`, `fix: set Heroku app name for staging apps too`
