### PR TITLE
fix: correct the node-test plugin name

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6932,6 +6932,10 @@
       "resolved": "plugins/node",
       "link": true
     },
+    "node_modules/@dotcom-tool-kit/node-test": {
+      "resolved": "plugins/node-test",
+      "link": true
+    },
     "node_modules/@dotcom-tool-kit/nodemon": {
       "resolved": "plugins/nodemon",
       "link": true
@@ -6970,10 +6974,6 @@
     },
     "node_modules/@dotcom-tool-kit/state": {
       "resolved": "lib/state",
-      "link": true
-    },
-    "node_modules/@dotcom-tool-kit/test": {
-      "resolved": "plugins/node-test",
       "link": true
     },
     "node_modules/@dotcom-tool-kit/typescript": {
@@ -34624,7 +34624,7 @@
       }
     },
     "plugins/node-test": {
-      "name": "@dotcom-tool-kit/test",
+      "name": "@dotcom-tool-kit/node-test",
       "version": "0.1.0",
       "license": "ISC",
       "dependencies": {

--- a/plugins/node-test/package.json
+++ b/plugins/node-test/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@dotcom-tool-kit/test",
+  "name": "@dotcom-tool-kit/node-test",
   "version": "0.1.0",
   "main": "lib",
   "scripts": {


### PR DESCRIPTION
# Description

Turns out `npm init` strips `node-` from the start of the name and we missed this.

# Checklist:

- [x] My branch has been rebased onto the latest commit on main (don't merge main into your branch)
- [x] My commit messages are [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/)
