### PR TITLE
fix: ensure tasks exit the command on failure

### DIFF
--- a/plugins/aws/src/tasks/assume-role.ts
+++ b/plugins/aws/src/tasks/assume-role.ts
@@ -43,13 +43,13 @@ export default class AwsAssumeRole extends Task<{ task: typeof AwsAssumeRoleSche
       writeState('ci', { awsCredentials })
       this.logger.info(`Saved AWS credentials to "ci" state with session name "${RoleSessionName}"`)
     } catch (err) {
-      if (err instanceof Error) {
-        const error = new ToolKitError('failed to assume AWS role')
-        error.details = err.message
+      // We wrap non-ToolKitError errors to ensure that they exit the process
+      if (err instanceof Error && !(err instanceof ToolKitError)) {
+        const error = new ToolKitError(err.message)
+        error.exitCode = 1
         throw error
-      } else {
-        throw err
       }
+      throw err
     }
   }
 }

--- a/plugins/docker/src/tasks/auth-cloudsmith.ts
+++ b/plugins/docker/src/tasks/auth-cloudsmith.ts
@@ -25,13 +25,13 @@ export default class DockerAuthCloudsmith extends Task {
       hookFork(this.logger, 'docker-login', child)
       await waitOnExit('docker-login', child)
     } catch (err) {
-      if (err instanceof Error) {
-        const error = new ToolKitError('docker auth with cloudsmith failed to run')
-        error.details = err.message
+      // We wrap non-ToolKitError errors to ensure that they exit the process
+      if (err instanceof Error && !(err instanceof ToolKitError)) {
+        const error = new ToolKitError(err.message)
+        error.exitCode = 1
         throw error
-      } else {
-        throw err
       }
+      throw err
     }
   }
 }

--- a/plugins/docker/src/tasks/build.ts
+++ b/plugins/docker/src/tasks/build.ts
@@ -69,13 +69,13 @@ export default class DockerBuild extends Task<{
         hookFork(this.logger, 'docker-build', childBuild)
         await waitOnExit('docker-build', childBuild)
       } catch (err) {
-        if (err instanceof Error) {
-          const error = new ToolKitError('docker build failed to run')
-          error.details = err.message
+        // We wrap non-ToolKitError errors to ensure that they exit the process
+        if (err instanceof Error && !(err instanceof ToolKitError)) {
+          const error = new ToolKitError(err.message)
+          error.exitCode = 1
           throw error
-        } else {
-          throw err
         }
+        throw err
       }
     }
   }

--- a/plugins/docker/src/tasks/push.ts
+++ b/plugins/docker/src/tasks/push.ts
@@ -26,13 +26,13 @@ export default class DockerPush extends Task<{
           fullyQualifiedName: imageName
         })
       } catch (err) {
-        if (err instanceof Error) {
-          const error = new ToolKitError('docker push failed to run')
-          error.details = err.message
+        // We wrap non-ToolKitError errors to ensure that they exit the process
+        if (err instanceof Error && !(err instanceof ToolKitError)) {
+          const error = new ToolKitError(err.message)
+          error.exitCode = 1
           throw error
-        } else {
-          throw err
         }
+        throw err
       }
     }
 

--- a/plugins/hako/src/tasks/deploy.ts
+++ b/plugins/hako/src/tasks/deploy.ts
@@ -160,13 +160,13 @@ export default class HakoDeploy extends Task<{ task: typeof HakoDeploySchema }> 
 
       await Promise.all(deploys)
     } catch (err) {
-      if (err instanceof Error) {
-        const error = new ToolKitError('hako deploy failed to run')
-        error.details = err.message
+      // We wrap non-ToolKitError errors to ensure that they exit the process
+      if (err instanceof Error && !(err instanceof ToolKitError)) {
+        const error = new ToolKitError(err.message)
+        error.exitCode = 1
         throw error
-      } else {
-        throw err
       }
+      throw err
     }
   }
 }


### PR DESCRIPTION
# Description

Many of the tasks added by CP Reliability rethrow errors to ensure that we catch and explain errors that are outside of our control, e.g. loading a file that doesn't exist. We wanted these to be Tool Kit errors so that we get nice error rendering. We also wanted to just throw normal errors for things like validation errors or missing data.

The issue is that we didn't know about the `exitCode` on Tool Kit error. This means that any `Error` instances that we wrap will not exit the command early. This is most notable in the Docker build/deploy commands: If the Docker build fails then we still move on to try and deploy even though there's no point. This results in longer build times, unnecessary tasks being run, and confusing error messages.

We now no longer wrap Tool Kit errors themselves, this allows us to throw them with the process exit code intact.

# Review notes

There's a little bit of whitespace churn due to indentation changes, [easier to review with whitespace changes ignored](https://github.com/Financial-Times/dotcom-tool-kit/pull/964/files?w=1).

# Checklist:

- [x] My branch has been rebased onto the latest commit on main (don't merge main into your branch)
- [x] My commit messages are [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/), for example: `feat(circleci): add support for nightly workflows`, `fix: set Heroku app name for staging apps too`
