### PR TITLE
Group `@type` definition updates with counterparts instead of with other development dependencies

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -16,6 +16,8 @@ updates:
           - 'patch'
       development-dependencies:
         dependency-type: 'development'
+        exclude-patterns:
+          - '@types/*'
         update-types:
           - 'minor'
           - 'patch'


### PR DESCRIPTION
# Description

They're currently grouped with all other dev dependency updates but this will lead them to going out of sync with the packages they define types for. If we don't bucket them in the `development-dependencies` group then Dependabot should fall back to its [default behaviour](https://github.com/dependabot/dependabot-core/pull/5000) of grouping them with their counterpart packages.

# Checklist:

- [x] My branch has been rebased onto the latest commit on main (don't merge main into your branch)
- [x] My commit messages are [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/), for example: `feat(circleci): add support for nightly workflows`, `fix: set Heroku app name for staging apps too`
