### PR TITLE
Fix error for using old `nodeVersion` option in `circleci` plugin not throwing

### DIFF
--- a/plugins/circleci/src/schemas/plugin.ts
+++ b/plugins/circleci/src/schemas/plugin.ts
@@ -29,6 +29,7 @@ export default z
         'the regular expression used to match tags for jobs that should run on tag workflows. by default, matches tags that look like `v1.2.3`; if your releases use a different tag format, change this option to match your tags.'
       )
   })
+  .passthrough()
   .refine((options) => !('nodeVersion' in options), {
     message: `the option ${s.code('nodeVersion')} has been replaced by ${s.code('cimgNodeVersions')}`
   })


### PR DESCRIPTION
# Description

We need to set the `passthrough` field so that zod doesn't strip unrecognised keys before passing the options to the refinement function. This is what we did for other option deprecation errors but was missed with this one. 

# Checklist:

- [x] My branch has been rebased onto the latest commit on main (don't merge main into your branch)
- [x] My commit messages are [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/), for example: `feat(circleci): add support for nightly workflows`, `fix: set Heroku app name for staging apps too`
