### PR TITLE
feat: update hako to v0.2.6-beta

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -32728,7 +32728,7 @@
         "node": "18.x || 20.x || 22.x"
       },
       "peerDependencies": {
-        "dotcom-tool-kit": "4.7.3"
+        "dotcom-tool-kit": "4.x"
       }
     },
     "plugins/babel": {
@@ -32753,7 +32753,7 @@
       },
       "peerDependencies": {
         "@babel/core": "7.x",
-        "dotcom-tool-kit": "4.7.3"
+        "dotcom-tool-kit": "4.x"
       }
     },
     "plugins/backend-app": {
@@ -32786,7 +32786,7 @@
         "node": "18.x || 20.x || 22.x"
       },
       "peerDependencies": {
-        "dotcom-tool-kit": "4.7.3"
+        "dotcom-tool-kit": "4.x"
       }
     },
     "plugins/backend-serverless-app": {
@@ -32803,7 +32803,7 @@
         "node": "18.x || 20.x || 22.x"
       },
       "peerDependencies": {
-        "dotcom-tool-kit": "4.7.3"
+        "dotcom-tool-kit": "4.x"
       }
     },
     "plugins/circleci": {
@@ -32834,7 +32834,7 @@
         "node": "18.x || 20.x || 22.x"
       },
       "peerDependencies": {
-        "dotcom-tool-kit": "4.7.3",
+        "dotcom-tool-kit": "4.x",
         "zod": "^3.24.3"
       }
     },
@@ -32853,7 +32853,7 @@
         "node": "18.x || 20.x || 22.x"
       },
       "peerDependencies": {
-        "dotcom-tool-kit": "4.7.3"
+        "dotcom-tool-kit": "4.x"
       }
     },
     "plugins/circleci-heroku": {
@@ -32887,7 +32887,7 @@
         "node": "18.x || 20.x || 22.x"
       },
       "peerDependencies": {
-        "dotcom-tool-kit": "4.7.3"
+        "dotcom-tool-kit": "4.x"
       }
     },
     "plugins/circleci/node_modules/type-fest": {
@@ -32916,7 +32916,7 @@
         "npm": "7.x || 8.x || 9.x || 10.x"
       },
       "peerDependencies": {
-        "dotcom-tool-kit": "4.7.3"
+        "dotcom-tool-kit": "4.x"
       }
     },
     "plugins/commitlint": {
@@ -32932,7 +32932,7 @@
       },
       "peerDependencies": {
         "@commitlint/cli": ">=16.x <=19.x",
-        "dotcom-tool-kit": "4.7.3"
+        "dotcom-tool-kit": "4.x"
       }
     },
     "plugins/component": {
@@ -32947,7 +32947,7 @@
         "node": "18.x || 20.x || 22.x"
       },
       "peerDependencies": {
-        "dotcom-tool-kit": "4.7.3"
+        "dotcom-tool-kit": "4.x"
       }
     },
     "plugins/containerised-app": {
@@ -32968,7 +32968,7 @@
         "node": "18.x || 20.x || 22.x"
       },
       "peerDependencies": {
-        "dotcom-tool-kit": "4.7.3"
+        "dotcom-tool-kit": "4.x"
       }
     },
     "plugins/containerised-app-with-assets": {
@@ -32985,7 +32985,7 @@
         "node": "18.x || 20.x || 22.x"
       },
       "peerDependencies": {
-        "dotcom-tool-kit": "4.7.3"
+        "dotcom-tool-kit": "4.x"
       }
     },
     "plugins/cypress": {
@@ -33004,7 +33004,7 @@
         "node": "18.x || 20.x || 22.x"
       },
       "peerDependencies": {
-        "dotcom-tool-kit": "4.7.3"
+        "dotcom-tool-kit": "4.x"
       }
     },
     "plugins/docker": {
@@ -33023,7 +33023,7 @@
         "node": "18.x || 20.x || 22.x"
       },
       "peerDependencies": {
-        "dotcom-tool-kit": "4.7.3"
+        "dotcom-tool-kit": "4.x"
       }
     },
     "plugins/doppler": {
@@ -33052,7 +33052,7 @@
         "node": "18.x || 20.x || 22.x"
       },
       "peerDependencies": {
-        "dotcom-tool-kit": "4.7.3",
+        "dotcom-tool-kit": "4.x",
         "eslint": "7.x || 8.x"
       }
     },
@@ -33069,7 +33069,7 @@
         "node": "18.x || 20.x || 22.x"
       },
       "peerDependencies": {
-        "dotcom-tool-kit": "4.7.3"
+        "dotcom-tool-kit": "4.x"
       }
     },
     "plugins/hako": {
@@ -33088,7 +33088,7 @@
         "node": "18.x || 20.x || 22.x"
       },
       "peerDependencies": {
-        "dotcom-tool-kit": "4.7.3"
+        "dotcom-tool-kit": "4.x"
       }
     },
     "plugins/heroku": {
@@ -33121,7 +33121,7 @@
         "node": "18.x || 20.x || 22.x"
       },
       "peerDependencies": {
-        "dotcom-tool-kit": "4.7.3"
+        "dotcom-tool-kit": "4.x"
       }
     },
     "plugins/husky-npm": {
@@ -33136,7 +33136,7 @@
         "node": "18.x || 20.x || 22.x"
       },
       "peerDependencies": {
-        "dotcom-tool-kit": "4.7.3",
+        "dotcom-tool-kit": "4.x",
         "husky": "4.x"
       }
     },
@@ -33157,7 +33157,7 @@
         "node": "18.x || 20.x || 22.x"
       },
       "peerDependencies": {
-        "dotcom-tool-kit": "4.7.3",
+        "dotcom-tool-kit": "4.x",
         "jest-cli": "27.x || 28.x || 29.x"
       }
     },
@@ -33176,7 +33176,7 @@
         "node": "18.x || 20.x || 22.x"
       },
       "peerDependencies": {
-        "dotcom-tool-kit": "4.7.3"
+        "dotcom-tool-kit": "4.x"
       }
     },
     "plugins/lint-staged-npm": {
@@ -33194,7 +33194,7 @@
         "node": "18.x || 20.x || 22.x"
       },
       "peerDependencies": {
-        "dotcom-tool-kit": "4.7.3"
+        "dotcom-tool-kit": "4.x"
       }
     },
     "plugins/lint-staged/node_modules/colorette": {
@@ -33269,7 +33269,7 @@
         "node": "18.x || 20.x || 22.x"
       },
       "peerDependencies": {
-        "dotcom-tool-kit": "4.7.3",
+        "dotcom-tool-kit": "4.x",
         "mocha": ">=6.x <=11.x"
       }
     },
@@ -33296,7 +33296,7 @@
         "npm": "7.x || 8.x || 9.x"
       },
       "peerDependencies": {
-        "dotcom-tool-kit": "4.7.3"
+        "dotcom-tool-kit": "4.x"
       }
     },
     "plugins/monorepo/node_modules/brace-expansion": {
@@ -33345,7 +33345,7 @@
         "node": "18.x || 20.x || 22.x"
       },
       "peerDependencies": {
-        "dotcom-tool-kit": "4.7.3"
+        "dotcom-tool-kit": "4.x"
       }
     },
     "plugins/next-router": {
@@ -33366,7 +33366,7 @@
         "node": "18.x || 20.x || 22.x"
       },
       "peerDependencies": {
-        "dotcom-tool-kit": "4.7.3"
+        "dotcom-tool-kit": "4.x"
       }
     },
     "plugins/node": {
@@ -33387,7 +33387,7 @@
         "node": "18.x || 20.x || 22.x"
       },
       "peerDependencies": {
-        "dotcom-tool-kit": "4.7.3"
+        "dotcom-tool-kit": "4.x"
       }
     },
     "plugins/node-test": {
@@ -33409,7 +33409,7 @@
         "node": "20.x || 22.x"
       },
       "peerDependencies": {
-        "dotcom-tool-kit": "4.7.3"
+        "dotcom-tool-kit": "4.x"
       }
     },
     "plugins/node-test/node_modules/@types/node": {
@@ -33545,7 +33545,7 @@
         "node": "18.x || 20.x || 22.x"
       },
       "peerDependencies": {
-        "dotcom-tool-kit": "4.7.3",
+        "dotcom-tool-kit": "4.x",
         "nodemon": "2.x"
       }
     },
@@ -33574,7 +33574,7 @@
         "node": "18.x || 20.x || 22.x"
       },
       "peerDependencies": {
-        "dotcom-tool-kit": "4.7.3"
+        "dotcom-tool-kit": "4.x"
       }
     },
     "plugins/npm/node_modules/@npmcli/git": {
@@ -33833,7 +33833,7 @@
         "node": "18.x || 20.x || 22.x"
       },
       "peerDependencies": {
-        "dotcom-tool-kit": "4.7.3"
+        "dotcom-tool-kit": "4.x"
       }
     },
     "plugins/prettier/node_modules/@types/prettier": {
@@ -33880,7 +33880,7 @@
         "node": "18.x || 20.x || 22.x"
       },
       "peerDependencies": {
-        "dotcom-tool-kit": "4.7.3",
+        "dotcom-tool-kit": "4.x",
         "serverless-offline": "12.x || 13.x"
       }
     },
@@ -33902,7 +33902,7 @@
         "node": "18.x || 20.x || 22.x"
       },
       "peerDependencies": {
-        "dotcom-tool-kit": "4.7.3",
+        "dotcom-tool-kit": "4.x",
         "typescript": "3.x || 4.x || 5.x"
       }
     },
@@ -34092,7 +34092,7 @@
         "node": "18.x || 20.x || 22.x"
       },
       "peerDependencies": {
-        "dotcom-tool-kit": "4.7.3"
+        "dotcom-tool-kit": "4.x"
       }
     },
     "plugins/webpack": {
@@ -34117,7 +34117,7 @@
         "node": "18.x || 20.x || 22.x"
       },
       "peerDependencies": {
-        "dotcom-tool-kit": "4.7.3",
+        "dotcom-tool-kit": "4.x",
         "webpack": "4.x.x || 5.x.x"
       }
     },

--- a/plugins/hako/src/tasks/deploy.ts
+++ b/plugins/hako/src/tasks/deploy.ts
@@ -8,7 +8,7 @@ import { readFile } from 'node:fs/promises'
 import { join } from 'node:path'
 import { createHash } from 'node:crypto'
 
-const hakoImageName = 'docker.packages.ft.com/financial-times-internal-releases/hako-cli:0.2.5-beta'
+const hakoImageName = 'docker.packages.ft.com/financial-times-internal-releases/hako-cli:0.2.6-beta'
 
 const HakoEnvironmentNames = z.enum(['ft-com-prod-eu', 'ft-com-prod-us', 'ft-com-test-eu'])
 type HakoEnvironmentNames = (typeof HakoEnvironmentNames.options)[number]


### PR DESCRIPTION
# Description

Switches us to use [hako v0.2.6-beta](https://github.com/Financial-Times/hako-cli/releases/tag/v0.2.6-beta) by default. In future we'll make this configurable but for now let's keep bumping. 

# Checklist:

- [x] My branch has been rebased onto the latest commit on main (don't merge main into your branch)
- [x] My commit messages are [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/), for example: `feat(circleci): add support for nightly workflows`, `fix: set Heroku app name for staging apps too`
