### PR TITLE
Bump to latest hako image

### DIFF
--- a/plugins/hako/src/tasks/deploy.ts
+++ b/plugins/hako/src/tasks/deploy.ts
@@ -8,7 +8,7 @@ import { readFile } from 'node:fs/promises'
 import { join } from 'node:path'
 import { createHash } from 'node:crypto'
 
-const hakoImageName = 'docker.packages.ft.com/financial-times-internal-releases/hako-cli:0.2.0-beta'
+const hakoImageName = 'docker.packages.ft.com/financial-times-internal-releases/hako-cli:0.2.3-beta'
 
 const HakoEnvironmentNames = z.enum(['ft-com-prod-eu', 'ft-com-prod-us', 'ft-com-test-eu'])
 type HakoEnvironmentNames = (typeof HakoEnvironmentNames.options)[number]


### PR DESCRIPTION
# Description

All the changes since the last release are [here](https://github.com/Financial-Times/hako-cli/compare/v0.2.0-beta...v0.2.3-beta). I don't think there's anything _particularly_ relevant to us but I'm nervous about using an old version because of compatibility issues.

# Checklist:

- [x] My branch has been rebased onto the latest commit on main (don't merge main into your branch)
- [x] My commit messages are [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/), for example: `feat(circleci): add support for nightly workflows`, `fix: set Heroku app name for staging apps too`
