### PR TITLE
Add Dependabot config to group updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,27 @@
+version: 2
+updates:
+  - package-ecosystem: 'npm'
+    directory: '/'
+    schedule:
+      interval: 'daily'
+    commit-message:
+      prefix: 'fix:'
+      prefix-development: 'chore:'
+    groups:
+      aws-sdk:
+        patterns:
+          - '@aws-sdk/*'
+        update-types:
+          - 'minor'
+          - 'patch'
+      development-dependencies:
+        dependency-type: 'development'
+        update-types:
+          - 'minor'
+          - 'patch'
+      reliability-kit:
+        patterns:
+          - '@dotcom-reliability-kit/*'
+        update-types:
+          - 'minor'
+          - 'patch'


### PR DESCRIPTION
# Description

We never enabled Dependabot/the auto merger in this repository! Let's get it configured.

# Checklist:

- [x] My branch has been rebased onto the latest commit on main (don't merge main into your branch)
- [x] My commit messages are [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/), for example: `feat(circleci): add support for nightly workflows`, `fix: set Heroku app name for staging apps too`
