### PR TITLE
feat(cli): add a --printMergedOptions flag

### DIFF
--- a/core/cli/bin/run
+++ b/core/cli/bin/run
@@ -23,6 +23,9 @@ async function main() {
     } else if (argv.printConfig) {
       const { printConfig } = require('../lib')
       await printConfig(rootLogger)
+    } else if (argv.printMergedOptions) {
+      const { printMergedOptions } = require('../lib')
+      await printMergedOptions(rootLogger)
     } else if (argv.help || argv._.length === 0) {
       const showHelp = require('../lib/help').default
       await showHelp(rootLogger, argv._)

--- a/core/cli/src/index.ts
+++ b/core/cli/src/index.ts
@@ -2,6 +2,7 @@ import { loadConfig } from './config'
 import type { Logger } from 'winston'
 import util from 'util'
 import { formatPluginTree } from './messages'
+import { loadHookInstallations } from './install'
 
 export { runTasks } from './tasks'
 export { shouldDisableNativeFetch } from './fetch'
@@ -19,4 +20,24 @@ export async function printConfig(logger: Logger): Promise<void> {
   const config = await loadConfig(logger, { validate: false, root: process.cwd() })
 
   logger.info(util.inspect(config, { depth: null, colors: true }))
+}
+
+export async function printMergedOptions(logger: Logger): Promise<void> {
+  const config = await loadConfig(logger, { validate: true, root: process.cwd() })
+  const hookInstallations = (await loadHookInstallations(logger, config)).unwrap('invalid hooks')
+
+  const mergedOptions = {
+    hooks: hookInstallations.map((h) => h.options),
+    plugins: Object.fromEntries(
+      Object.entries(config.pluginOptions).map(([pluginId, optionsForPlugin]) => [
+        pluginId,
+        optionsForPlugin.options
+      ])
+    ),
+    tasks: Object.fromEntries(
+      Object.entries(config.taskOptions).map(([taskId, optionsForTask]) => [taskId, optionsForTask.options])
+    )
+  }
+
+  logger.info(util.inspect(mergedOptions, { depth: null, colors: true }))
 }


### PR DESCRIPTION
would have been useful when diagnosing [CPP-2561](https://financialtimes.atlassian.net/browse/CPP-2561), and will help with visibility for users on what options will be different when we release the breaking change fix for that

[CPP-2561]: https://financialtimes.atlassian.net/browse/CPP-2561?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ