### PR TITLE
CPP-2451 Use correct number of test threads in new CircleCI executor

### DIFF
--- a/plugins/jest/src/tasks/jest.ts
+++ b/plugins/jest/src/tasks/jest.ts
@@ -6,6 +6,11 @@ import * as z from 'zod'
 
 const jestCLIPath = require.resolve('jest-cli/bin/jest')
 
+// TODO:IM:20250407 This function has been copied wholesale to
+// plugins/node-test/src/tasks/node-test.ts. There isn't a clear shared library
+// to put it in but something should be worked out if it needs to be
+// modified/copied again.
+//
 // By default Jest will choose the number of worker threads based on the number
 // of reported CPUs. However, when running within Docker in CircleCI, the
 // number of reported CPUs is taken from the host machine rather than the


### PR DESCRIPTION
# Description

CircleCI [recently updated](https://discuss.circleci.com/t/docker-executor-infrastructure-upgrade/52282) the version of cgroups running on their Docker executors. [cgroups](https://man7.org/linux/man-pages/man7/cgroups.7.html) is used to limit the effective number of CPUs our jobs can use on a CircleCI server based on our [resource class](https://circleci.com/docs/configuration-reference/#resourceclass). This causes problems for us when we run Jest as [by default](https://jestjs.io/docs/cli#--maxworkersnumstring) the tester will guess how many threads it can use with a [call](https://github.com/jestjs/jest/blob/4e56991693da7cd4c3730dc3579a1dd1403ee630/packages/jest-worker/src/index.ts#L62-L66) to `os.availableParallelism` which returns the actual number of CPUs available, as opposed to the effective ('virtual') number of CPUs. Therefore, we had our own logic in the Jest plugin to get the number of virtual CPUs and pass that to Jest instead. But this previous method of guessing how many virtual CPUs were allocated to us no longer works with the new version of cgroups (cgroupv2) (the file we checked no longer exists.) In this PR I've added additional logic that gets the number of CPUs available to us in the new CircleCI executors.

Additionally, I've updated the logic to account for multiple threads being available per core, as the Intel servers we use have [hyper-threading](https://en.wikipedia.org/wiki/Hyper-threading). This means that twice as many threads will be used as previously to make full use of the cores. I benchmarked Tool Kit's own tests with 3 workers instead of 1 (we subtract 1 from the total number of available threads) and confirmed it resulted in the fastest completion of the test suite (including faster than using 4 workers.) Something to be aware of is that some of our projects' test suites (particularly ones using [ts-jest](https://kulshekhar.github.io/ts-jest)) allocate a lot of heap memory per worker and increasing the worker count can make [OOM](https://en.wikipedia.org/wiki/Out_of_memory) termination more likely. This will likely be symptomatic of greater issues in the test suite configuration (or issues with ts-jest itself...) but we may want to consider adding an option to override the maximum Jest workers in the future if this blocks teams.

Finally, this PR adds the same logic to the `node-test` plugin. Similarly to Jest, by default Node's test runner uses `os.availableParallelism` to choose its concurrency and so needs to be corrected in CircleCI. We don't really have a Tool Kit library for shared utility functions like this at the moment, so I've instead copy and pasted it between the two plugins with a clear warning that we should create such a library if further changes are made so that we don't start seeing drift between the two plugins.

# Checklist:

- [x] My branch has been rebased onto the latest commit on main (don't merge main into your branch)
- [x] My commit messages are [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/), for example: `feat(circleci): add support for nightly workflows`, `fix: set Heroku app name for staging apps too`
