### PR TITLE
Increase number of allowed open dependabot PRs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,6 +4,7 @@ updates:
     directory: '/'
     schedule:
       interval: 'daily'
+    open-pull-requests-limit: 20
     commit-message:
       prefix: 'fix:'
       prefix-development: 'chore:'


### PR DESCRIPTION
# Description

Tweak the [`open-pull-requests-limit`](https://docs.github.com/en/code-security/dependabot/working-with-dependabot/dependabot-options-reference#open-pull-requests-limit-) value.

The default of 5 is usually a good choice to reduce PR noise, but it's problematic when we're quite behind on dependency versions and some dependencies can only be safely updated once others have been updated. Hopefully, this will allow us to more efficiently go through updates as part of some BAU work until we've reached a status quo where we've largely caught up or triaged updates.

# Checklist:

- [x] My branch has been rebased onto the latest commit on main (don't merge main into your branch)
- [x] My commit messages are [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/), for example: `feat(circleci): add support for nightly workflows`, `fix: set Heroku app name for staging apps too`
