### PR TITLE
Improve logging for the `node-test` plugin

### DIFF
--- a/lib/logger/src/index.ts
+++ b/lib/logger/src/index.ts
@@ -1,4 +1,4 @@
 export { createFormatter } from './format'
-export { hookConsole, hookFork, waitOnExit } from './helpers'
+export { createWritableLogger, hookConsole, hookFork, hookStream, waitOnExit } from './helpers'
 export { rootLogger } from './logger'
 export { styles } from './styles'

--- a/package-lock.json
+++ b/package-lock.json
@@ -34630,6 +34630,7 @@
       "dependencies": {
         "@dotcom-tool-kit/base": "^1.2.0",
         "@dotcom-tool-kit/error": "^4.1.0",
+        "@dotcom-tool-kit/logger": "^4.1.1",
         "glob": "^11.0.1",
         "tslib": "^2.3.1",
         "zod": "^3.24.1"

--- a/package-lock.json
+++ b/package-lock.json
@@ -34625,7 +34625,7 @@
     },
     "plugins/node-test": {
       "name": "@dotcom-tool-kit/node-test",
-      "version": "0.1.0",
+      "version": "1.0.0",
       "license": "ISC",
       "dependencies": {
         "@dotcom-tool-kit/base": "^1.2.0",

--- a/plugins/node-test/package.json
+++ b/plugins/node-test/package.json
@@ -32,6 +32,7 @@
   "dependencies": {
     "@dotcom-tool-kit/base": "^1.2.0",
     "@dotcom-tool-kit/error": "^4.1.0",
+    "@dotcom-tool-kit/logger": "^4.1.1",
     "glob": "^11.0.1",
     "tslib": "^2.3.1",
     "zod": "^3.24.1"

--- a/plugins/node-test/src/tasks/node-test.ts
+++ b/plugins/node-test/src/tasks/node-test.ts
@@ -7,6 +7,7 @@ import { run } from 'node:test'
 import { spec } from 'node:test/reporters'
 import { Task, TaskRunContext } from '@dotcom-tool-kit/base'
 import { ToolKitError } from '@dotcom-tool-kit/error'
+import { createWritableLogger } from '@dotcom-tool-kit/logger'
 import { z } from 'zod'
 
 // We need to maintain this list of file patterns if we want to make this plugin work consistently
@@ -76,7 +77,8 @@ export default class NodeTest extends Task<{ task: typeof NodeTestSchema }> {
       testStream.on('test:fail', () => {
         success = false
       })
-      await pipeline(testStream, new spec(), process.stdout, { end: false })
+
+      await pipeline(testStream, new spec(), createWritableLogger(this.logger, 'node-test'))
       if (!success) {
         throw new ToolKitError('some tests did not pass, error output has been logged above ☝️')
       }

--- a/plugins/node-test/src/tasks/node-test.ts
+++ b/plugins/node-test/src/tasks/node-test.ts
@@ -72,15 +72,11 @@ export default class NodeTest extends Task<{ task: typeof NodeTestSchema }> {
       const files = await glob(filePatterns, { cwd, ignore })
 
       let success = true
-      const testStream = run(Object.assign({ concurrency, files, forceExit, watch }, customOptions));
+      const testStream = run(Object.assign({ concurrency, files, forceExit, watch }, customOptions))
       testStream.on('test:fail', () => {
-        success = false;
+        success = false
       })
-      await pipeline(
-        testStream,
-        new spec(),
-        process.stdout
-      )
+      await pipeline(testStream, new spec(), process.stdout, { end: false })
       if (!success) {
         throw new ToolKitError('some tests did not pass, error output has been logged above ☝️')
       }

--- a/plugins/node-test/tsconfig.json
+++ b/plugins/node-test/tsconfig.json
@@ -10,6 +10,9 @@
     },
     {
       "path": "../../lib/error"
+    },
+    {
+      "path": "../../lib/logger"
     }
   ],
   "include": ["src/**/*"]


### PR DESCRIPTION
# Description

The `node-test` plugin now pipes the output from the `TestStream` into a winston log we've set up. This means that all the standard logging formatting is now applied to these logs rather instead of streaming directly to `stdout`. In particular, this means the task/process prefix is applied so the logs can be differentiated from logs by other tasks.

I refactored the helpers in the `logger` module to do this, pulling out a function from `hookFork` into its own helper. This will mean it will be easier to hook into Node streams in future plugins.

# Checklist:

- [x] My branch has been rebased onto the latest commit on main (don't merge main into your branch)
- [x] My commit messages are [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/), for example: `feat(circleci): add support for nightly workflows`, `fix: set Heroku app name for staging apps too`
