### PR TITLE
feat: update hako to v0.2.5-beta

### DIFF
--- a/plugins/hako/src/tasks/deploy.ts
+++ b/plugins/hako/src/tasks/deploy.ts
@@ -8,7 +8,7 @@ import { readFile } from 'node:fs/promises'
 import { join } from 'node:path'
 import { createHash } from 'node:crypto'
 
-const hakoImageName = 'docker.packages.ft.com/financial-times-internal-releases/hako-cli:0.2.4-beta'
+const hakoImageName = 'docker.packages.ft.com/financial-times-internal-releases/hako-cli:0.2.5-beta'
 
 const HakoEnvironmentNames = z.enum(['ft-com-prod-eu', 'ft-com-prod-us', 'ft-com-test-eu'])
 type HakoEnvironmentNames = (typeof HakoEnvironmentNames.options)[number]


### PR DESCRIPTION
# Description

Switches us to use [hako v0.2.5-beta](https://github.com/Financial-Times/hako-cli/releases/tag/v0.2.5-beta) by default. In future we'll make this configurable but for now let's keep bumping.

# Checklist:

- [x] My branch has been rebased onto the latest commit on main (don't merge main into your branch)
- [x] My commit messages are [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/), for example: `feat(circleci): add support for nightly workflows`, `fix: set Heroku app name for staging apps too`
