### PR TITLE
Use correct load balancer URL in hako plugin based on environment

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -32722,13 +32722,13 @@
     },
     "plugins/backend-serverless-app": {
       "name": "@dotcom-tool-kit/backend-serverless-app",
-      "version": "4.1.12",
+      "version": "4.1.13",
       "license": "ISC",
       "dependencies": {
         "@dotcom-tool-kit/circleci-deploy": "^4.1.12",
         "@dotcom-tool-kit/node": "^4.3.1",
         "@dotcom-tool-kit/npm": "^4.2.11",
-        "@dotcom-tool-kit/serverless": "^3.3.1"
+        "@dotcom-tool-kit/serverless": "^3.4.0"
       },
       "engines": {
         "node": "18.x || 20.x || 22.x"
@@ -33683,7 +33683,7 @@
     },
     "plugins/containerised-app": {
       "name": "@dotcom-tool-kit/containerised-app",
-      "version": "0.1.6",
+      "version": "0.1.7",
       "license": "ISC",
       "dependencies": {
         "@dotcom-tool-kit/aws": "^0.1.4",
@@ -33691,7 +33691,7 @@
         "@dotcom-tool-kit/cloudsmith": "^1.0.1",
         "@dotcom-tool-kit/docker": "^0.4.0",
         "@dotcom-tool-kit/doppler": "^2.1.7",
-        "@dotcom-tool-kit/hako": "^0.1.6",
+        "@dotcom-tool-kit/hako": "^0.1.7",
         "@dotcom-tool-kit/node": "^4.3.1",
         "zod": "^3.24.1"
       },
@@ -33704,10 +33704,10 @@
     },
     "plugins/containerised-app-with-assets": {
       "name": "@dotcom-tool-kit/containerised-app-with-assets",
-      "version": "0.1.6",
+      "version": "0.1.7",
       "license": "ISC",
       "dependencies": {
-        "@dotcom-tool-kit/containerised-app": "^0.1.6",
+        "@dotcom-tool-kit/containerised-app": "^0.1.7",
         "@dotcom-tool-kit/upload-assets-to-s3": "^4.3.1",
         "@dotcom-tool-kit/webpack": "^4.3.1",
         "zod": "^3.24.1"
@@ -34008,7 +34008,7 @@
     },
     "plugins/hako": {
       "name": "@dotcom-tool-kit/hako",
-      "version": "0.1.6",
+      "version": "0.1.7",
       "license": "ISC",
       "dependencies": {
         "@dotcom-tool-kit/base": "^1.2.0",
@@ -34980,7 +34980,7 @@
     },
     "plugins/serverless": {
       "name": "@dotcom-tool-kit/serverless",
-      "version": "3.3.1",
+      "version": "3.4.0",
       "license": "ISC",
       "dependencies": {
         "@dotcom-tool-kit/base": "^1.2.0",

--- a/plugins/hako/src/tasks/deploy.ts
+++ b/plugins/hako/src/tasks/deploy.ts
@@ -28,6 +28,11 @@ const hakoEnvironments: Record<HakoEnvironmentNames, string> = {
   'ft-com-prod-us': 'us-east-1',
   'ft-com-test-eu': 'eu-west-1'
 }
+const hakoDomains: Record<HakoEnvironmentNames, string> = {
+  'ft-com-prod-eu': 'ft-com-prod.ftweb.tech',
+  'ft-com-prod-us': 'ft-com-prod.ftweb.tech',
+  'ft-com-test-eu': 'ft-com-test.ftweb.tech'
+}
 
 export { HakoDeploySchema as schema }
 
@@ -67,6 +72,7 @@ export default class HakoDeploy extends Task<{ task: typeof HakoDeploySchema }> 
       '--env',
       environment
     ]
+    const domain = hakoDomains[environment]
     if (this.options.asReviewApp) {
       if (!process.env.CIRCLE_BRANCH) {
         throw new Error(
@@ -75,9 +81,9 @@ export default class HakoDeploy extends Task<{ task: typeof HakoDeploySchema }> 
       }
       const hash = createHash('sha256').update(process.env.CIRCLE_BRANCH).digest('hex').slice(0, 6)
       commandArgs.push('--ephemeral', '--ephemeral-id', hash)
-      writeState('review', { url: `https://${name}-${hash}.${awsRegion}.${environment}.ftweb.tech` })
+      writeState('review', { url: `https://${name}-${hash}.${awsRegion}.${domain}` })
     } else {
-      writeState('staging', { url: `https://${name}.${awsRegion}.${environment}.ftweb.tech` })
+      writeState('staging', { url: `https://${name}.${awsRegion}.${domain}` })
     }
 
     const child = spawn('docker', commandArgs)


### PR DESCRIPTION
# Description

Previously we were assuming that the load balancer URL we should point to for tests was the name of the environment + `ftweb.tech`. This isn't actually the case – the region prefixes the account name in the URL, as opposed to being suffixed in the environment name. I've introduced a map to convert from an environment to a domain. Currently, all domain names follow the same pattern so we could generate this programmatically but let's not assume that future domains will follow this pattern too.

# Checklist:

- [x] My branch has been rebased onto the latest commit on main (don't merge main into your branch)
- [x] My commit messages are [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/), for example: `feat(circleci): add support for nightly workflows`, `fix: set Heroku app name for staging apps too`
