### PR TITLE
Require Tool Kit version which supports array substitution for `containerised-app` plugins

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -35049,7 +35049,7 @@
         "node": "18.x || 20.x || 22.x"
       },
       "peerDependencies": {
-        "dotcom-tool-kit": "4.x"
+        "dotcom-tool-kit": "^4.8.0"
       }
     },
     "plugins/containerised-app-with-assets": {
@@ -35066,7 +35066,7 @@
         "node": "18.x || 20.x || 22.x"
       },
       "peerDependencies": {
-        "dotcom-tool-kit": "4.x"
+        "dotcom-tool-kit": "^4.8.0"
       }
     },
     "plugins/cypress": {

--- a/plugins/containerised-app-with-assets/package.json
+++ b/plugins/containerised-app-with-assets/package.json
@@ -22,7 +22,7 @@
     "node": "18.x || 20.x || 22.x"
   },
   "peerDependencies": {
-    "dotcom-tool-kit": "4.x"
+    "dotcom-tool-kit": "^4.8.0"
   },
   "dependencies": {
     "@dotcom-tool-kit/containerised-app": "^0.2.1",

--- a/plugins/containerised-app/package.json
+++ b/plugins/containerised-app/package.json
@@ -23,7 +23,7 @@
     "node": "18.x || 20.x || 22.x"
   },
   "peerDependencies": {
-    "dotcom-tool-kit": "4.x"
+    "dotcom-tool-kit": "^4.8.0"
   },
   "dependencies": {
     "@dotcom-tool-kit/aws": "^0.1.8",


### PR DESCRIPTION
# Description

We generally try to make our dotcom-tool-kit dependency ranges as broad as possible as they're a peer dependency and we don't want to limit version resolution. But for these plugins we need to depend on at least v4.8.0 as the plugins make use of array substitution of HakoDeploy's `environments` option, support for which was only added in that version. Fixes the issue Dawn reported [here](https://financialtimes.slack.com/archives/C3TJ6KXEU/p1747825732103119).

# Checklist:

- [x] My branch has been rebased onto the latest commit on main (don't merge main into your branch)
- [x] My commit messages are [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/), for example: `feat(circleci): add support for nightly workflows`, `fix: set Heroku app name for staging apps too`
