### PR TITLE
Delete unused dependencies from packages

### DIFF
--- a/core/cli/package.json
+++ b/core/cli/package.json
@@ -23,7 +23,6 @@
     "@jest/globals": "^27.4.6",
     "@types/lodash": "^4.14.185",
     "@types/pluralize": "^0.0.33",
-    "chai": "^4.3.4",
     "globby": "^10.0.2",
     "ts-node": "^8.10.2",
     "winston": "^3.5.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -77,7 +77,6 @@
         "@jest/globals": "^27.4.6",
         "@types/lodash": "^4.14.185",
         "@types/pluralize": "^0.0.33",
-        "chai": "^4.3.4",
         "globby": "^10.0.2",
         "ts-node": "^8.10.2",
         "winston": "^3.5.1",
@@ -11031,11 +11030,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/@types/js-yaml": {
-      "version": "4.0.5",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/@types/json-schema": {
       "version": "7.0.11",
       "license": "MIT"
@@ -12498,14 +12492,6 @@
       "integrity": "sha512-BSHWgDSAiKs50o2Re8ppvp3seVHXSRM44cdSsT9FfNEUUZLOGWVCsiWaRPWM1Znn+mqZ1OfVZ3z3DWEzSp7hRA==",
       "peer": true
     },
-    "node_modules/assertion-error": {
-      "version": "1.1.0",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": "*"
-      }
-    },
     "node_modules/ast-types": {
       "version": "0.13.4",
       "resolved": "https://registry.npmjs.org/ast-types/-/ast-types-0.13.4.tgz",
@@ -13416,23 +13402,6 @@
       ],
       "license": "CC-BY-4.0"
     },
-    "node_modules/chai": {
-      "version": "4.3.6",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "assertion-error": "^1.1.0",
-        "check-error": "^1.0.2",
-        "deep-eql": "^3.0.1",
-        "get-func-name": "^2.0.0",
-        "loupe": "^2.3.1",
-        "pathval": "^1.1.1",
-        "type-detect": "^4.0.5"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
     "node_modules/chalk": {
       "version": "4.1.2",
       "license": "MIT",
@@ -13470,14 +13439,6 @@
       },
       "bin": {
         "check-engines": "bin/check-engines"
-      }
-    },
-    "node_modules/check-error": {
-      "version": "1.0.2",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": "*"
       }
     },
     "node_modules/cheerio": {
@@ -15229,17 +15190,6 @@
     "node_modules/dedent": {
       "version": "0.7.0",
       "license": "MIT"
-    },
-    "node_modules/deep-eql": {
-      "version": "3.0.1",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "type-detect": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=0.12"
-      }
     },
     "node_modules/deep-extend": {
       "version": "0.6.0",
@@ -17618,14 +17568,6 @@
         "node": "6.* || 8.* || >= 10.*"
       }
     },
-    "node_modules/get-func-name": {
-      "version": "2.0.0",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": "*"
-      }
-    },
     "node_modules/get-intrinsic": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
@@ -18208,13 +18150,6 @@
       "integrity": "sha512-tzcUFauisWKNHaRkN4Wjl/ZA07gENAjFl3J/c480dprkGTg5EQstgaNFqBfUqCq54kZRIEcreTsAgF/m2quD7A==",
       "engines": {
         "node": "*"
-      }
-    },
-    "node_modules/hook-std": {
-      "version": "2.0.0",
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
       }
     },
     "node_modules/hosted-git-info": {
@@ -22378,14 +22313,6 @@
       "integrity": "sha512-BFRuQUqc7x2NWxfJBCyUrN8iYUYznzL9JROmRz1gZ6KlOIgmoD+njPVbb+VNn2nGMKggMsK79iUNErillsrx7w==",
       "peer": true
     },
-    "node_modules/loupe": {
-      "version": "2.3.4",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "get-func-name": "^2.0.0"
-      }
-    },
     "node_modules/lowercase-keys": {
       "version": "1.0.1",
       "license": "MIT",
@@ -25113,14 +25040,6 @@
       "resolved": "https://registry.npmjs.org/path2/-/path2-0.1.0.tgz",
       "integrity": "sha512-TX+cz8Jk+ta7IvRy2FAej8rdlbrP0+uBIkP/5DTODez/AuL/vSb30KuAdDxGVREXzn8QfAiu5mJYJ1XjbOhEPA==",
       "peer": true
-    },
-    "node_modules/pathval": {
-      "version": "1.1.1",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": "*"
-      }
     },
     "node_modules/peek-readable": {
       "version": "4.1.0",
@@ -30963,7 +30882,6 @@
         "@dotcom-tool-kit/plugin": "^1.1.0",
         "@jest/globals": "^27.4.6",
         "@types/jest": "^29.5.14",
-        "@types/js-yaml": "^4.0.3",
         "@types/lodash": "^4.14.185",
         "type-fest": "^3.5.4",
         "winston": "^3.5.1"
@@ -32064,7 +31982,6 @@
         "@dotcom-tool-kit/logger": "^4.2.0",
         "@dotcom-tool-kit/package-json-hook": "^5.2.2",
         "fast-glob": "^3.3.3",
-        "hook-std": "^2.0.0",
         "prettier": "^2.2.1",
         "tslib": "^2.8.1",
         "zod": "^3.24.3"

--- a/plugins/circleci/package.json
+++ b/plugins/circleci/package.json
@@ -32,7 +32,6 @@
     "@dotcom-tool-kit/plugin": "^1.1.0",
     "@jest/globals": "^27.4.6",
     "@types/jest": "^29.5.14",
-    "@types/js-yaml": "^4.0.3",
     "@types/lodash": "^4.14.185",
     "type-fest": "^3.5.4",
     "winston": "^3.5.1"

--- a/plugins/prettier/package.json
+++ b/plugins/prettier/package.json
@@ -15,7 +15,6 @@
     "@dotcom-tool-kit/logger": "^4.2.0",
     "@dotcom-tool-kit/package-json-hook": "^5.2.2",
     "fast-glob": "^3.3.3",
-    "hook-std": "^2.0.0",
     "prettier": "^2.2.1",
     "tslib": "^2.8.1",
     "zod": "^3.24.3"


### PR DESCRIPTION
# Description

Dependabot has created PRs for all of these dependencies and thus highlighted how they aren't actually used anywhere. `hook-std` was initially used when prototyping hooking logs into stdout, we've removed `js-yaml` already so don't need `@types/js-yaml` and `chai` seems to have just been added accidentally.

# Checklist:

- [x] My branch has been rebased onto the latest commit on main (don't merge main into your branch)
- [x] My commit messages are [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/), for example: `feat(circleci): add support for nightly workflows`, `fix: set Heroku app name for staging apps too`
