### PR TITLE
fix: always output requires into .circleci/config.yml

### DIFF
--- a/plugins/circleci/src/circleci-config.ts
+++ b/plugins/circleci/src/circleci-config.ts
@@ -470,7 +470,7 @@ const generateWorkflowJobs = (
             } else {
               return requiredName
             }
-          })
+          }) ?? []
         },
         tagFilterRegex && workflow.runOnRelease && (job.runOnRelease ?? true)
           ? tagFilter(tagFilterRegex)


### PR DESCRIPTION
if `requires` is empty, we end up with a `requires: undefined` in the `expectedConfig`, which gets compared against the not-present `requires` key from the current config and fails to match; however, trying to serialise `requires: undefined` to YAML simply does not output the key, so we end up with a situation where Tool Kit (semi-correctly(?)) tells the user to run `dotcom-tool-kit --install`, but that command is a noop.

default `requires` to an empty array so the config parsing and generation are in a consistent state.
