### PR TITLE
Upgrade Hako image from 0.2.9 to 0.2.13

### DIFF
--- a/plugins/hako/src/hako.ts
+++ b/plugins/hako/src/hako.ts
@@ -1,6 +1,6 @@
 import * as z from 'zod'
 
-export const hakoImageName = 'docker.packages.ft.com/financial-times-internal-releases/hako-cli:0.2.9-beta'
+export const hakoImageName = 'docker.packages.ft.com/financial-times-internal-releases/hako-cli:0.2.13-beta'
 
 export const HakoEnvironmentName = z.string().transform((val, ctx) => {
   const match = val.match(/-(prod|test|review)-(eu|us)$/)


### PR DESCRIPTION
# Description

- https://github.com/Financial-Times/hako-cli/releases/tag/v0.2.10-beta
- https://github.com/Financial-Times/hako-cli/releases/tag/v0.2.11-beta
- https://github.com/Financial-Times/hako-cli/releases/tag/v0.2.12-beta
- https://github.com/Financial-Times/hako-cli/releases/tag/v0.2.13-beta

Shouldn't be any breaking changes for us in these releases, but will add support for new features that teams want.

# Checklist:

- [x] My branch has been rebased onto the latest commit on main (don't merge main into your branch)
- [x] My commit messages are [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/), for example: `feat(circleci): add support for nightly workflows`, `fix: set Heroku app name for staging apps too`
