### PR TITLE
feat(hako): upgrade Hako from 0.2.7 to 0.2.9

### DIFF
--- a/plugins/hako/src/hako.ts
+++ b/plugins/hako/src/hako.ts
@@ -1,6 +1,6 @@
 import * as z from 'zod'
 
-export const hakoImageName = 'docker.packages.ft.com/financial-times-internal-releases/hako-cli:0.2.7-beta'
+export const hakoImageName = 'docker.packages.ft.com/financial-times-internal-releases/hako-cli:0.2.9-beta'
 
 export const HakoEnvironmentName = z.string().transform((val, ctx) => {
   const match = val.match(/-(prod|test)-(eu|us)$/)


### PR DESCRIPTION
# Description

Upgrade Hako from 0.2.7 to 0.2.9

- https://github.com/Financial-Times/hako-cli/releases/tag/v0.2.8-beta
- https://github.com/Financial-Times/hako-cli/releases/tag/v0.2.9-beta
 

# Checklist:

- [ ] My branch has been rebased onto the latest commit on main (don't merge main into your branch)
- [ ] My commit messages are [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/), for example: `feat(circleci): add support for nightly workflows`, `fix: set Heroku app name for staging apps too`
