### PR TITLE
Correct hako subcommand when deleting ephemeral apps

### DIFF
--- a/plugins/hako/src/tasks/delete.ts
+++ b/plugins/hako/src/tasks/delete.ts
@@ -44,7 +44,7 @@ export default class HakoDelete extends Task<{ task: typeof HakoDeleteSchema }> 
       '--platform',
       'linux/amd64',
       hakoImageName,
-      'image',
+      'app',
       'delete',
       '--app',
       name,


### PR DESCRIPTION
# Description

 The `HakoDelete` task was calling `hako image delete ...` rather than `hako app delete ...`. The former is not a valid hako command and will result in an error. I believe this was just a mistake when I wrote the code as we _do_ want to delete the canary app from AWS, not the current task/image.

# Checklist:

- [x] My branch has been rebased onto the latest commit on main (don't merge main into your branch)
- [x] My commit messages are [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/), for example: `feat(circleci): add support for nightly workflows`, `fix: set Heroku app name for staging apps too`
